### PR TITLE
980 External Document Factory/Validation

### DIFF
--- a/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
@@ -1,0 +1,17 @@
+const { ExternalDocumentStandard } = require('./ExternalDocumentStandard');
+
+/**
+ *
+ * @constructor
+ */
+function ExternalDocumentFactory() {}
+
+/**
+ *
+ * @param documentMetadata
+ */
+ExternalDocumentFactory.get = documentMetadata => {
+  return new ExternalDocumentStandard(documentMetadata);
+};
+
+module.exports = { ExternalDocumentFactory };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
@@ -35,25 +35,28 @@ function ExternalDocumentFactory() {}
  * @param documentMetadata
  */
 ExternalDocumentFactory.get = documentMetadata => {
-  const scenario = documentMetadata.scenario.toLowerCase().trim();
-  switch (scenario) {
-    case 'nonstandard a':
-      return new ExternalDocumentNonStandardA(documentMetadata);
-    case 'nonstandard b':
-      return new ExternalDocumentNonStandardB(documentMetadata);
-    case 'nonstandard c':
-      return new ExternalDocumentNonStandardC(documentMetadata);
-    case 'nonstandard d':
-      return new ExternalDocumentNonStandardD(documentMetadata);
-    case 'nonstandard e':
-      return new ExternalDocumentNonStandardE(documentMetadata);
-    case 'nonstandard f':
-      return new ExternalDocumentNonStandardF(documentMetadata);
-    case 'nonstandard g':
-      return new ExternalDocumentNonStandardG(documentMetadata);
-    case 'nonstandard h':
-      return new ExternalDocumentNonStandardH(documentMetadata);
+  if (documentMetadata && documentMetadata.scenario) {
+    const scenario = documentMetadata.scenario.toLowerCase().trim();
+    switch (scenario) {
+      case 'nonstandard a':
+        return new ExternalDocumentNonStandardA(documentMetadata);
+      case 'nonstandard b':
+        return new ExternalDocumentNonStandardB(documentMetadata);
+      case 'nonstandard c':
+        return new ExternalDocumentNonStandardC(documentMetadata);
+      case 'nonstandard d':
+        return new ExternalDocumentNonStandardD(documentMetadata);
+      case 'nonstandard e':
+        return new ExternalDocumentNonStandardE(documentMetadata);
+      case 'nonstandard f':
+        return new ExternalDocumentNonStandardF(documentMetadata);
+      case 'nonstandard g':
+        return new ExternalDocumentNonStandardG(documentMetadata);
+      case 'nonstandard h':
+        return new ExternalDocumentNonStandardH(documentMetadata);
+    }
   }
+
   // standard - default
   return new ExternalDocumentStandard(documentMetadata);
 };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
@@ -1,3 +1,27 @@
+const {
+  ExternalDocumentNonStandardA,
+} = require('./ExternalDocumentNonStandardA');
+const {
+  ExternalDocumentNonStandardB,
+} = require('./ExternalDocumentNonStandardB');
+const {
+  ExternalDocumentNonStandardC,
+} = require('./ExternalDocumentNonStandardC');
+const {
+  ExternalDocumentNonStandardD,
+} = require('./ExternalDocumentNonStandardD');
+const {
+  ExternalDocumentNonStandardE,
+} = require('./ExternalDocumentNonStandardE');
+const {
+  ExternalDocumentNonStandardF,
+} = require('./ExternalDocumentNonStandardF');
+const {
+  ExternalDocumentNonStandardG,
+} = require('./ExternalDocumentNonStandardG');
+const {
+  ExternalDocumentNonStandardH,
+} = require('./ExternalDocumentNonStandardH');
 const { ExternalDocumentStandard } = require('./ExternalDocumentStandard');
 
 /**
@@ -11,6 +35,26 @@ function ExternalDocumentFactory() {}
  * @param documentMetadata
  */
 ExternalDocumentFactory.get = documentMetadata => {
+  const scenario = documentMetadata.scenario.toLowerCase().trim();
+  switch (scenario) {
+    case 'nonstandard a':
+      return new ExternalDocumentNonStandardA(documentMetadata);
+    case 'nonstandard b':
+      return new ExternalDocumentNonStandardB(documentMetadata);
+    case 'nonstandard c':
+      return new ExternalDocumentNonStandardC(documentMetadata);
+    case 'nonstandard d':
+      return new ExternalDocumentNonStandardD(documentMetadata);
+    case 'nonstandard e':
+      return new ExternalDocumentNonStandardE(documentMetadata);
+    case 'nonstandard f':
+      return new ExternalDocumentNonStandardF(documentMetadata);
+    case 'nonstandard g':
+      return new ExternalDocumentNonStandardG(documentMetadata);
+    case 'nonstandard h':
+      return new ExternalDocumentNonStandardH(documentMetadata);
+  }
+  // standard - default
   return new ExternalDocumentStandard(documentMetadata);
 };
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentFactory.js
@@ -53,7 +53,10 @@ ExternalDocumentFactory.get = documentMetadata => {
       case 'nonstandard g':
         return new ExternalDocumentNonStandardG(documentMetadata);
       case 'nonstandard h':
-        return new ExternalDocumentNonStandardH(documentMetadata);
+        return new ExternalDocumentNonStandardH(
+          documentMetadata,
+          ExternalDocumentFactory,
+        );
     }
   }
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardA.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardA.js
@@ -1,0 +1,34 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardA(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardA.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentName: 'You must select a document.',
+  documentType: 'You must select a document type.',
+};
+
+ExternalDocumentNonStandardA.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentName: joi.string().required(),
+  documentType: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardA,
+  ExternalDocumentNonStandardA.schema,
+  undefined,
+  ExternalDocumentNonStandardA.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardA };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardA.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardA.test.js
@@ -1,0 +1,26 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardA', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard A',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentName: 'You must select a document.',
+        documentType: 'You must select a document type.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Supporting Document',
+        documentName: 'Petition',
+        documentType: 'Brief in Support of [Document Name]',
+        scenario: 'Nonstandard A',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardB.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardB.js
@@ -1,0 +1,34 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardB(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardB.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentName: 'You must provide a document name.',
+  documentType: 'You must select a document type.',
+};
+
+ExternalDocumentNonStandardB.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentName: joi.string().required(),
+  documentType: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardB,
+  ExternalDocumentNonStandardB.schema,
+  undefined,
+  ExternalDocumentNonStandardB.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardB };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardB.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardB.test.js
@@ -1,0 +1,26 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardB', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard B',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentName: 'You must provide a document name.',
+        documentType: 'You must select a document type.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Application',
+        documentName: 'Petition',
+        documentType: 'Application to Take Deposition of [Name]',
+        scenario: 'Nonstandard B',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardC.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardC.js
@@ -1,0 +1,36 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardC(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardC.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentName: 'You must select a document.',
+  documentType: 'You must select a document type.',
+  name: 'You must provide a name.',
+};
+
+ExternalDocumentNonStandardC.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentName: joi.string().required(),
+  documentType: joi.string().required(),
+  name: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardC,
+  ExternalDocumentNonStandardC.schema,
+  undefined,
+  ExternalDocumentNonStandardC.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardC };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardC.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardC.test.js
@@ -1,0 +1,28 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardC', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard C',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentName: 'You must select a document.',
+        documentType: 'You must select a document type.',
+        name: 'You must provide a name.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Supporting Document',
+        documentName: 'Petition',
+        documentType: 'Affidavit Of [Name] in Support Of [Document Name]',
+        name: 'Lori Loughlin',
+        scenario: 'Nonstandard C',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.js
@@ -1,0 +1,40 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardD(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardD.errorToMessageMap = {
+  category: 'You must select a category.',
+  date: 'You must provide a service date.',
+  documentName: 'You must select a document.',
+  documentType: 'You must select a document type.',
+};
+
+ExternalDocumentNonStandardD.schema = joi.object().keys({
+  category: joi.string().required(),
+  date: joi
+    .date()
+    .iso()
+    .max('now')
+    .required(),
+  documentName: joi.string().required(),
+  documentType: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardD,
+  ExternalDocumentNonStandardD.schema,
+  undefined,
+  ExternalDocumentNonStandardD.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardD };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.test.js
@@ -1,0 +1,29 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardD', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard D',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        date: 'You must provide a service date.',
+        documentName: 'You must select a document.',
+        documentType: 'You must select a document type.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const date = new Date().toISOString();
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Supporting Document',
+        date,
+        documentName: 'Petition',
+        documentType: 'Certificate of Service [Document Name] [Date]',
+        scenario: 'Nonstandard D',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardE.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardE.js
@@ -1,0 +1,34 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardE(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardE.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentType: 'You must select a document type.',
+  trialLocation: 'You must select a trial location.',
+};
+
+ExternalDocumentNonStandardE.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentType: joi.string().required(),
+  trialLocation: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardE,
+  ExternalDocumentNonStandardE.schema,
+  undefined,
+  ExternalDocumentNonStandardE.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardE };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardE.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardE.test.js
@@ -1,0 +1,27 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardE', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard E',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentType: 'You must select a document type.',
+        trialLocation: 'You must select a trial location.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Motion',
+        documentType:
+          'Motion to Change Place of Submission of Declaratory Judgment Case to [Place]',
+        scenario: 'Nonstandard E',
+        trialLocation: 'Little Rock, AR',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardF.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardF.js
@@ -1,0 +1,36 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardF(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardF.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentName: 'You must select a document.',
+  documentType: 'You must select a document type.',
+  ordinal: 'You must select an iteration.',
+};
+
+ExternalDocumentNonStandardF.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentName: joi.string().required(),
+  documentType: joi.string().required(),
+  ordinal: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardF,
+  ExternalDocumentNonStandardF.schema,
+  undefined,
+  ExternalDocumentNonStandardF.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardF };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardF.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardF.test.js
@@ -1,0 +1,28 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardF', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard F',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentName: 'You must select a document.',
+        documentType: 'You must select a document type.',
+        ordinal: 'You must select an iteration.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Miscellaneous',
+        documentName: 'Petition',
+        documentType: '[First, Second, etc.] Amended [Document Name]',
+        ordinal: 'First',
+        scenario: 'Nonstandard F',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardG.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardG.js
@@ -1,0 +1,34 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardG(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardG.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentType: 'You must select a document type.',
+  ordinal: 'You must select an iteration.',
+};
+
+ExternalDocumentNonStandardG.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentType: joi.string().required(),
+  ordinal: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardG,
+  ExternalDocumentNonStandardG.schema,
+  undefined,
+  ExternalDocumentNonStandardG.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardG };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardG.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardG.test.js
@@ -1,0 +1,26 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardG', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard G',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentType: 'You must select a document type.',
+        ordinal: 'You must select an iteration.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Answer',
+        documentType: '[First, Second, etc.] Amendment to Answer',
+        ordinal: 'First',
+        scenario: 'Nonstandard G',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.js
@@ -1,0 +1,36 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentNonStandardH(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentNonStandardH.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentType: 'You must select a document type.',
+  secondaryCategory: 'You must select a category.',
+  secondaryDocumentType: 'You must select a document type.',
+};
+
+ExternalDocumentNonStandardH.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentType: joi.string().required(),
+  secondaryCategory: joi.string().required(),
+  secondaryDocumentType: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentNonStandardH,
+  ExternalDocumentNonStandardH.schema,
+  undefined,
+  ExternalDocumentNonStandardH.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentNonStandardH };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.js
@@ -2,34 +2,36 @@ const joi = require('joi-browser');
 const {
   joiValidationDecorator,
 } = require('../../../utilities/JoiValidationDecorator');
-
 /**
  *
  * @param rawProps
+ * @param ExternalDocumentFactory
  * @constructor
  */
-function ExternalDocumentNonStandardH(rawProps) {
+function ExternalDocumentNonStandardH(rawProps, ExternalDocumentFactory) {
   Object.assign(this, rawProps);
+  const { secondaryDocument } = rawProps;
+  this.secondaryDocument = ExternalDocumentFactory.get(secondaryDocument || {});
 }
 
 ExternalDocumentNonStandardH.errorToMessageMap = {
   category: 'You must select a category.',
   documentType: 'You must select a document type.',
-  secondaryCategory: 'You must select a category.',
-  secondaryDocumentType: 'You must select a document type.',
+  secondaryDocument: 'You must select a document.',
 };
 
 ExternalDocumentNonStandardH.schema = joi.object().keys({
   category: joi.string().required(),
   documentType: joi.string().required(),
-  secondaryCategory: joi.string().required(),
-  secondaryDocumentType: joi.string().required(),
+  secondaryDocument: joi.object().required(),
 });
 
 joiValidationDecorator(
   ExternalDocumentNonStandardH,
   ExternalDocumentNonStandardH.schema,
-  undefined,
+  function() {
+    return !this.getFormattedValidationErrors();
+  },
   ExternalDocumentNonStandardH.errorToMessageMap,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.test.js
@@ -9,8 +9,10 @@ describe('ExternalDocumentNonStandardH', () => {
       expect(extDoc.getFormattedValidationErrors()).toEqual({
         category: 'You must select a category.',
         documentType: 'You must select a document type.',
-        secondaryCategory: 'You must select a category.',
-        secondaryDocumentType: 'You must select a document type.',
+        secondaryDocument: {
+          category: 'You must select a category.',
+          documentType: 'You must select a document type.',
+        },
       });
     });
 
@@ -19,10 +21,45 @@ describe('ExternalDocumentNonStandardH', () => {
         category: 'Motion',
         documentType: 'Motion for Leave to File [Document Name]',
         scenario: 'Nonstandard H',
-        secondaryCategory: 'Application',
-        secondaryDocumentType: 'Application for Waiver of Filing Fee',
+        secondaryDocument: {
+          category: 'Application',
+          documentType: 'Application for Waiver of Filing Fee',
+        },
       });
       expect(extDoc.getFormattedValidationErrors()).toEqual(null);
     });
+
+    it('should have error messages for nonstandard secondary document', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Motion',
+        documentType: 'Motion for Leave to File [Document Name]',
+        scenario: 'Nonstandard H',
+        secondaryDocument: {
+          scenario: 'Nonstandard A',
+        },
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        secondaryDocument: {
+          category: 'You must select a category.',
+          documentName: 'You must select a document.',
+          documentType: 'You must select a document type.',
+        },
+      });
+    });
+  });
+
+  it('should be valid when all nonstandard secondary document fields are present', () => {
+    const extDoc = ExternalDocumentFactory.get({
+      category: 'Motion',
+      documentType: 'Motion for Leave to File [Document Name]',
+      scenario: 'Nonstandard H',
+      secondaryDocument: {
+        category: 'Supporting Document',
+        documentName: 'Petition',
+        documentType: 'Brief in Support of [Document Name]',
+        scenario: 'Nonstandard A',
+      },
+    });
+    expect(extDoc.getFormattedValidationErrors()).toEqual(null);
   });
 });

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.test.js
@@ -1,0 +1,28 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentNonStandardH', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Nonstandard H',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentType: 'You must select a document type.',
+        secondaryCategory: 'You must select a category.',
+        secondaryDocumentType: 'You must select a document type.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Motion',
+        documentType: 'Motion for Leave to File [Document Name]',
+        scenario: 'Nonstandard H',
+        secondaryCategory: 'Application',
+        secondaryDocumentType: 'Application for Waiver of Filing Fee',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/entities/externalDocument/ExternalDocumentStandard.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentStandard.js
@@ -1,7 +1,7 @@
+const joi = require('joi-browser');
 const {
   joiValidationDecorator,
 } = require('../../../utilities/JoiValidationDecorator');
-const joi = require('joi-browser');
 
 /**
  *

--- a/shared/src/business/entities/externalDocument/ExternalDocumentStandard.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentStandard.js
@@ -1,0 +1,32 @@
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+const joi = require('joi-browser');
+
+/**
+ *
+ * @param rawProps
+ * @constructor
+ */
+function ExternalDocumentStandard(rawProps) {
+  Object.assign(this, rawProps);
+}
+
+ExternalDocumentStandard.errorToMessageMap = {
+  category: 'You must select a category.',
+  documentType: 'You must select a document type.',
+};
+
+ExternalDocumentStandard.schema = joi.object().keys({
+  category: joi.string().required(),
+  documentType: joi.string().required(),
+});
+
+joiValidationDecorator(
+  ExternalDocumentStandard,
+  ExternalDocumentStandard.schema,
+  undefined,
+  ExternalDocumentStandard.errorToMessageMap,
+);
+
+module.exports = { ExternalDocumentStandard };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentStandard.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentStandard.test.js
@@ -1,0 +1,24 @@
+const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
+
+describe('ExternalDocumentStandard', () => {
+  describe('validation', () => {
+    it('should have error messages for missing fields', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        scenario: 'Standard',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual({
+        category: 'You must select a category.',
+        documentType: 'You must select a document type.',
+      });
+    });
+
+    it('should be valid when all fields are present', () => {
+      const extDoc = ExternalDocumentFactory.get({
+        category: 'Application',
+        documentType: 'Application for Waiver of Filing Fee',
+        scenario: 'Standard',
+      });
+      expect(extDoc.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+});

--- a/shared/src/business/useCases/externalDocument/validateExternalDocumentInteractor.js
+++ b/shared/src/business/useCases/externalDocument/validateExternalDocumentInteractor.js
@@ -1,0 +1,16 @@
+/**
+ * validateExternalDocument
+ * @param applicationContext
+ * @param documentMetadata
+ * @returns {Object} errors (null if no errors)
+ */
+exports.validateExternalDocument = ({
+  applicationContext,
+  documentMetadata,
+}) => {
+  const externalDocument = applicationContext
+    .getEntityConstructors()
+    .ExternalDocumentFactory.get(documentMetadata);
+
+  return externalDocument.getFormattedValidationErrors();
+};

--- a/shared/src/business/useCases/externalDocument/validateExternalDocumentInteractor.test.js
+++ b/shared/src/business/useCases/externalDocument/validateExternalDocumentInteractor.test.js
@@ -1,0 +1,41 @@
+const {
+  ExternalDocumentFactory,
+} = require('../../entities/externalDocument/ExternalDocumentFactory');
+const {
+  validateExternalDocument,
+} = require('./validateExternalDocumentInteractor');
+
+describe('validateExternalDocument', () => {
+  it('returns the expected errors object on an empty message', () => {
+    const errors = validateExternalDocument({
+      applicationContext: {
+        getEntityConstructors: () => ({
+          ExternalDocumentFactory,
+        }),
+      },
+      documentMetadata: {},
+    });
+
+    expect(errors).toEqual({
+      category: 'You must select a category.',
+      documentType: 'You must select a document type.',
+    });
+  });
+
+  it('returns no errors when all fields are defined', () => {
+    const errors = validateExternalDocument({
+      applicationContext: {
+        getEntityConstructors: () => ({
+          ExternalDocumentFactory,
+        }),
+      },
+      documentMetadata: {
+        category: 'Application',
+        documentType: 'Application for Waiver of Filing Fee',
+        scenario: 'Standard',
+      },
+    });
+
+    expect(errors).toEqual(null);
+  });
+});

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -26,6 +26,7 @@ import {
   SECTIONS,
 } from '../../shared/src/business/entities/WorkQueue';
 import { ErrorFactory } from './presenter/errors/ErrorFactory';
+import { ExternalDocumentFactory } from '../../shared/src/business/entities/externalDocument/ExternalDocumentFactory';
 import { ForwardMessage } from '../../shared/src/business/entities/ForwardMessage';
 import { InitialWorkItemMessage } from '../../shared/src/business/entities/InitialWorkItemMessage';
 import { Petition } from '../../shared/src/business/entities/Petition';
@@ -64,6 +65,7 @@ import { tryCatchDecorator } from './tryCatchDecorator';
 import { updateCase } from '../../shared/src/proxies/updateCaseProxy';
 import { updateWorkItem } from '../../shared/src/proxies/workitems/updateWorkItemProxy';
 import { validateCaseDetail } from '../../shared/src/business/useCases/validateCaseDetailInteractor';
+import { validateExternalDocument } from '../../shared/src/business/useCases/externalDocument/validateExternalDocumentInteractor';
 import { validateForwardMessage } from '../../shared/src/business/useCases/workitems/validateForwardMessageInteractor';
 import { validateInitialWorkItemMessage } from '../../shared/src/business/useCases/workitems/validateInitialWorkItemMessageInteractor';
 import { validatePetition } from '../../shared/src/business/useCases/validatePetitionInteractor';
@@ -123,6 +125,7 @@ const allUseCases = {
   updateCase,
   updateWorkItem,
   validateCaseDetail,
+  validateExternalDocument,
   validateForwardMessage,
   validateInitialWorkItemMessage,
   validatePetition,
@@ -163,6 +166,7 @@ const applicationContext = {
   getCurrentUser,
   getCurrentUserToken,
   getEntityConstructors: () => ({
+    ExternalDocumentFactory,
     ForwardMessage,
     InitialWorkItemMessage,
     Petition,

--- a/web-client/src/presenter/actions/validateSelectDocumentTypeAction.js
+++ b/web-client/src/presenter/actions/validateSelectDocumentTypeAction.js
@@ -10,16 +10,19 @@ import { state } from 'cerebral';
  * @param {Object} providers.props the cerebral props object
  * @returns {Object} the next path based on if validation was successful or error
  */
-export const validateSelectDocumentTypeAction = ({ path, get }) => {
-  const form = get(state.form);
+export const validateSelectDocumentTypeAction = ({
+  applicationContext,
+  path,
+  get,
+}) => {
+  const documentMetadata = get(state.form);
 
-  const errors = {};
+  const errors = applicationContext.getUseCases().validateExternalDocument({
+    applicationContext,
+    documentMetadata,
+  });
 
-  if (!form.category) errors.category = 'You must select a category.';
-  if (!form.documentType)
-    errors.documentType = 'You must select a document type.';
-
-  if (Object.keys(errors).length === 0) {
+  if (!errors) {
     return path.success();
   } else {
     return path.error({


### PR DESCRIPTION
ustaxcourt/ef-cms#6771 

* Factory method to create an instance of an External Document
* Standard document type
* Use case for validation
* Incorporate the use case in validation with the current product.
* Non Standard Types
* Non Standard H Secondary Document