### PR TITLE
402: override uswds style for options

### DIFF
--- a/web-client/src/styles/overrides.scss
+++ b/web-client/src/styles/overrides.scss
@@ -8,6 +8,7 @@
   label {
     margin: 0 0 5px;
   }
+
   option:first-child {
     font-weight: initial;
   }

--- a/web-client/src/styles/overrides.scss
+++ b/web-client/src/styles/overrides.scss
@@ -8,6 +8,9 @@
   label {
     margin: 0 0 5px;
   }
+  option:first-child {
+    font-weight: initial;
+  }
 }
 
 .usa-form-hint {


### PR DESCRIPTION
fixing odd “first-child” rule which is undesirable for optgroups (and not universally applied)