### PR TITLE
joi validation default messages

### DIFF
--- a/shared/src/utilities/JoiValidationDecorator.js
+++ b/shared/src/utilities/JoiValidationDecorator.js
@@ -42,7 +42,7 @@ function getFormattedValidationErrorsHelper(entity) {
           errors[key] = errorObject;
         }
       }
-    } else {
+    } else if (errorMap) {
       errors[key] = errorMap;
     }
   }

--- a/shared/src/utilities/JoiValidationDecorator.test.js
+++ b/shared/src/utilities/JoiValidationDecorator.test.js
@@ -62,5 +62,16 @@ describe('Joi Validation Decorator', () => {
       const errors = obj.getFormattedValidationErrors();
       expect(Object.keys(errors).length).not.toBe(0);
     });
+
+    it('returns default validation error for field without formatted string in errorToMessageMap', () => {
+      const invalidEntity = new MockEntity1({
+        favoriteNumber: 7,
+        name: 'name',
+      });
+      expect(invalidEntity.isValid()).toBe(false);
+      const errors = invalidEntity.getFormattedValidationErrors();
+      const joiGeneratedMessageNotFromErrorToMessageMap = errors.hasNickname;
+      expect(joiGeneratedMessageNotFromErrorToMessageMap).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
when no formatted message is present in the map, instead return the generated message from Joi.
This should “never happen”, but it if does, gives engineers a quick way to identify the source of the validation message issue and correct it.