### PR TITLE
Updated approach to getting commit hash on prod deploys

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -10,7 +10,7 @@
     "dev": "GIT_COMMIT=$(git log --pretty=format:'%h' -n 1) USTC_ENV=dev parcel --no-cache --no-hmr --no-source-maps src/index.pug",
     "dev:cognito": "GIT_COMMIT=$(git log --pretty=format:'%h' -n 1) COGNITO=true USTC_ENV=dev parcel --no-cache --no-hmr --no-source-maps src/index.pug",
     "dev:debug": "GIT_COMMIT=$(git log --pretty=format:'%h' -n 1) USTC_DEBUG=true npm run dev",
-    "dist": "rm -rf dist; GIT_COMMIT=$(git log --pretty=format:'%h' -n 1) USTC_ENV=prod parcel build --no-cache --no-source-maps src/index.pug",
+    "dist": "rm -rf dist; USTC_ENV=prod parcel build --no-cache --no-source-maps src/index.pug",
     "lint": "eslint ./src && stylelint ./src/**/*.scss",
     "lint:fix": "eslint ./src --fix && stylelint ./src/**/*.scss --fix",
     "test": "jest .*test\\.js$",

--- a/web-client/src/index.pug
+++ b/web-client/src/index.pug
@@ -3,7 +3,7 @@ html(lang="en")
   head
     meta(charset="utf-8")
     meta(built="" + Date())
-    meta(revision="" + process.env.GIT_COMMIT)
+    meta(revision="" + (process.env.CIRCLE_SHA1 || process.env.GIT_COMMIT))
     meta(name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no")
     title U.S. Tax Court Electronic Filing and Case Management System
     link(rel="preload" as="font" type="font/woff2" href="fonts/noto-serif-jp-v4-latin-400.woff2")


### PR DESCRIPTION
Since possibly no access to a 'git' binary, utilize circle env var.
previous attempt produced empty string for GIT_COMMIT when built via CircleCI