### PR TITLE
699: removing validation for IRS notice date and trial city

### DIFF
--- a/shared/src/business/entities/Case.js
+++ b/shared/src/business/entities/Case.js
@@ -123,11 +123,8 @@ joiValidationDecorator(
       .date()
       .iso()
       .max('now')
-      .when('hasVerifiedIrsNotice', {
-        is: true,
-        otherwise: joi.optional().allow(null),
-        then: joi.optional(),
-      }),
+      .optional()
+      .allow(null),
     irsSendDate: joi
       .date()
       .iso()
@@ -143,7 +140,10 @@ joiValidationDecorator(
       .string()
       .allow(null)
       .optional(),
-    preferredTrialCity: joi.string().optional(),
+    preferredTrialCity: joi
+      .string()
+      .optional()
+      .allow(null),
     procedureType: joi.string().optional(),
     respondent: joi
       .object()

--- a/web-client/src/presenter/actions/getFormCombinedWithCaseDetailAction.js
+++ b/web-client/src/presenter/actions/getFormCombinedWithCaseDetailAction.js
@@ -91,6 +91,11 @@ export const getFormCombinedWithCaseDetailAction = ({ get }) => {
   form.irsNoticeDate = checkDate(form.irsNoticeDate, caseDetail.irsNoticeDate);
   form.payGovDate = checkDate(form.payGovDate, caseDetail.payGovDate);
 
+  // cannot store empty strings in persistence
+  if (caseDetail.preferredTrialCity === '') {
+    delete caseDetail.preferredTrialCity;
+  }
+
   caseDetail.yearAmounts = caseDetail.yearAmounts
     .map(yearAmount => ({
       amount: !yearAmount.amount


### PR DESCRIPTION
Preferred trial city is being deleted from the case when an empty string value is provided due to limitations in persistence layer. Discuss?