### PR TITLE
Fixing Duplicate Docket Numbers

### DIFF
--- a/efcms-service/src/applicationContext.js
+++ b/efcms-service/src/applicationContext.js
@@ -142,10 +142,12 @@ const User = require('ef-cms-shared/src/business/entities/User');
 const environment = {
   documentsBucketName: process.env.DOCUMENTS_BUCKET_NAME || '',
   dynamoDbEndpoint: process.env.DYNAMODB_ENDPOINT || 'http://localhost:8000',
+  masterRegion: process.env.MASTER_REGION || 'us-east-1',
   region: process.env.AWS_REGION || 'us-east-1',
   s3Endpoint: process.env.S3_ENDPOINT || 'localhost',
   stage: process.env.STAGE || 'local',
 };
+
 let user;
 const getCurrentUser = () => {
   return user;
@@ -162,17 +164,12 @@ module.exports = (appContextUser = {}) => {
 
   return {
     docketNumberGenerator,
-    environment: {
-      documentsBucketName: process.env.DOCUMENTS_BUCKET_NAME || '',
-      region: process.env.AWS_REGION || 'us-east-1',
-      s3Endpoint: process.env.S3_ENDPOINT || 'localhost',
-      stage: process.env.STAGE || 'local',
-    },
+    environment,
     getCurrentUser,
-    getDocumentClient: () => {
+    getDocumentClient: ({region} = {}) => {
       return new DynamoDB.DocumentClient({
         endpoint: environment.dynamoDbEndpoint,
-        region: environment.region,
+        region: region || environment.region,
       });
     },
     getDocumentsBucketName: () => {

--- a/shared/src/persistence/dynamodbClientService.js
+++ b/shared/src/persistence/dynamodbClientService.js
@@ -32,9 +32,10 @@ exports.put = params => {
  * @returns {*}
  */
 exports.updateConsistent = params => {
-  // TODO: refactor: this method is not generic enough; it expects all updates to return back an object with a 'id' property..
   return params.applicationContext
-    .getDocumentClient()
+    .getDocumentClient({
+      region: params.applicationContext.environment.masterRegion,
+    })
     .update(params)
     .promise()
     .then(data => data.Attributes.id);

--- a/shared/src/persistence/dynamodbClientService.test.js
+++ b/shared/src/persistence/dynamodbClientService.test.js
@@ -18,6 +18,7 @@ const MOCK_ITEM = {
 let documentClientStub;
 
 const applicationContext = {
+  environment: {},
   getDocumentClient: () => {
     return documentClientStub;
   },


### PR DESCRIPTION
- There is a bug which allows duplicate docket numbers to be generated....  our updateConsistent method used to do requests ony to the MASTER_REGION (us-east-1), but that must have been refactored during the Clean Arch tasks which introduced this bug.  