### PR TITLE
h1:focus, more specific rules

### DIFF
--- a/web-client/src/styles/typography.scss
+++ b/web-client/src/styles/typography.scss
@@ -86,13 +86,15 @@ h6 {
   }
 }
 
-h1[tabIndex='-1'],
-h2[tabIndex='-1'],
-h3[tabIndex='-1'],
-h4[tabIndex='-1'],
-h5[tabIndex='-1'],
-h6[tabIndex='-1']:focus {
-  outline: none;
+#main-content {
+  h1[tabIndex='-1'],
+  h2[tabIndex='-1'],
+  h3[tabIndex='-1'],
+  h4[tabIndex='-1'],
+  h5[tabIndex='-1'],
+  h6[tabIndex='-1']:focus {
+    outline: none;
+  }
 }
 
 p {


### PR DESCRIPTION
Hides outlines on h# elements with tabindex attribute