### PR TITLE
going back to old acm approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN pip install --upgrade awscli==${AWS_CLI_VERSION}
 
 RUN apt-get install -y jq
 
-RUN wget -q -O terraform_0.11.11_linux_amd64.zip https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip && \
-    unzip -o terraform_0.11.11_linux_amd64.zip terraform
+RUN wget -q -O terraform_0.11.13_linux_amd64.zip https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip && \
+    unzip -o terraform_0.11.13_linux_amd64.zip terraform
 
 RUN cp terraform /usr/local/bin/
 

--- a/efcms-service/terraform/template/acm.tf
+++ b/efcms-service/terraform/template/acm.tf
@@ -1,55 +1,29 @@
+module "efcms-api-certificate" {
+  source = "github.com/traveloka/terraform-aws-acm-certificate?ref=v0.1.2"
 
-data "aws_route53_zone" "zone" {
-  name         = "${var.dns_domain}."
-  private_zone = "false"
+  domain_name            = "efcms-${var.environment}.${var.dns_domain}"
+  hosted_zone_name       = "${var.dns_domain}."
+  is_hosted_zone_private = "false"
+  validation_method      = "DNS"
+  certificate_name       = "efcms-${var.environment}.${var.dns_domain}"
+  environment            = "${var.environment}"
+  description            = "Certificate for efcms-${var.environment}.${var.dns_domain}"
+  product_domain         = "EFCMS"
 }
 
-resource "aws_acm_certificate" "us-east-1" {
-  domain_name       = "efcms-${var.environment}.${var.dns_domain}"
-  validation_method = "DNS"
+module "efcms-api-certificate-us-west-1" {
+  source = "github.com/traveloka/terraform-aws-acm-certificate?ref=v0.1.2"
 
-  tags = {
-    Name          = "efcms-${var.environment}.${var.dns_domain}"
-    ProductDomain = "EFCMS"
-    Environment   = "${var.environment}"
-    Description   = "Certificate for efcms-${var.environment}.${var.dns_domain}"
-    ManagedBy     = "terraform"
+  domain_name            = "efcms-${var.environment}.${var.dns_domain}"
+  hosted_zone_name       = "${var.dns_domain}."
+  is_hosted_zone_private = "false"
+  validation_method      = "DNS"
+  certificate_name       = "efcms-${var.environment}.${var.dns_domain}"
+  environment            = "${var.environment}"
+  description            = "Certificate for efcms-${var.environment}.${var.dns_domain}"
+  product_domain         = "EFCMS"
+
+  providers {
+    aws = "aws.us-west-1"
   }
-}
-
-resource "aws_acm_certificate_validation" "dns_validation-us-east-1" {
-  certificate_arn         = "${aws_acm_certificate.us-east-1.arn}"
-  validation_record_fqdns = ["${aws_route53_record.record.fqdn}"]
-}
-
-resource "aws_acm_certificate" "us-west-1" {
-  domain_name       = "efcms-${var.environment}.${var.dns_domain}"
-  validation_method = "DNS"
-
-  tags = {
-    Name          = "efcms-${var.environment}.${var.dns_domain}"
-    ProductDomain = "EFCMS"
-    Environment   = "${var.environment}"
-    Description   = "Certificate for efcms-${var.environment}.${var.dns_domain}"
-    ManagedBy     = "terraform"
-  }
-
-  provider       = "aws.us-west-1"
-}
-
-resource "aws_route53_record" "record" {
-  name    = "${aws_acm_certificate.us-east-1.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.us-east-1.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = [
-    "${aws_acm_certificate.us-east-1.domain_validation_options.0.resource_record_value}",
-    "${aws_acm_certificate.us-west-1.domain_validation_options.0.resource_record_value}"
-  ]
-  ttl     = 60
-}
-
-resource "aws_acm_certificate_validation" "dns_validation-us-west-1" {
-  certificate_arn         = "${aws_acm_certificate.us-west-1.arn}"
-  validation_record_fqdns = ["${aws_route53_record.record.fqdn}"]
-  provider       = "aws.us-west-1"
 }


### PR DESCRIPTION
terraform is failing to run due to issues with trying to validate the certificates... and I have no clue why.  This used to work in the past, so I'm reverting back to using that ACM plugin and updating terraform.