### PR TITLE
310: Edit caption updates, notification scrolling fix

### DIFF
--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -11,6 +11,7 @@ export default get => {
 
   return {
     showActionRequired: !caseDetail.payGovId,
+    showCaptionEditButton: caseDetail.status !== 'Batched for IRS',
     showDirectDownloadLink: directDocumentLinkDesired,
     showDocumentDetailLink: !directDocumentLinkDesired,
     showDocumentStatus: !caseDetail.irsSendDate,

--- a/web-client/src/presenter/computeds/documentDetailHelper.js
+++ b/web-client/src/presenter/computeds/documentDetailHelper.js
@@ -27,7 +27,6 @@ export default get => {
       const actions = get(state.workItemActions);
       return actions[workItemId] === action;
     },
-    showCaptionEditButton: caseDetail.status !== 'Batched for IRS',
     showCaseDetailsEdit: ['New', 'Recalled'].includes(caseDetail.status),
     showCaseDetailsView: ['Batched for IRS'].includes(caseDetail.status),
     showDocumentInfo: get(state.currentTab) === 'Document Info',

--- a/web-client/src/views/CaseDetailInternal.jsx
+++ b/web-client/src/views/CaseDetailInternal.jsx
@@ -1,21 +1,24 @@
-import { connect } from '@cerebral/react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { sequences, state } from 'cerebral';
-import React from 'react';
 
 import { CaseInformationInternal } from './CaseInformationInternal';
 import { DocketRecord } from './DocketRecord';
 import { ErrorNotification } from './ErrorNotification';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PartyInformation } from './PartyInformation';
+import React from 'react';
 import { SuccessNotification } from './SuccessNotification';
+import { UpdateCaseCaptionModalDialog } from './CaseDetailEdit/UpdateCaseCaptionModalDialog';
+import { connect } from '@cerebral/react';
 
 export const CaseDetailInternal = connect(
   {
     caseDetail: state.formattedCaseDetail,
+    caseHelper: state.caseDetailHelper,
     currentTab: state.currentTab,
     documentHelper: state.documentHelper,
     extractedPendingMessages: state.extractedPendingMessagesFromCaseDetail,
-    helper: state.caseDetailHelper,
+    openCaseCaptionModalSequence: sequences.openCaseCaptionModalSequence,
+    showModal: state.showModal,
     submitUpdateCaseSequence: sequences.submitUpdateCaseSequence,
     updateCaseValueSequence: sequences.updateCaseValueSequence,
     updateCurrentTabSequence: sequences.updateCurrentTabSequence,
@@ -23,10 +26,12 @@ export const CaseDetailInternal = connect(
   },
   ({
     caseDetail,
+    caseHelper,
     currentTab,
     documentHelper,
     extractedPendingMessages,
-    helper,
+    openCaseCaptionModalSequence,
+    showModal,
     submitUpdateCaseSequence,
     updateCaseValueSequence,
     updateCurrentTabSequence,
@@ -44,8 +49,23 @@ export const CaseDetailInternal = connect(
           <h1 className="captioned" tabIndex="-1">
             Docket Number: {caseDetail.docketNumberWithSuffix}
           </h1>
-          <p>{caseDetail.caseTitle}</p>
-          <p>
+          <p className="float-left">{caseDetail.caseTitle} </p>
+          {caseHelper.showCaptionEditButton && (
+            <p className="float-left">
+              <button
+                className="link"
+                onClick={() => {
+                  openCaseCaptionModalSequence();
+                }}
+              >
+                <FontAwesomeIcon icon="edit" size="sm" /> Edit
+              </button>
+            </p>
+          )}
+          {showModal == 'UpdateCaseCaptionModalDialog' && (
+            <UpdateCaseCaptionModalDialog />
+          )}
+          <p className="clear-both">
             <span
               className="usa-label case-status-label"
               aria-label={'status: ' + caseDetail.status}
@@ -147,13 +167,13 @@ export const CaseDetailInternal = connect(
               <div>
                 <fieldset className="usa-fieldset-inputs usa-sans">
                   <legend>Petition fee</legend>
-                  {helper.showPaymentRecord && (
+                  {caseHelper.showPaymentRecord && (
                     <React.Fragment>
                       <p className="label">Paid by pay.gov</p>
                       <p>{caseDetail.payGovId}</p>
                     </React.Fragment>
                   )}
-                  {helper.showPaymentOptions && (
+                  {caseHelper.showPaymentOptions && (
                     <ul className="usa-unstyled-list">
                       <li>
                         <input
@@ -169,7 +189,7 @@ export const CaseDetailInternal = connect(
                           }}
                         />
                         <label htmlFor="paygov">Paid by pay.gov</label>
-                        {helper.showPayGovIdInput && (
+                        {caseHelper.showPayGovIdInput && (
                           <React.Fragment>
                             <label htmlFor="paygovid">Payment ID</label>
                             <input

--- a/web-client/src/views/DocumentDetail.jsx
+++ b/web-client/src/views/DocumentDetail.jsx
@@ -43,7 +43,7 @@ class DocumentDetailComponent extends React.Component {
             </a>
           </h1>
           <p className="float-left">{caseDetail.caseTitle} </p>
-          {helper.showCaptionEditButton && (
+          {caseHelper.showCaptionEditButton && (
             <p className="float-left">
               <button
                 className="link"

--- a/web-client/src/views/ErrorNotification.jsx
+++ b/web-client/src/views/ErrorNotification.jsx
@@ -1,7 +1,7 @@
-import { connect } from '@cerebral/react';
-import { state } from 'cerebral';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from '@cerebral/react';
+import { state } from 'cerebral';
 
 class ErrorNotificationComponent extends React.Component {
   componentDidUpdate() {
@@ -11,7 +11,11 @@ class ErrorNotificationComponent extends React.Component {
   focusNotification() {
     const notification = this.notificationRef.current;
     if (notification) {
-      notification.scrollIntoView();
+      window.scrollTo({
+        behavior: 'smooth',
+        left: 0,
+        top: 0,
+      });
     }
   }
 

--- a/web-client/src/views/ErrorNotification.jsx
+++ b/web-client/src/views/ErrorNotification.jsx
@@ -11,11 +11,7 @@ class ErrorNotificationComponent extends React.Component {
   focusNotification() {
     const notification = this.notificationRef.current;
     if (notification) {
-      window.scrollTo({
-        behavior: 'smooth',
-        left: 0,
-        top: 0,
-      });
+      window.scrollTo(0, 0);
     }
   }
 

--- a/web-client/src/views/SuccessNotification.jsx
+++ b/web-client/src/views/SuccessNotification.jsx
@@ -14,11 +14,7 @@ class SuccessNotificationComponent extends React.Component {
   focusNotification() {
     const notification = this.notificationRef.current;
     if (notification) {
-      window.scrollTo({
-        behavior: 'smooth',
-        left: 0,
-        top: 0,
-      });
+      window.scrollTo(0, 0);
     }
   }
 

--- a/web-client/src/views/SuccessNotification.jsx
+++ b/web-client/src/views/SuccessNotification.jsx
@@ -1,9 +1,10 @@
-import { connect } from '@cerebral/react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { sequences, state } from 'cerebral';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { connect } from '@cerebral/react';
 
 class SuccessNotificationComponent extends React.Component {
   componentDidUpdate() {
@@ -13,7 +14,11 @@ class SuccessNotificationComponent extends React.Component {
   focusNotification() {
     const notification = this.notificationRef.current;
     if (notification) {
-      notification.scrollIntoView();
+      window.scrollTo({
+        behavior: 'smooth',
+        left: 0,
+        top: 0,
+      });
     }
   }
 


### PR DESCRIPTION
Fix notification-scrolling to go to top of page rather than putting notification itself at scrollTop=0.

Moved computed helper to common caseDetailHelper; renamed for clarity upon import. Edit functionality now available on case detail page also

<img width="987" alt="Screen Shot 2019-03-13 at 10 45 56 AM" src="https://user-images.githubusercontent.com/2445917/54293457-04c92e00-457e-11e9-943a-6d2d3fe53077.png">
<img width="1035" alt="Screen Shot 2019-03-13 at 10 46 08 AM" src="https://user-images.githubusercontent.com/2445917/54293464-08f54b80-457e-11e9-9e1c-aa86ff129a93.png">
<img width="953" alt="Screen Shot 2019-03-13 at 10 46 16 AM" src="https://user-images.githubusercontent.com/2445917/54293467-0a267880-457e-11e9-9ced-6d68a514009e.png">
