### PR TITLE
Revert "DevEx: Replace tabs instances with Tabs Component"

### DIFF
--- a/web-client/src/views/IndividualWorkQueue.jsx
+++ b/web-client/src/views/IndividualWorkQueue.jsx
@@ -1,7 +1,6 @@
 import { connect } from '@cerebral/react';
-import { sequences } from 'cerebral';
+import { sequences, state } from 'cerebral';
 import React from 'react';
-import { Tab, Tabs } from '../ustc-ui/Tabs/Tabs';
 
 import { IndividualWorkQueueInbox } from './IndividualWorkQueueInbox';
 import { IndividualWorkQueueOutbox } from './IndividualWorkQueueOutbox';
@@ -9,25 +8,54 @@ import { IndividualWorkQueueOutbox } from './IndividualWorkQueueOutbox';
 export const IndividualWorkQueue = connect(
   {
     chooseWorkQueueSequence: sequences.chooseWorkQueueSequence,
+    workQueueHelper: state.workQueueHelper,
   },
-  ({ chooseWorkQueueSequence }) => {
+  ({ chooseWorkQueueSequence, workQueueHelper }) => {
     return (
-      <Tabs
-        className="container-tabs"
-        bind="workQueueToDisplay.box"
-        onSelect={() => chooseWorkQueueSequence()}
-      >
-        <Tab tabName="inbox" title="Inbox" id="individual-inbox-tab">
-          <div id="individual-inbox-tab-content">
+      <React.Fragment>
+        <div role="tablist" className="queue-tab-container">
+          <button
+            aria-controls="individual-inbox-tab-content"
+            aria-selected={workQueueHelper.showInbox}
+            className="tab-link queue-tab"
+            id="individual-inbox-tab"
+            role="tab"
+            onClick={() =>
+              chooseWorkQueueSequence({
+                box: 'inbox',
+                queue: 'my',
+              })
+            }
+          >
+            Inbox
+          </button>
+          <button
+            aria-controls="individual-sent-tab-content"
+            aria-selected={workQueueHelper.showOutbox}
+            className="tab-link queue-tab"
+            id="individual-sent-tab"
+            role="tab"
+            onClick={() =>
+              chooseWorkQueueSequence({
+                box: 'outbox',
+                queue: 'my',
+              })
+            }
+          >
+            Sent
+          </button>
+        </div>
+        {workQueueHelper.showInbox && (
+          <div role="tabpanel" id="individual-inbox-tab-content">
             <IndividualWorkQueueInbox />
           </div>
-        </Tab>
-        <Tab tabName="outbox" title="Sent" id="individual-sent-tab">
-          <div id="individual-sent-tab-content">
+        )}
+        {workQueueHelper.showOutbox && (
+          <div role="tabpanel" id="individual-sent-tab-content">
             <IndividualWorkQueueOutbox />
           </div>
-        </Tab>
-      </Tabs>
+        )}
+      </React.Fragment>
     );
   },
 );

--- a/web-client/src/views/SectionWorkQueue.jsx
+++ b/web-client/src/views/SectionWorkQueue.jsx
@@ -1,7 +1,6 @@
 import { connect } from '@cerebral/react';
-import { sequences } from 'cerebral';
+import { sequences, state } from 'cerebral';
 import React from 'react';
-import { Tab, Tabs } from '../ustc-ui/Tabs/Tabs';
 
 import { SectionWorkQueueOutbox } from './SectionWorkQueueOutbox';
 import { SectionWorkQueueInbox } from './SectionWorkQueueInbox';
@@ -9,25 +8,54 @@ import { SectionWorkQueueInbox } from './SectionWorkQueueInbox';
 export const SectionWorkQueue = connect(
   {
     chooseWorkQueueSequence: sequences.chooseWorkQueueSequence,
+    workQueueHelper: state.workQueueHelper,
   },
-  ({ chooseWorkQueueSequence }) => {
+  ({ chooseWorkQueueSequence, workQueueHelper }) => {
     return (
-      <Tabs
-        className="container-tabs"
-        bind="workQueueToDisplay.box"
-        onSelect={() => chooseWorkQueueSequence()}
-      >
-        <Tab tabName="inbox" title="Inbox" id="section-inbox-tab">
-          <div id="section-inbox-tab-content">
+      <React.Fragment>
+        <div role="tablist" className="queue-tab-container">
+          <button
+            aria-controls="section-inbox-tab-content"
+            aria-selected={workQueueHelper.showInbox}
+            className="tab-link queue-tab"
+            id="section-inbox-tab"
+            role="tab"
+            onClick={() =>
+              chooseWorkQueueSequence({
+                box: 'inbox',
+                queue: 'section',
+              })
+            }
+          >
+            Inbox
+          </button>
+          <button
+            aria-controls="section-sent-tab-content"
+            aria-selected={workQueueHelper.showOutbox}
+            className="tab-link queue-tab"
+            id="section-sent-tab"
+            role="tab"
+            onClick={() =>
+              chooseWorkQueueSequence({
+                box: 'outbox',
+                queue: 'section',
+              })
+            }
+          >
+            Sent
+          </button>
+        </div>
+        {workQueueHelper.showInbox && (
+          <div role="tabpanel" id="section-inbox-tab-content">
             <SectionWorkQueueInbox />
           </div>
-        </Tab>
-        <Tab tabName="outbox" title="Sent" id="section-sent-tab">
-          <div id="section-sent-tab-content">
+        )}
+        {workQueueHelper.showOutbox && (
+          <div role="tabpanel" id="section-sent-tab-content">
             <SectionWorkQueueOutbox />
           </div>
-        </Tab>
-      </Tabs>
+        )}
+      </React.Fragment>
     );
   },
 );


### PR DESCRIPTION

![Screenshot 2019-04-01 14 25 11](https://user-images.githubusercontent.com/1385752/55354926-8b41a300-548c-11e9-98a3-06486cc5ef35.png)
![Screenshot 2019-04-01 14 25 06](https://user-images.githubusercontent.com/1385752/55354927-8b41a300-548c-11e9-8904-e23c5b6bc112.png)
![Screenshot 2019-04-01 14 25 01](https://user-images.githubusercontent.com/1385752/55354928-8bda3980-548c-11e9-9f37-15f15277f1cc.png)
![Screenshot 2019-04-01 14 24 56](https://user-images.githubusercontent.com/1385752/55354929-8bda3980-548c-11e9-882d-85498fa2ee4e.png)



There are some border/margin styling issues that should be addressed in the next sprint.

This reverts commit f82ea93f14160d5fa9a22af60df146a78152b6d5.