### PR TITLE
Fixing border-radius side-effect

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -252,16 +252,17 @@ iframe {
     position: absolute;
     top: 0;
     display: inline-block;
-    width: 150px;
+    width: 100px;
+    height: 100px;
+    padding: 20px;
+    border: 3px solid $color-primary-alt;
+    border-radius: 55px;
     color: $color-primary-alt;
 
     svg,
     .svg-wrapper {
-      width: 100px;
-      height: 100px;
-      padding: 20px;
-      border: 3px solid $color-primary-alt;
-      border-radius: 55px;
+      width: 100%;
+      height: 100%;
       color: $color-primary-alt;
     }
 


### PR DESCRIPTION
Safari-specific bug
BEFORE:
<img width="466" alt="Screen Shot 2019-03-11 at 9 42 39 AM" src="https://user-images.githubusercontent.com/2445917/54132641-969c3400-43e2-11e9-8d0c-1b0664309f9d.png">
AFTER:
<img width="387" alt="Screen Shot 2019-03-11 at 9 42 50 AM" src="https://user-images.githubusercontent.com/2445917/54132658-9ef46f00-43e2-11e9-938f-1a695127fce2.png">

(checked in both Chrome and Safari)

