### PR TITLE
113 - Revert back to the old approach of just putting the S3 url directly in the iframe for the document detail page

### DIFF
--- a/shared/src/business/useCases/getDownloadDocumentUrl.interactor.js
+++ b/shared/src/business/useCases/getDownloadDocumentUrl.interactor.js
@@ -1,0 +1,6 @@
+exports.getDownloadDocumentUrl = ({ documentId, applicationContext }) => {
+  return applicationContext.getPersistenceGateway().getDownloadPolicy({
+    documentId: documentId,
+    applicationContext,
+  });
+};

--- a/shared/src/persistence/awsS3Persistence.js
+++ b/shared/src/persistence/awsS3Persistence.js
@@ -47,6 +47,8 @@ const getDownloadPolicy = async ({ applicationContext, documentId }) => {
   return url;
 };
 
+exports.getDownloadPolicy = getDownloadPolicy;
+
 exports.getDocument = async ({ applicationContext, documentId }) => {
   const url = await getDownloadPolicy({ applicationContext, documentId });
   const { data: fileBlob } = await axios({

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -3,6 +3,7 @@ const {
   uploadDocument,
   uploadPdf,
   uploadPdfsForNewCase,
+  getDownloadPolicy,
 } = require('../../shared/src/persistence/awsS3Persistence');
 
 import { createCase } from '../../shared/src/proxies/createCaseProxy';
@@ -21,6 +22,7 @@ import { updateCase } from '../../shared/src/proxies/updateCaseProxy';
 import { updateWorkItem } from '../../shared/src/proxies/workitems/updateWorkItemProxy';
 import { uploadCasePdfs } from '../../shared/src/business/useCases/uploadCasePdfs.interactor';
 import { associateRespondentDocumentToCase } from '../../shared/src/proxies/respondent/associateRespondentDocumentToCaseProxy';
+import { getDownloadDocumentUrl } from '../../shared/src/business/useCases/getDownloadDocumentUrl.interactor';
 
 import Case from '../../shared/src/business/entities/Case';
 
@@ -35,6 +37,7 @@ const applicationContext = {
       uploadDocument,
       uploadPdf,
       uploadPdfsForNewCase,
+      getDownloadPolicy,
     };
   },
   getUseCases: () => {
@@ -54,6 +57,7 @@ const applicationContext = {
       updateWorkItem,
       uploadCasePdfs,
       associateRespondentDocumentToCase,
+      getDownloadDocumentUrl,
     };
   },
   getUseCaseForDocumentUpload: (documentType, role) => {

--- a/web-client/src/presenter/actions/getDocumentUrlAction.js
+++ b/web-client/src/presenter/actions/getDocumentUrlAction.js
@@ -1,11 +1,9 @@
 import { state } from 'cerebral';
 
 export default async ({ store, applicationContext, props }) => {
-  console.log('props', props);
   const url = await applicationContext.getUseCases().getDownloadDocumentUrl({
     documentId: props.documentId,
     applicationContext,
   });
-  console.log('url', url);
-  store.set(state.documentUrl, url);
+  store.set(state.documentDownloadUrl, url);
 };

--- a/web-client/src/presenter/actions/getDocumentUrlAction.js
+++ b/web-client/src/presenter/actions/getDocumentUrlAction.js
@@ -1,0 +1,11 @@
+import { state } from 'cerebral';
+
+export default async ({ store, applicationContext, props }) => {
+  console.log('props', props);
+  const url = await applicationContext.getUseCases().getDownloadDocumentUrl({
+    documentId: props.documentId,
+    applicationContext,
+  });
+  console.log('url', url);
+  store.set(state.documentUrl, url);
+};

--- a/web-client/src/presenter/sequences/gotoDocumentDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoDocumentDetailSequence.js
@@ -3,11 +3,13 @@ import getCase from '../actions/getCaseAction';
 import setCase from '../actions/setCaseAction';
 import setDocumentId from '../actions/setDocumentIdAction';
 import setCurrentPage from '../actions/setCurrentPageAction';
+import getDocumentUrl from '../actions/getDocumentUrlAction';
 
 export default [
   clearAlerts,
   setDocumentId,
   getCase,
   setCase,
+  getDocumentUrl,
   setCurrentPage('DocumentDetail'),
 ];

--- a/web-client/src/views/DocumentDetail.jsx
+++ b/web-client/src/views/DocumentDetail.jsx
@@ -14,7 +14,7 @@ export default connect(
     submitForwardSequence: sequences.submitForwardSequence,
     updateFormValueSequence: sequences.updateFormValueSequence,
     workItems: state.extractedWorkItems,
-    documentUrl: state.documentUrl,
+    documentUrl: state.documentDownloadUrl,
   },
   function DocumentDetail({
     caseDetail,

--- a/web-client/src/views/DocumentDetail.jsx
+++ b/web-client/src/views/DocumentDetail.jsx
@@ -1,48 +1,30 @@
 import { connect } from '@cerebral/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { state, sequences } from 'cerebral';
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import ErrorNotification from './ErrorNotification';
 import SuccessNotification from './SuccessNotification';
 
-class DocumentDetail extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { documentUrl: '' };
-  }
-
-  displayPdf(documentBlob) {
-    this.setState({
-      documentUrl: window.URL.createObjectURL(documentBlob, {
-        type: 'application/pdf',
-      }),
-    });
-  }
-
-  componentDidMount() {
-    this.props.viewDocumentSequence({
-      documentId: this.props.document.documentId,
-      callback: this.displayPdf.bind(this),
-    });
-  }
-
-  componentWillUnmount() {
-    window.URL.revokeObjectURL(this.state.documentUrl);
-  }
-
-  render() {
-    const {
-      caseDetail,
-      document,
-      form,
-      showForwardInputs,
-      submitForwardSequence,
-      updateFormValueSequence,
-      workItems,
-    } = this.props;
-
+export default connect(
+  {
+    caseDetail: state.formattedCaseDetail,
+    document: state.extractedDocument,
+    showForwardInputs: state.form.showForwardInputs,
+    submitForwardSequence: sequences.submitForwardSequence,
+    updateFormValueSequence: sequences.updateFormValueSequence,
+    workItems: state.extractedWorkItems,
+    documentUrl: state.documentUrl,
+  },
+  function DocumentDetail({
+    caseDetail,
+    document,
+    showForwardInputs,
+    submitForwardSequence,
+    updateFormValueSequence,
+    workItems,
+    documentUrl,
+  }) {
     return (
       <React.Fragment>
         <div className="usa-grid breadcrumb">
@@ -189,37 +171,12 @@ class DocumentDetail extends React.Component {
             <div className="usa-width-two-thirds">
               <iframe
                 title={`Document type: ${document.documentType}`}
-                src={this.state.documentUrl}
+                src={documentUrl}
               />
             </div>
           </div>
         </section>
       </React.Fragment>
     );
-  }
-}
-
-DocumentDetail.propTypes = {
-  caseDetail: PropTypes.object,
-  document: PropTypes.object,
-  form: PropTypes.object,
-  showForwardInputs: PropTypes.bool,
-  submitForwardSequence: PropTypes.func,
-  updateFormValueSequence: PropTypes.func,
-  workItems: PropTypes.array,
-  viewDocumentSequence: PropTypes.func,
-};
-
-export default connect(
-  {
-    caseDetail: state.formattedCaseDetail,
-    document: state.extractedDocument,
-    form: state.form,
-    showForwardInputs: state.form.showForwardInputs,
-    submitForwardSequence: sequences.submitForwardSequence,
-    updateFormValueSequence: sequences.updateFormValueSequence,
-    workItems: state.extractedWorkItems,
-    viewDocumentSequence: sequences.viewDocumentSequence,
   },
-  DocumentDetail,
 );


### PR DESCRIPTION
Bug:
You can't display file blobs in an iframe in IE11, so the whole useCase returning a file blob isn't going to work unless we bring in a third party library for rendering the pdf.

What changed:
- revert back from the react component 
- new action which gets the documentDownloadUrl and puts it on the state