### PR TITLE
698 - fixing an issue with the container names

### DIFF
--- a/shared/Jenkinsfile
+++ b/shared/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
       steps {
         script {
           dir('shared') {
-            def CONTAINER_NAME = "api-test-${BUILD_NUMBER}"
+            def CONTAINER_NAME = "shared-test-${BUILD_NUMBER}"
             sh "CONTAINER_NAME=$CONTAINER_NAME ./docker-test.sh"
           }
         }


### PR DESCRIPTION
this was named api when it should have been 'shared'