### PR TITLE
588: fix color on icon specifically for .fa-before

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -236,6 +236,7 @@ iframe {
       padding: 20px;
       border: 3px solid $color-primary-alt;
       border-radius: 55px;
+      color: $color-primary-alt;
     }
 
     .svg-wrapper img.svg {


### PR DESCRIPTION
<img width="551" alt="screen shot 2019-02-22 at 2 26 02 pm" src="https://user-images.githubusercontent.com/2445917/53269184-d0183400-36ad-11e9-8bf2-a1cdc3acd336.png">
