### PR TITLE
402: revive payment fields

### DIFF
--- a/web-client/src/views/CaseDetailInternal.jsx
+++ b/web-client/src/views/CaseDetailInternal.jsx
@@ -209,6 +209,60 @@ export default connect(
             <div className="tab-content" role="tabpanel">
               <CaseInformationInternal />
               <PartyInformation />
+
+              <div>
+                <fieldset className="usa-fieldset-inputs usa-sans">
+                  <legend>Petition fee</legend>
+                  {helper.showPaymentRecord && (
+                    <React.Fragment>
+                      <p className="label">Paid by pay.gov</p>
+                      <p>{caseDetail.payGovId}</p>
+                    </React.Fragment>
+                  )}
+                  {helper.showPaymentOptions && (
+                    <ul className="usa-unstyled-list">
+                      <li>
+                        <input
+                          id="paygov"
+                          type="radio"
+                          name="paymentType"
+                          value="payGov"
+                          onChange={e => {
+                            updateFormValueSequence({
+                              key: e.target.name,
+                              value: e.target.value,
+                            });
+                          }}
+                        />
+                        <label htmlFor="paygov">Paid by pay.gov</label>
+                        {helper.showPayGovIdInput && (
+                          <React.Fragment>
+                            <label htmlFor="paygovid">Payment ID</label>
+                            <input
+                              id="paygovid"
+                              type="text"
+                              name="payGovId"
+                              value={caseDetail.payGovId || ''}
+                              onChange={e => {
+                                updateCaseValueSequence({
+                                  key: e.target.name,
+                                  value: e.target.value,
+                                });
+                              }}
+                            />
+                            <button
+                              id="update-case-page-end"
+                              onClick={() => submitUpdateCaseSequence()}
+                            >
+                              Save updates
+                            </button>
+                          </React.Fragment>
+                        )}
+                      </li>
+                    </ul>
+                  )}
+                </fieldset>
+              </div>
             </div>
           )}
         </section>


### PR DESCRIPTION
Adding payment fields back in — should not have been removed when internal case info was added (see #584 )