### PR TITLE
310 Initial Caption

### DIFF
--- a/shared/src/business/entities/Case.js
+++ b/shared/src/business/entities/Case.js
@@ -71,6 +71,8 @@ function Case(rawCase) {
   this.initialDocketNumberSuffix =
     this.initialDocketNumberSuffix || this.docketNumberSuffix || '_';
 
+  this.initialCaption = this.initialCaption || this.caseTitle;
+
   this.yearAmounts = (this.yearAmounts || []).map(
     yearAmount => new YearAmount(yearAmount),
   );


### PR DESCRIPTION
* set initial caption for items with caseTitle. Was only set on creation of Case, now being added to help the migration of older items.