### PR TITLE
adding types to cerebral debugger

### DIFF
--- a/web-client/src/index.dev.js
+++ b/web-client/src/index.dev.js
@@ -3,6 +3,8 @@ import Devtools from 'cerebral/devtools';
 
 import app from './app';
 import dev from './environments/dev';
+import Case from './entities/Case';
+import User from './entities/User';
 
 /**
  * Initializes the app with dev environment context
@@ -12,7 +14,7 @@ if (process.env.USTC_DEBUG) {
   debugTools = {
     devtools: Devtools({
       host: 'localhost:8585',
-      allowedTypes: [Blob],
+      allowedTypes: [Blob, User, Case],
     }),
   };
 }


### PR DESCRIPTION
add types as shown to permit cerebral debugger to not "break" app when running "npm run dev:debug"