### PR TITLE
remove npm audit temp

### DIFF
--- a/document-service/Jenkinsfile
+++ b/document-service/Jenkinsfile
@@ -55,18 +55,18 @@ pipeline {
         }
       }
     }
-    stage('Audit') {
-      steps {
-        script {
-          def runner = docker.build 'setup', '-f document-service/Dockerfile.test .'
-          runner.inside('-v /home/tomcat:/home/tomcat') {
-            dir('document-service') {
-              sh 'npm audit'
-            }
-          }
-        }
-      }
-    }
+//    stage('Audit') {
+//      steps {
+//        script {
+//          def runner = docker.build 'setup', '-f document-service/Dockerfile.test .'
+//          runner.inside('-v /home/tomcat:/home/tomcat') {
+//            dir('document-service') {
+//              sh 'npm audit'
+//            }
+//          }
+//        }
+//      }
+//    }
     stage('Lint') {
       steps {
         script {


### PR DESCRIPTION
* serverless-offline used for dev has a broken dep and npm audit can't ignore dev dependencies so we are manually checking this for now