### PR TITLE
reducing the number of smoketest runs for now

### DIFF
--- a/efcms-service/smokeTest.yml
+++ b/efcms-service/smokeTest.yml
@@ -1,7 +1,7 @@
 config:
   target: 'https://{{$processEnvironment.API_TARGET}}.execute-api.{{$processEnvironment.API_REGION}}.amazonaws.com'
   phases:
-    - duration: 10
+    - duration: 1
       arrivalRate: 1
       name: 'load test everything'
 scenarios:


### PR DESCRIPTION
the smoke tests are causing a ton of data to be put into the dev environment which ends up causing some of our queries to break because of how large they are.