### PR TITLE
Specify the needed installation of the AWS CLI

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -12,6 +12,7 @@ This section outlines the steps necessary for creating the necessary resources n
 - install terraform locally
     - https://www.terraform.io/downloads.html
 - create an aws account
+- set up the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) locally, and configure it to use your AWS account
 - setup a user or role with admin privileges
 - set local machine to use this role or user
 - clone this repo locally


### PR DESCRIPTION
I don't want to get all "to bake an apple pie from scratch, you must first create the universe," but since `deploy-infrastructure.sh` requires the AWS CLI and doesn't test for it, best to specify that in the list of prerequisites.