### PR TITLE
676 unknown routes

### DIFF
--- a/web-client/src/presenter/actions/setAlertFromExceptionAction.js
+++ b/web-client/src/presenter/actions/setAlertFromExceptionAction.js
@@ -1,6 +1,9 @@
 import { state } from 'cerebral';
 
 export default ({ props, store }) => {
+  if (!props.error) {
+    return;
+  }
   store.set(state.alertError, {
     title: props.error.title,
     message: props.error.message,

--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -44,6 +44,16 @@ const router = {
       document.title = `Style Guide ${pageTitleSuffix}`;
       app.getSequence('gotoStyleGuideSequence')();
     });
+    route(
+      '..',
+      () => {
+        document.title = `Error ${pageTitleSuffix}`;
+        app.getSequence('unauthorizedErrorSequence')({
+          error: { title: '', message: '' },
+        });
+      },
+      true,
+    );
     route.start(true);
   },
 };


### PR DESCRIPTION
* return from setAlertFromException action if no route in props
* add catchall route that routes to the not found page and resets history

<img width="551" alt="screen shot 2019-01-29 at 12 05 15 pm" src="https://user-images.githubusercontent.com/2058839/51929601-3a46fd00-23be-11e9-9da4-7a9ca2936d2e.png">
