### PR TITLE
1140: reposition ‘create message’ modal

### DIFF
--- a/web-client/src/styles/modals.scss
+++ b/web-client/src/styles/modals.scss
@@ -15,7 +15,7 @@
 
 @media only screen and (min-width: $medium-screen) {
   .modal-dialog {
-    top: 15%;
+    top: 10%;
     width: 500px;
   }
 }

--- a/web-client/src/styles/modals.scss
+++ b/web-client/src/styles/modals.scss
@@ -1,6 +1,6 @@
 .modal-screen {
   position: fixed;
-  z-index: 100;
+  z-index: 9500;
   top: 0;
   right: 0;
   bottom: 0;
@@ -15,8 +15,9 @@
 
 @media only screen and (min-width: $medium-screen) {
   .modal-dialog {
-    top: 10%;
+    top: 50%;
     width: 500px;
+    transform: translateY(-50%);
   }
 }
 

--- a/web-client/src/styles/modals.scss
+++ b/web-client/src/styles/modals.scss
@@ -15,7 +15,7 @@
 
 @media only screen and (min-width: $medium-screen) {
   .modal-dialog {
-    top: 25%;
+    top: 15%;
     width: 500px;
   }
 }


### PR DESCRIPTION
Moves modal upward to use 15% from top; should work on viewports with heights as small as 665px
![Screen Shot 2019-03-18 at 3 30 03 PM](https://user-images.githubusercontent.com/2445917/54561511-cf17b100-4992-11e9-9c89-6bbf85d8e295.png)
