### PR TITLE
980 Validation Updates

### DIFF
--- a/web-client/src/presenter/sequences/gotoFileDocumentSequence.js
+++ b/web-client/src/presenter/sequences/gotoFileDocumentSequence.js
@@ -11,6 +11,7 @@ import { state } from 'cerebral';
 
 const gotoFileDocument = [
   setCurrentPageAction('Interstitial'),
+  set(state.showValidation, false),
   clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,

--- a/web-client/src/presenter/sequences/validateSelectDocumentTypeSequence.js
+++ b/web-client/src/presenter/sequences/validateSelectDocumentTypeSequence.js
@@ -1,4 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
+import { computeFormDateAction } from '../actions/FileDocument/computeFormDateAction';
+import { computeSecondaryFormDateAction } from '../actions/FileDocument/computeSecondaryFormDateAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { shouldValidateAction } from '../actions/shouldValidateAction';
 import { validateSelectDocumentTypeAction } from '../actions/validateSelectDocumentTypeAction';
@@ -8,6 +10,8 @@ export const validateSelectDocumentTypeSequence = [
   {
     ignore: [],
     validate: [
+      computeFormDateAction,
+      computeSecondaryFormDateAction,
       validateSelectDocumentTypeAction,
       {
         error: [setValidationErrorsAction],

--- a/web-client/src/views/FileDocument/NonstandardForm.jsx
+++ b/web-client/src/views/FileDocument/NonstandardForm.jsx
@@ -15,6 +15,8 @@ export const NonstandardForm = connect(
     namespace: props.namespace,
     screenMetadata: state.screenMetadata,
     updateFormValueSequence: sequences.updateFormValueSequence,
+    validateSelectDocumentTypeSequence:
+      sequences.validateSelectDocumentTypeSequence,
     validationErrors: state[props.validationErrors],
   },
   ({
@@ -25,6 +27,7 @@ export const NonstandardForm = connect(
     screenMetadata,
     updateFormValueSequence,
     validationErrors,
+    validateSelectDocumentTypeSequence,
   }) => {
     namespace = namespace ? `${namespace}.` : '';
     return (
@@ -51,6 +54,9 @@ export const NonstandardForm = connect(
                   key: e.target.name,
                   value: e.target.value,
                 });
+              }}
+              onBlur={() => {
+                validateSelectDocumentTypeSequence();
               }}
             />
             <Text
@@ -81,6 +87,7 @@ export const NonstandardForm = connect(
                   key: e.target.name,
                   value: e.target.value,
                 });
+                validateSelectDocumentTypeSequence();
               }}
             >
               <option value="">- Select -</option>
@@ -138,6 +145,9 @@ export const NonstandardForm = connect(
                         value: e.target.value,
                       });
                     }}
+                    onBlur={() => {
+                      validateSelectDocumentTypeSequence();
+                    }}
                   />
                 </div>
                 <div className="usa-form-group usa-form-group-day">
@@ -165,6 +175,9 @@ export const NonstandardForm = connect(
                         value: e.target.value,
                       });
                     }}
+                    onBlur={() => {
+                      validateSelectDocumentTypeSequence();
+                    }}
                   />
                 </div>
                 <div className="usa-form-group usa-form-group-year">
@@ -191,6 +204,9 @@ export const NonstandardForm = connect(
                         key: e.target.name,
                         value: e.target.value,
                       });
+                    }}
+                    onBlur={() => {
+                      validateSelectDocumentTypeSequence();
                     }}
                   />
                 </div>
@@ -223,6 +239,7 @@ export const NonstandardForm = connect(
                   key: `${namespace}trialLocation`,
                   value: e.target.value,
                 });
+                validateSelectDocumentTypeSequence();
               }}
             />
             <Text
@@ -265,6 +282,7 @@ export const NonstandardForm = connect(
                           key: e.target.name,
                           value: e.target.value,
                         });
+                        validateSelectDocumentTypeSequence();
                       }}
                     />
                     <label htmlFor={`${namespace}${ordinalValue}`}>


### PR DESCRIPTION
ustaxcourt/ef-cms#6771

Stop validation on page entry

* at a point where validation was started a user could navigate around the app in a way where validation was still running when initial selection where occurring. This stops that from occurring.

Non-Standard Form Re-validation 

* make sure validation occurs onBlur/onSelect.