### PR TITLE
402: accessibility & screenreader compatibility

### DIFF
--- a/web-client/src/views/ModalDialog.jsx
+++ b/web-client/src/views/ModalDialog.jsx
@@ -1,20 +1,48 @@
 import { connect } from '@cerebral/react';
 import { state, sequences } from 'cerebral';
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default connect(
-  {
-    modal: state.modal,
-    showModal: state.showModal,
-    clickCancelSequence: sequences.startACaseToggleCancelSequence,
-    clickConfirmSequence: sequences.startACaseConfirmCancelSequence,
-  },
-  function ModalDialog({
-    modal,
-    showModal,
-    clickConfirmSequence,
-    clickCancelSequence,
-  }) {
+class ModalDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.keydownTriggered = this.keydownTriggered.bind(this);
+  }
+
+  keydownTriggered(event) {
+    if (event.keyCode === 27) {
+      this.escapeKeyCaptured();
+    }
+  }
+  escapeKeyCaptured() {
+    if (this.props.showModal) {
+      this.props.clickCancelSequence();
+    }
+  }
+  componentDidMount() {
+    document.addEventListener('keydown', this.keydownTriggered, false);
+  }
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.keydownTriggered, false);
+  }
+
+  componentDidUpdate() {
+    this.focusModal();
+  }
+
+  focusModal() {
+    const modalHeader = document.querySelector('.modal-dialog h3');
+    modalHeader && modalHeader.focus();
+  }
+
+  render() {
+    const {
+      modal,
+      showModal,
+      clickConfirmSequence,
+      clickCancelSequence,
+    } = this.props;
+
     return (
       showModal && (
         <div className="modal-screen">
@@ -42,5 +70,22 @@ export default connect(
         </div>
       )
     );
+  }
+}
+
+ModalDialog.propTypes = {
+  modal: PropTypes.object,
+  showModal: PropTypes.bool,
+  clickCancelSequence: PropTypes.func,
+  clickConfirmSequence: PropTypes.func,
+};
+
+export default connect(
+  {
+    modal: state.modal,
+    showModal: state.showModal,
+    clickCancelSequence: sequences.startACaseToggleCancelSequence,
+    clickConfirmSequence: sequences.startACaseConfirmCancelSequence,
   },
+  ModalDialog,
 );

--- a/web-client/src/views/ModalDialog.jsx
+++ b/web-client/src/views/ModalDialog.jsx
@@ -22,7 +22,7 @@ export default connect(
             className={`modal-dialog ${modal.classNames}`}
             aria-live="assertive"
           >
-            <h3>{modal.title}</h3>
+            <h3 tabIndex="-1">{modal.title}</h3>
             <p>{modal.message}</p>
             <button
               type="button"

--- a/web-client/src/views/StartCase.jsx
+++ b/web-client/src/views/StartCase.jsx
@@ -106,7 +106,12 @@ export default connect(
               <legend>Date of Notice</legend>
               <div className="usa-date-of-birth">
                 <div className="usa-form-group usa-form-group-month">
-                  <label htmlFor="date-of-notice-month">MM</label>
+                  <label
+                    htmlFor="date-of-notice-month"
+                    aria-label="month, two digits"
+                  >
+                    MM
+                  </label>
                   <input
                     className="usa-input-inline"
                     aria-label="month"
@@ -124,7 +129,12 @@ export default connect(
                   />
                 </div>
                 <div className="usa-form-group usa-form-group-day">
-                  <label htmlFor="date-of-notice-day">DD</label>
+                  <label
+                    htmlFor="date-of-notice-day"
+                    aria-label="day of month, two digits"
+                  >
+                    DD
+                  </label>
                   <input
                     className="usa-input-inline"
                     aria-label="day"
@@ -142,7 +152,12 @@ export default connect(
                   />
                 </div>
                 <div className="usa-form-group usa-form-group-year">
-                  <label htmlFor="date-of-notice-year">YYYY</label>
+                  <label
+                    htmlFor="date-of-notice-year"
+                    aria-label="year, four digits"
+                  >
+                    YYYY
+                  </label>
                   <input
                     className="usa-input-inline"
                     aria-label="year"

--- a/web-client/src/views/StartCase.jsx
+++ b/web-client/src/views/StartCase.jsx
@@ -111,20 +111,18 @@ export default connect(
               </select>
             </div>
             <fieldset>
-              <legend>Date of Notice</legend>
+              <legend id="date-of-notice-legend">Date of Notice</legend>
               <div className="usa-date-of-birth">
                 <div className="usa-form-group usa-form-group-month">
-                  <label
-                    htmlFor="date-of-notice-month"
-                    aria-label="month, two digits"
-                  >
+                  <label htmlFor="date-of-notice-month" aria-hidden="true">
                     MM
                   </label>
                   <input
                     className="usa-input-inline"
-                    aria-label="month"
+                    aria-describedby="date-of-notice-legend"
                     id="date-of-notice-month"
                     name="month"
+                    aria-label="month, two digits"
                     type="number"
                     min="1"
                     max="12"
@@ -137,15 +135,13 @@ export default connect(
                   />
                 </div>
                 <div className="usa-form-group usa-form-group-day">
-                  <label
-                    htmlFor="date-of-notice-day"
-                    aria-label="day of month, two digits"
-                  >
+                  <label htmlFor="date-of-notice-day" aria-hidden="true">
                     DD
                   </label>
                   <input
                     className="usa-input-inline"
-                    aria-label="day"
+                    aria-describedby="date-of-notice-legend"
+                    aria-label="day, two digits"
                     id="date-of-notice-day"
                     name="day"
                     type="number"
@@ -160,15 +156,13 @@ export default connect(
                   />
                 </div>
                 <div className="usa-form-group usa-form-group-year">
-                  <label
-                    htmlFor="date-of-notice-year"
-                    aria-label="year, four digits"
-                  >
+                  <label htmlFor="date-of-notice-year" aria-hidden="true">
                     YYYY
                   </label>
                   <input
                     className="usa-input-inline"
-                    aria-label="year"
+                    aria-describedby="date-of-notice-legend"
+                    aria-label="year, four digits"
                     id="date-of-notice-year"
                     name="year"
                     type="number"
@@ -261,7 +255,7 @@ export default connect(
             <button
               type="button"
               className="usa-accordion-button"
-              aria-expanded={form.showCaseDifference === true}
+              aria-expanded={!!form.showCaseDifference}
               aria-controls="case-difference-container"
               onClick={() => toggleCaseDifferenceSequence()}
             >
@@ -278,7 +272,7 @@ export default connect(
             <div
               id="case-difference-container"
               className="usa-accordion-content"
-              aria-hidden={form.showCaseDifference !== true}
+              aria-hidden={!form.showCaseDifference}
             >
               <CaseDifferenceExplained />
             </div>


### PR DESCRIPTION
Updates to ensure that screenreaders have access to useful & descriptive labels for form controls and inputs, that the forms can be navigated with a keyboard, and also with MacOS Voiceover keyboard navigation.

Included in this effort is alteration of the modal dialog so that it receives focus when it becomes visible, and the ESCAPE key will dismiss the modal dialog.