### PR TITLE
Fixing Safari Login - preventDefault was needed

### DIFF
--- a/web-client/src/views/LogIn.jsx
+++ b/web-client/src/views/LogIn.jsx
@@ -18,7 +18,8 @@ export const LogIn = connect(
         <form
           id="log-in"
           noValidate
-          onSubmit={() => {
+          onSubmit={event => {
+            event.preventDefault();
             submitLoginSequence();
           }}
         >


### PR DESCRIPTION
the login form was refreshing the page because preventDefault was missing