### PR TITLE
trying to fix the expired token errors

### DIFF
--- a/web-client/src/presenter/errors/ErrorFactory.js
+++ b/web-client/src/presenter/errors/ErrorFactory.js
@@ -18,7 +18,7 @@ export default {
       return new InvalidRequestError(e);
     } else if (/^5/.test(responseCode)) {
       return new ServerInvalidResponseError(e);
-    } else if (!responseCode) {
+    } else if (!e.response) {
       // this should only happen if cognito throws a cors exception due to expired tokens or invalid tokens
       return new UnidentifiedUserError(e);
     } else {

--- a/web-client/src/presenter/errors/ErrorFactory.js
+++ b/web-client/src/presenter/errors/ErrorFactory.js
@@ -18,7 +18,11 @@ export default {
       return new InvalidRequestError(e);
     } else if (/^5/.test(responseCode)) {
       return new ServerInvalidResponseError(e);
+    } else if (!responseCode) {
+      // this should only happen if cognito throws a cors exception due to expired tokens or invalid tokens
+      return new UnidentifiedUserError(e);
+    } else {
+      return new ActionError(e);
     }
-    return new ActionError(e);
   },
 };

--- a/web-client/src/presenter/errors/ErrorFactory.test.js
+++ b/web-client/src/presenter/errors/ErrorFactory.test.js
@@ -62,6 +62,14 @@ describe('ErrorFactory', () => {
     expect(result.className).toEqual('ActionError');
     expect(result.title).toEqual('An error occurred');
   });
+
+  it('creates UnidentifiedUserError errors for null responses (when cors error happen in cognito)', () => {
+    const error = new Error();
+    error.response = null;
+    const result = ErrorFactory.getError(error);
+    expect(result.className).toEqual('UnidentifiedUserError');
+    expect(result.title).toEqual('You are not logged in');
+  });
   it('creates ActionError errors for unusually constructed Errors', () => {
     const error = new Error('something completely different');
     error.response = {};


### PR DESCRIPTION
When the Cognito authorizer runs -- which happens right before it tries to run the lambda function --, it validates the token and makes sure the token is not expired.  If the token IS bad, Cognito will NOT set CORS headers (for whatever reason..). So, when that CORS issue occurs, it looks like the browser will not set the response object due to security reasons, so the way I am checking for a CORS issue would be if the response is not defined.

This probably isn't the best way to check because we could have legit CORS issue occur and it will just redirect the user to cognito every time, but we can refactor this approach if needed.