### PR TITLE
367: start case form styling cleanup

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -178,9 +178,6 @@ label.validated::after {
   .email-input {
     margin-bottom: 25px;
   }
-  .contact-group {
-    margin-top: 40px;
-  }
   .usa-form-hint {
     margin-bottom: 0;
   }

--- a/web-client/src/views/StartCase/Address.jsx
+++ b/web-client/src/views/StartCase/Address.jsx
@@ -22,7 +22,7 @@ export const Address = connect(
       <React.Fragment>
         <div
           className={
-            'usa-form-group ' +
+            'ustc-form-group ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].address1
@@ -52,7 +52,7 @@ export const Address = connect(
             bind={`validationErrors.${type}.address1`}
           />
         </div>
-        <div className="usa-form-group">
+        <div className="ustc-form-group">
           <label htmlFor={`${type}.address2`}>
             Address Line 2 <span className="usa-form-hint">(optional)</span>
           </label>
@@ -73,7 +73,7 @@ export const Address = connect(
             }}
           />
         </div>
-        <div className="usa-form-group">
+        <div className="ustc-form-group">
           <label htmlFor={`${type}.address3`}>
             Address Line 3 <span className="usa-form-hint">(optional)</span>
           </label>
@@ -103,7 +103,7 @@ export const Address = connect(
               : ''
           }
         >
-          <div className="usa-form-group ustc-form-group-city">
+          <div className="ustc-form-group ustc-form-group-city">
             <label htmlFor={`${type}.city`}>City</label>
             <input
               id={`${type}.city`}
@@ -130,7 +130,7 @@ export const Address = connect(
               }}
             />
           </div>
-          <div className="usa-form-group ustc-form-group-state">
+          <div className="ustc-form-group ustc-form-group-state">
             <label htmlFor={`${type}.state`}>State</label>
             <select
               className={
@@ -138,7 +138,7 @@ export const Address = connect(
                 (validationErrors &&
                 validationErrors[type] &&
                 validationErrors[type].state
-                  ? 'ustc-input-error'
+                  ? 'usa-input-error'
                   : '')
               }
               id={`${type}.state`}
@@ -232,7 +232,7 @@ export const Address = connect(
         </div>
         <div
           className={
-            'usa-form-group clear-both ' +
+            'ustc-form-group clear-both ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].postalCode

--- a/web-client/src/views/StartCase/ContactPrimary.jsx
+++ b/web-client/src/views/StartCase/ContactPrimary.jsx
@@ -36,13 +36,13 @@ export const ContactPrimary = connect(
     contactsHelper,
   }) => {
     return (
-      <div className="contact-group">
+      <>
         {parentView === 'StartCase' ? (
           <h3>{contactsHelper.contactPrimary.header}</h3>
         ) : (
           <h4>{contactsHelper.contactPrimary.header}</h4>
         )}
-        <div className="blue-container">
+        <div className="blue-container contact-group">
           <Country
             type="contactPrimary"
             bind={bind}
@@ -203,7 +203,7 @@ export const ContactPrimary = connect(
             />
           </div>
         </div>
-      </div>
+      </>
     );
   },
 );

--- a/web-client/src/views/StartCase/ContactPrimary.jsx
+++ b/web-client/src/views/StartCase/ContactPrimary.jsx
@@ -36,13 +36,13 @@ export const ContactPrimary = connect(
     contactsHelper,
   }) => {
     return (
-      <div className="usa-form-group contact-group">
+      <div className="contact-group">
         {parentView === 'StartCase' ? (
           <h3>{contactsHelper.contactPrimary.header}</h3>
         ) : (
           <h4>{contactsHelper.contactPrimary.header}</h4>
         )}
-        <div className="blue-container usa-grid-full">
+        <div className="blue-container">
           <Country
             type="contactPrimary"
             bind={bind}
@@ -51,7 +51,7 @@ export const ContactPrimary = connect(
           />
           <div
             className={
-              'usa-form-group ' +
+              'ustc-form-group ' +
               (validationErrors.contactPrimary &&
               validationErrors.contactPrimary.name
                 ? 'usa-input-error'
@@ -83,7 +83,7 @@ export const ContactPrimary = connect(
             />
           </div>
           {contactsHelper.contactPrimary.displayTitle && (
-            <div className="usa-form-group">
+            <div className="ustc-form-group">
               <label htmlFor="title">
                 Title
                 <p className="usa-form-hint">For example, Executor, PR, etc.</p>
@@ -106,7 +106,7 @@ export const ContactPrimary = connect(
           {contactsHelper.contactPrimary.displayInCareOf && (
             <div
               className={
-                'usa-form-group ' +
+                'ustc-form-group ' +
                 (validationErrors.contactPrimary &&
                 validationErrors.contactPrimary.inCareOf
                   ? 'usa-input-error'
@@ -172,7 +172,7 @@ export const ContactPrimary = connect(
           <Email bind={emailBind} />
           <div
             className={
-              'usa-form-group phone-input ' +
+              'ustc-form-group phone-input ' +
               (validationErrors.contactPrimary &&
               validationErrors.contactPrimary.phone
                 ? 'usa-input-error'

--- a/web-client/src/views/StartCase/ContactSecondary.jsx
+++ b/web-client/src/views/StartCase/ContactSecondary.jsx
@@ -33,13 +33,13 @@ export const ContactSecondary = connect(
     contactsHelper,
   }) => {
     return (
-      <div className="contact-group">
+      <>
         {parentView === 'CaseDetail' ? (
           <h4>{contactsHelper.contactSecondary.header}</h4>
         ) : (
           <h3>{contactsHelper.contactSecondary.header}</h3>
         )}
-        <div className="blue-container">
+        <div className="blue-container contact-group">
           <Country
             type="contactSecondary"
             bind={bind}
@@ -180,7 +180,7 @@ export const ContactSecondary = connect(
             </div>
           )}
         </div>
-      </div>
+      </>
     );
   },
 );

--- a/web-client/src/views/StartCase/ContactSecondary.jsx
+++ b/web-client/src/views/StartCase/ContactSecondary.jsx
@@ -33,7 +33,7 @@ export const ContactSecondary = connect(
     contactsHelper,
   }) => {
     return (
-      <div className="usa-form-group contact-group">
+      <div className="contact-group">
         {parentView === 'CaseDetail' ? (
           <h4>{contactsHelper.contactSecondary.header}</h4>
         ) : (
@@ -48,7 +48,7 @@ export const ContactSecondary = connect(
           />
           <div
             className={
-              'usa-form-group ' +
+              'ustc-form-group ' +
               (validationErrors.contactSecondary &&
               validationErrors.contactSecondary.name
                 ? 'usa-input-error'
@@ -82,7 +82,7 @@ export const ContactSecondary = connect(
           {contactsHelper.contactSecondary.displayInCareOf && (
             <div
               className={
-                'usa-form-group ' +
+                'ustc-form-group ' +
                 (validationErrors.contactSecondary &&
                 validationErrors.contactSecondary.inCareOf
                   ? 'usa-input-error'
@@ -148,7 +148,7 @@ export const ContactSecondary = connect(
           {contactsHelper.contactSecondary.displayPhone && (
             <div
               className={
-                'usa-form-group ' +
+                'ustc-form-group ' +
                 (validationErrors.contactSecondary &&
                 validationErrors.contactSecondary.phone
                   ? 'usa-input-error'

--- a/web-client/src/views/StartCase/Country.jsx
+++ b/web-client/src/views/StartCase/Country.jsx
@@ -24,7 +24,7 @@ export const Country = connect(
       <React.Fragment>
         <div
           className={
-            'usa-form-group ' +
+            'ustc-form-group ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].countryType
@@ -34,14 +34,7 @@ export const Country = connect(
         >
           <label htmlFor={`${type}.countryType`}>Country</label>
           <select
-            className={
-              `usa-input-inline ${type}-country-type ` +
-              (validationErrors &&
-              validationErrors[type] &&
-              validationErrors[type].countryType
-                ? 'ustc-input-error'
-                : '')
-            }
+            className={`${type}-country-type `}
             id={`${type}.countryType`}
             name={`${type}.countryType`}
             value={data[type].countryType}
@@ -68,7 +61,7 @@ export const Country = connect(
         {data[type].countryType === constants.COUNTRY_TYPES.INTERNATIONAL && (
           <div
             className={
-              'usa-form-group ' +
+              'ustc-form-group ' +
               (validationErrors &&
               validationErrors[type] &&
               validationErrors[type].country

--- a/web-client/src/views/StartCase/InternationalAddress.jsx
+++ b/web-client/src/views/StartCase/InternationalAddress.jsx
@@ -22,7 +22,7 @@ export const InternationalAddress = connect(
       <React.Fragment>
         <div
           className={
-            'usa-form-group ' +
+            'ustc-form-group ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].address1
@@ -52,7 +52,7 @@ export const InternationalAddress = connect(
             bind={`validationErrors.${type}.address1`}
           />
         </div>
-        <div className="usa-form-group">
+        <div className="ustc-form-group">
           <label htmlFor={`${type}.address2`}>
             Address Line 2 <span className="usa-form-hint">(optional)</span>
           </label>
@@ -73,7 +73,7 @@ export const InternationalAddress = connect(
             }}
           />
         </div>
-        <div className="usa-form-group">
+        <div className="ustc-form-group">
           <label htmlFor={`${type}.address3`}>
             Address Line 3 <span className="usa-form-hint">(optional)</span>
           </label>
@@ -96,7 +96,7 @@ export const InternationalAddress = connect(
         </div>
         <div
           className={
-            'usa-form-group ' +
+            'ustc-form-group ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].state
@@ -131,7 +131,7 @@ export const InternationalAddress = connect(
         </div>
         <div
           className={
-            'usa-form-group ' +
+            'ustc-form-group ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].city
@@ -163,7 +163,7 @@ export const InternationalAddress = connect(
         </div>
         <div
           className={
-            'usa-form-group clear-both ' +
+            'ustc-form-group ' +
             (validationErrors &&
             validationErrors[type] &&
             validationErrors[type].postalCode


### PR DESCRIPTION
This messes up the styling on the QC forms a little bit. Should I fix that now, or are we cleaning those up separately?

<img width="636" alt="Screen Shot 2019-03-22 at 2 53 55 PM" src="https://user-images.githubusercontent.com/43251054/54855128-642bea00-4cb2-11e9-82b4-580fa6b2becd.png">
<img width="270" alt="Screen Shot 2019-03-22 at 2 54 12 PM" src="https://user-images.githubusercontent.com/43251054/54855131-65f5ad80-4cb2-11e9-993d-39845422fee1.png">
<img width="371" alt="Screen Shot 2019-03-22 at 2 56 12 PM" src="https://user-images.githubusercontent.com/43251054/54855196-a8b78580-4cb2-11e9-8500-8b21866848c6.png">