### PR TITLE
514 - Cypress test to verify updating the document info

### DIFF
--- a/web-client/cypress/integration/update-petition-info.spec.js
+++ b/web-client/cypress/integration/update-petition-info.spec.js
@@ -1,0 +1,40 @@
+describe('Updates the case information on a petition document', function() {
+  before(() => {
+    cy.login('petitionsclerk', '/case-detail/102-18');
+  });
+
+  it('clicks case info tab', () => {
+    cy.get('#case-info-tab').click();
+  });
+
+  it('verifies the irs date is not defined', () => {
+    cy.get('#irs-notice-date')
+      .scrollIntoView()
+      .should('contain', 'No Date Provided');
+  });
+
+  it('goes to the petition document info tab', () => {
+    cy.login(
+      'petitionsclerk',
+      '/case-detail/102-18/documents/8eef49b4-9d40-4773-84ab-49e1e59e49cd',
+    );
+    cy.get('#date-of-notice-month')
+      .scrollIntoView()
+      .type('01');
+    cy.get('#date-of-notice-day')
+      .scrollIntoView()
+      .type('06');
+    cy.get('#date-of-notice-year')
+      .scrollIntoView()
+      .type('2001');
+    cy.get('#case-edit-form').submit();
+  });
+
+  it('goes back to the case info tab on the case details page', () => {
+    cy.login('petitionsclerk', '/case-detail/102-18');
+    cy.get('#case-info-tab').click();
+    cy.get('#irs-notice-date')
+      .scrollIntoView()
+      .should('contain', '01/06/2001');
+  });
+});

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -45,7 +45,7 @@ const formatCase = caseDetail => {
   }${result.docketNumberSuffix || ''}`;
 
   result.irsNoticeDateFormatted = result.irsNoticeDate
-    ? moment(result.irsNoticeDate).format('L')
+    ? moment.utc(result.irsNoticeDate).format('L')
     : 'No Date Provided';
 
   result.datePetitionSentToIrsMessage = `Respondent served ${

--- a/web-client/src/views/CaseDetailEdit.jsx
+++ b/web-client/src/views/CaseDetailEdit.jsx
@@ -37,6 +37,7 @@ export default connect(
   }) {
     return (
       <form
+        id="case-edit-form"
         noValidate
         onSubmit={e => {
           e.preventDefault();

--- a/web-client/src/views/CaseInformationInternal.jsx
+++ b/web-client/src/views/CaseInformationInternal.jsx
@@ -19,7 +19,7 @@ export default connect(
                 <p className="label">Notice/Case Type</p>
                 <p>{caseDetail.caseType}</p>
                 <p className="label">IRS Notice Date</p>
-                <p>{caseDetail.irsNoticeDateFormatted}</p>
+                <p id="irs-notice-date">{caseDetail.irsNoticeDateFormatted}</p>
               </div>
               <div className="usa-width-one-third">
                 <p className="label">Case Procedure</p>


### PR DESCRIPTION
- start of a simple test which verifies the irs date field says "No Date Provided", then updates that date to something real, then verifies the correct date
- fixing a bug where the date was a day off due to moment; had to call moment.utc() instead

![ezgif-2-5d83d0ca144b](https://user-images.githubusercontent.com/1868782/51751665-604d6400-2083-11e9-8c86-6a125caee828.gif)
