### PR TITLE
fixing coverage path

### DIFF
--- a/docker-cerebral.sh
+++ b/docker-cerebral.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 docker build -t cerebral -f Dockerfile.web-client .
-docker run -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop cerebral /bin/sh -c "cd efcms-service && npm run install:dynamodb && (npm start &) && ../wait-until.sh http://localhost:3000/v1/swagger && cd ../web-client && npm run test"
+docker run -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop cerebral /bin/sh -c "cd efcms-service && npm run install:dynamodb && (npm start &) && ../wait-until.sh http://localhost:3000/v1/swagger && cd ../web-client && sleep 5; npm run test"

--- a/efcms-service/docker-sonarqube.sh
+++ b/efcms-service/docker-sonarqube.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 branch_name="${branch_name}"
 docker build -t api-sonarqube -f ../Dockerfile.web-client ..
-docker run -e "SONAR_KEY=${SONAR_KEY}" -e "branch_name=${branch_name}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${SONAR_TOKEN}" -v "$(pwd)/coverage:/home/app/coverage" --rm api-sonarqube /bin/sh -c 'cd efcms-service && ./verify-sonarqube-passed.sh'
+docker run -e "SONAR_KEY=${SONAR_KEY}" -e "branch_name=${branch_name}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${SONAR_TOKEN}" -v "$(pwd)/coverage:/home/app/efcms-service/coverage" --rm api-sonarqube /bin/sh -c 'cd efcms-service && ./verify-sonarqube-passed.sh'

--- a/shared/docker-sonarqube.sh
+++ b/shared/docker-sonarqube.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 branch_name="${branch_name}"
 docker build -t shared-sonarqube -f ../Dockerfile.web-client ..
-docker run -e "SONAR_KEY=${SONAR_KEY}" -e "branch_name=${branch_name}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${SONAR_TOKEN}" -v "$(pwd)/coverage:/home/app/coverage" --rm shared-sonarqube /bin/sh -c 'cd shared && ./verify-sonarqube-passed.sh'
+docker run -e "SONAR_KEY=${SONAR_KEY}" -e "branch_name=${branch_name}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${SONAR_TOKEN}" -v "$(pwd)/coverage:/home/app/shared/coverage" --rm shared-sonarqube /bin/sh -c 'cd shared && ./verify-sonarqube-passed.sh'

--- a/web-client/docker-sonarqube.sh
+++ b/web-client/docker-sonarqube.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 branch_name="${branch_name}"
 docker build -t web-client-build -f ../Dockerfile.web-client ..
-docker run -e "SONAR_KEY=${SONAR_KEY}" -e "branch_name=${branch_name}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${SONAR_TOKEN}" -v "$(pwd)/coverage:/home/app/coverage" --rm web-client-build /bin/sh -c 'cd web-client && ./verify-sonarqube-passed.sh'
+docker run -e "SONAR_KEY=${SONAR_KEY}" -e "branch_name=${branch_name}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${SONAR_TOKEN}" -v "$(pwd)/coverage:/home/app/web-client/coverage" --rm web-client-build /bin/sh -c 'cd web-client && ./verify-sonarqube-passed.sh'


### PR DESCRIPTION
- coverage is not working correctly in sonarqube
- adding an extra sleep 5 when running the docker-cerebral.sh command because for some reason the tests are starting before the seeds are done running