### PR TITLE
367 - fixing the work queue item expand 

### DIFF
--- a/web-client/src/presenter/actions/setFocusedWorkItemAction.js
+++ b/web-client/src/presenter/actions/setFocusedWorkItemAction.js
@@ -9,8 +9,8 @@ import { state } from 'cerebral';
  * @param {Object} providers.props the cerebral props object used for passing the props.workItemId
  */
 export const setFocusedWorkItemAction = ({ get, store, props }) => {
-  const queue = get(state[props.queueType]).map((item, i) => {
-    if (i === props.idx) {
+  const queue = get(state[props.queueType]).map(item => {
+    if (item.uiKey === props.uiKey) {
       item.isFocused = !item.isFocused;
     }
     return item;

--- a/web-client/src/presenter/actions/setWorkItemsAction.js
+++ b/web-client/src/presenter/actions/setWorkItemsAction.js
@@ -8,7 +8,12 @@ import _ from 'lodash';
  * @param {Object} providers.store the cerebral store used for setting state.workQueue
  * @param {Object} providers.props the cerebral props object used for getting the props.workItems
  */
-export const setWorkItemsAction = ({ store, props }) => {
-  const orderedWorkItems = _.orderBy(props.workItems, 'updatedAt', 'desc');
+export const setWorkItemsAction = ({ applicationContext, store, props }) => {
+  const orderedWorkItems = _.orderBy(props.workItems, 'updatedAt', 'desc').map(
+    workItem => ({
+      ...workItem,
+      uiKey: applicationContext.getUniqueId(),
+    }),
+  );
   store.set(state.workQueue, orderedWorkItems);
 };

--- a/web-client/src/presenter/sequences/setFocusedWorkItemSequence.test.js
+++ b/web-client/src/presenter/sequences/setFocusedWorkItemSequence.test.js
@@ -12,12 +12,13 @@ describe('setFocusedWorkItemSequence', () => {
     test.setState('workQueue', [
       {
         isFocused: false,
+        uiKey: 'a',
         workItemId: 'abc',
       },
     ]);
     await test.runSequence('setFocusedWorkItemSequence', {
-      idx: 0,
       queueType: 'workQueue',
+      uiKey: 'a',
     });
     expect(test.getState('workQueue')).toMatchObject([
       {
@@ -26,28 +27,63 @@ describe('setFocusedWorkItemSequence', () => {
     ]);
   });
 
-  it('should set the workItems isFocused to false when called if the work item is already focused', async () => {
+  it('should collapse the alaready expanded work item of uiKey of a', async () => {
     test.setState('workQueue', [
       {
         isFocused: true,
+        uiKey: 'a',
         workItemId: 'abc',
       },
       {
-        isfocused: false,
+        isFocused: false,
+        uiKey: 'b',
         workItemId: 'gg',
       },
     ]);
     await test.runSequence('setFocusedWorkItemSequence', {
-      idx: 0,
       queueType: 'workQueue',
+      uiKey: 'a',
     });
     expect(test.getState('workQueue')).toMatchObject([
       {
         isFocused: false,
+        uiKey: 'a',
         workItemId: 'abc',
       },
       {
-        isfocused: false,
+        isFocused: false,
+        uiKey: 'b',
+        workItemId: 'gg',
+      },
+    ]);
+  });
+
+  it('should expand the work item with a key of b', async () => {
+    test.setState('workQueue', [
+      {
+        isFocused: true,
+        uiKey: 'a',
+        workItemId: 'abc',
+      },
+      {
+        isFocused: false,
+        uiKey: 'b',
+        workItemId: 'gg',
+      },
+    ]);
+    await test.runSequence('setFocusedWorkItemSequence', {
+      queueType: 'workQueue',
+      uiKey: 'b',
+    });
+    expect(test.getState('workQueue')).toMatchObject([
+      {
+        isFocused: true,
+        uiKey: 'a',
+        workItemId: 'abc',
+      },
+      {
+        isFocused: true,
+        uiKey: 'b',
         workItemId: 'gg',
       },
     ]);

--- a/web-client/src/views/IndividualWorkQueueInbox.jsx
+++ b/web-client/src/views/IndividualWorkQueueInbox.jsx
@@ -35,8 +35,8 @@ export const IndividualWorkQueueInbox = connect(
               key={idx}
               onClick={() =>
                 setFocusedWorkItem({
-                  idx,
                   queueType: 'workQueue',
+                  uiKey: item.uiKey,
                 })
               }
             >

--- a/web-client/src/views/IndividualWorkQueueOutbox.jsx
+++ b/web-client/src/views/IndividualWorkQueueOutbox.jsx
@@ -34,8 +34,8 @@ export const IndividualWorkQueueOutbox = connect(
               key={idx}
               onClick={() =>
                 setFocusedWorkItem({
-                  idx,
                   queueType: 'workQueue',
+                  uiKey: item.uiKey,
                 })
               }
             >

--- a/web-client/src/views/SectionWorkQueueInbox.jsx
+++ b/web-client/src/views/SectionWorkQueueInbox.jsx
@@ -90,8 +90,8 @@ export const SectionWorkQueueInbox = connect(
             key={idx}
             onClick={() =>
               setFocusedWorkItem({
-                idx,
                 queueType: 'workQueue',
+                uiKey: item.uiKey,
               })
             }
           >

--- a/web-client/src/views/SectionWorkQueueOutbox.jsx
+++ b/web-client/src/views/SectionWorkQueueOutbox.jsx
@@ -34,8 +34,8 @@ export const SectionWorkQueueOutbox = connect(
             key={idx}
             onClick={() =>
               setFocusedWorkItem({
-                idx,
                 queueType: 'workQueue',
+                uiKey: item.uiKey,
               })
             }
           >


### PR DESCRIPTION
There is a bug occurring when you try to expand a work item to view the message, it expands the wrong work item.  That is because it was using the index of the array (which gets sorted in the computed) to figure out which one to expand.  Since we can have multiple work item's with the same workItemId in the workQueue, we can't use workItemId as a key.  I don't think we can pass the object by reference because the objects change.

The solution I came up with was the add a unique id after it comes back from the backend to each work item.  

let me know if anyone can think of a better solution.

