### PR TITLE
removing variable

### DIFF
--- a/document-service/terraform/dev/variables.tf
+++ b/document-service/terraform/dev/variables.tf
@@ -1,6 +1,3 @@
 variable "aws_region" {
   default = "us-east-1"
 }
-variable "dns_domain" {
-  type = "string"
-}


### PR DESCRIPTION
- since it is hard coded, we don't need that top level variable