### PR TITLE
406: make hover-button visible in IE

### DIFF
--- a/web-client/src/styles/tables.scss
+++ b/web-client/src/styles/tables.scss
@@ -53,10 +53,10 @@ table.work-queue {
             bottom: 0;
             left: 0;
             width: 5px;
-            padding: 0;
+            padding: 50px;
             margin: 0;
             background-color: transparent;
-            border-radius: unset;
+            border-radius: 0;
 
             &:hover,
             &:focus,


### PR DESCRIPTION
Though padding exceeds size, overflow:hidden will constrain what is visible.
Was built/run using
`USTC_ENV=prod API_URL=https://efcms-dev.ustc-case-mgmt.flexion.us/v1 parcel --no-cache --no-hmr src/index.pug`
and accessing my dev machine's hostname (KK-MbP) from within the VM (see screenshot below)