### PR TITLE
302 Optional Secondary Document

### DIFF
--- a/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.js
@@ -154,7 +154,9 @@ ExternalDocumentInformationFactory.get = documentMetadata => {
       makeRequired('secondaryDocumentFile');
     }
 
-    makeRequired('hasSecondarySupportingDocuments');
+    if (documentMetadata.secondaryDocumentFile) {
+      makeRequired('hasSecondarySupportingDocuments');
+    }
 
     if (documentMetadata.hasSecondarySupportingDocuments === true) {
       makeRequired('secondarySupportingDocument');

--- a/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.test.js
@@ -153,12 +153,23 @@ describe('ExternalDocumentInformationFactory', () => {
         it('should not require secondary document file be added', () => {
           expect(errors().secondaryDocumentFile).toEqual(undefined);
         });
-        it('should require has supporting secondary documents radio be selected', () => {
-          expect(errors().hasSecondarySupportingDocuments).toEqual(
-            'Enter selection for Secondary Supporting Documents.',
-          );
-          baseDoc.hasSecondarySupportingDocuments = false;
+
+        it(`should not require 'has supporting secondary documents' radio be selected`, () => {
           expect(errors().hasSecondarySupportingDocuments).toEqual(undefined);
+        });
+
+        describe('Secondary document file added', () => {
+          beforeEach(() => {
+            baseDoc.secondaryDocumentFile = {};
+          });
+
+          it(`should require 'has supporting secondary documents' radio be selected`, () => {
+            expect(errors().hasSecondarySupportingDocuments).toEqual(
+              'Enter selection for Secondary Supporting Documents.',
+            );
+            baseDoc.hasSecondarySupportingDocuments = false;
+            expect(errors().hasSecondarySupportingDocuments).toEqual(undefined);
+          });
         });
       });
 
@@ -175,12 +186,23 @@ describe('ExternalDocumentInformationFactory', () => {
           baseDoc.secondaryDocumentFile = {};
           expect(errors().secondaryDocumentFile).toEqual(undefined);
         });
-        it('should require has supporting secondary documents radio be selected', () => {
-          expect(errors().hasSecondarySupportingDocuments).toEqual(
-            'Enter selection for Secondary Supporting Documents.',
-          );
-          baseDoc.hasSecondarySupportingDocuments = false;
+
+        it(`should not require 'has supporting secondary documents' radio be selected`, () => {
           expect(errors().hasSecondarySupportingDocuments).toEqual(undefined);
+        });
+
+        describe('Secondary document file added', () => {
+          beforeEach(() => {
+            baseDoc.secondaryDocumentFile = {};
+          });
+
+          it(`should require 'has supporting secondary documents' radio be selected`, () => {
+            expect(errors().hasSecondarySupportingDocuments).toEqual(
+              'Enter selection for Secondary Supporting Documents.',
+            );
+            baseDoc.hasSecondarySupportingDocuments = false;
+            expect(errors().hasSecondarySupportingDocuments).toEqual(undefined);
+          });
         });
 
         describe('Has Supporting Secondary Documents', () => {

--- a/web-client/e2e/journey/taxpayerFilesDocumentForCase.js
+++ b/web-client/e2e/journey/taxpayerFilesDocumentForCase.js
@@ -114,8 +114,6 @@ export default (test, fakeFile) => {
       attachments: 'Enter selection for Attachments.',
       certificateOfService: 'Enter selection for Certificate of Service.',
       exhibits: 'Enter selection for Exhibits.',
-      hasSecondarySupportingDocuments:
-        'Enter selection for Secondary Supporting Documents.',
       hasSupportingDocuments: 'Enter selection for Supporting Documents.',
       objections: 'Enter selection for Objections.',
       primaryDocumentFile: 'A file was not selected.',
@@ -132,11 +130,6 @@ export default (test, fakeFile) => {
       value: true,
     });
 
-    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
-      key: 'hasSecondarySupportingDocuments',
-      value: true,
-    });
-
     await test.runSequence('validateExternalDocumentInformationSequence');
     expect(test.getState('validationErrors')).toEqual({
       attachments: 'Enter selection for Attachments.',
@@ -145,8 +138,6 @@ export default (test, fakeFile) => {
       objections: 'Enter selection for Objections.',
       primaryDocumentFile: 'A file was not selected.',
       secondaryDocumentFile: 'A file was not selected.',
-      secondarySupportingDocument:
-        'Enter selection for Secondary Supporting Document.',
       supportingDocument: 'Enter selection for Supporting Document.',
     });
 
@@ -168,8 +159,6 @@ export default (test, fakeFile) => {
       certificateOfServiceDate: 'Enter a Certificate of Service Date.',
       primaryDocumentFile: 'A file was not selected.',
       secondaryDocumentFile: 'A file was not selected.',
-      secondarySupportingDocument:
-        'Enter selection for Secondary Supporting Document.',
       supportingDocument: 'Enter selection for Supporting Document.',
     });
 
@@ -192,8 +181,6 @@ export default (test, fakeFile) => {
         'Certificate of Service date is in the future. Please enter a valid date.',
       primaryDocumentFile: 'A file was not selected.',
       secondaryDocumentFile: 'A file was not selected.',
-      secondarySupportingDocument:
-        'Enter selection for Secondary Supporting Document.',
       supportingDocument: 'Enter selection for Supporting Document.',
     });
 
@@ -206,15 +193,9 @@ export default (test, fakeFile) => {
     expect(test.getState('validationErrors')).toEqual({
       primaryDocumentFile: 'A file was not selected.',
       secondaryDocumentFile: 'A file was not selected.',
-      secondarySupportingDocument:
-        'Enter selection for Secondary Supporting Document.',
       supportingDocument: 'Enter selection for Supporting Document.',
     });
 
-    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
-      key: 'secondarySupportingDocument',
-      value: 'Declaration in Support',
-    });
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'supportingDocument',
       value: 'Affidavit in Support',
@@ -224,16 +205,10 @@ export default (test, fakeFile) => {
     expect(test.getState('validationErrors')).toEqual({
       primaryDocumentFile: 'A file was not selected.',
       secondaryDocumentFile: 'A file was not selected.',
-      secondarySupportingDocumentFile: 'A file was not selected.',
-      secondarySupportingDocumentFreeText: 'Please provide a value.',
       supportingDocumentFile: 'A file was not selected.',
       supportingDocumentFreeText: 'Please provide a value.',
     });
 
-    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
-      key: 'secondarySupportingDocumentFreeText',
-      value: 'Declaration in Support',
-    });
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'supportingDocumentFreeText',
       value: 'Affidavit in Support',
@@ -243,7 +218,6 @@ export default (test, fakeFile) => {
     expect(test.getState('validationErrors')).toEqual({
       primaryDocumentFile: 'A file was not selected.',
       secondaryDocumentFile: 'A file was not selected.',
-      secondarySupportingDocumentFile: 'A file was not selected.',
       supportingDocumentFile: 'A file was not selected.',
     });
 
@@ -256,12 +230,46 @@ export default (test, fakeFile) => {
       value: fakeFile,
     });
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'supportingDocumentFile',
+      value: fakeFile,
+    });
+
+    await test.runSequence('validateExternalDocumentInformationSequence');
+    expect(test.getState('validationErrors')).toEqual({
+      hasSecondarySupportingDocuments:
+        'Enter selection for Secondary Supporting Documents.',
+    });
+
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'hasSecondarySupportingDocuments',
+      value: true,
+    });
+
+    await test.runSequence('validateExternalDocumentInformationSequence');
+    expect(test.getState('validationErrors')).toEqual({
+      secondarySupportingDocument:
+        'Enter selection for Secondary Supporting Document.',
+    });
+
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondarySupportingDocument',
+      value: 'Declaration in Support',
+    });
+
+    await test.runSequence('validateExternalDocumentInformationSequence');
+    expect(test.getState('validationErrors')).toEqual({
+      secondarySupportingDocumentFile: 'A file was not selected.',
+      secondarySupportingDocumentFreeText: 'Please provide a value.',
+    });
+
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'secondarySupportingDocumentFile',
       value: fakeFile,
     });
+
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
-      key: 'supportingDocumentFile',
-      value: fakeFile,
+      key: 'secondarySupportingDocumentFreeText',
+      value: 'Declaration in Support',
     });
 
     await test.runSequence('reviewExternalDocumentInformationSequence');

--- a/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.js
+++ b/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.js
@@ -37,6 +37,13 @@ export const clearWizardDataAction = ({ store, get, props }) => {
       store.set(state.form.supportingDocumentFile, null);
 
       break;
+    case 'secondaryDocumentFile':
+      store.set(state.form.hasSecondarySupportingDocuments, null);
+      store.set(state.form.secondarySupportingDocument, null);
+      store.set(state.form.secondarySupportingDocumentFreeText, null);
+      store.set(state.form.secondarySupportingDocumentFile, null);
+      store.set(state.form.secondarySupportingDocumentMetadata, null);
+      break;
     case 'hasSecondarySupportingDocuments':
       store.set(state.form.secondarySupportingDocument, null);
       store.set(state.form.secondarySupportingDocumentFreeText, null);

--- a/web-client/src/views/FileDocument/SecondaryDocumentForm.jsx
+++ b/web-client/src/views/FileDocument/SecondaryDocumentForm.jsx
@@ -82,52 +82,54 @@ export const SecondaryDocumentForm = connect(
                 />
               </div>
 
-              <div
-                className={`ustc-form-group ${
-                  validationErrors.hasSecondarySupportingDocuments
-                    ? 'usa-input-error'
-                    : ''
-                }`}
-              >
-                <fieldset className="usa-fieldset-inputs usa-sans">
-                  <legend id="secondary-support-docs">
-                    Do You Have Any Supporting Documents for This Filing?
-                  </legend>
-                  <ul className="usa-unstyled-list">
-                    {['Yes', 'No'].map(option => (
-                      <li key={option}>
-                        <input
-                          id={`secondary-supporting-documents-${option}`}
-                          type="radio"
-                          aria-describedby="secondary-support-docs"
-                          name="hasSecondarySupportingDocuments"
-                          value={option}
-                          checked={
-                            form.hasSecondarySupportingDocuments ===
-                            (option === 'Yes')
-                          }
-                          onChange={e => {
-                            updateFileDocumentWizardFormValueSequence({
-                              key: e.target.name,
-                              value: e.target.value === 'Yes',
-                            });
-                            validateExternalDocumentInformationSequence();
-                          }}
-                        />
-                        <label
-                          htmlFor={`secondary-supporting-documents-${option}`}
-                        >
-                          {option}
-                        </label>
-                      </li>
-                    ))}
-                  </ul>
-                </fieldset>
-                <Text
-                  className="usa-input-error-message"
-                  bind="validationErrors.hasSecondarySupportingDocuments"
-                />
-              </div>
+              {fileDocumentHelper.showSecondaryDocumentValid && (
+                <div
+                  className={`ustc-form-group ${
+                    validationErrors.hasSecondarySupportingDocuments
+                      ? 'usa-input-error'
+                      : ''
+                  }`}
+                >
+                  <fieldset className="usa-fieldset-inputs usa-sans">
+                    <legend id="secondary-support-docs">
+                      Do You Have Any Supporting Documents for This Filing?
+                    </legend>
+                    <ul className="usa-unstyled-list">
+                      {['Yes', 'No'].map(option => (
+                        <li key={option}>
+                          <input
+                            id={`secondary-supporting-documents-${option}`}
+                            type="radio"
+                            aria-describedby="secondary-support-docs"
+                            name="hasSecondarySupportingDocuments"
+                            value={option}
+                            checked={
+                              form.hasSecondarySupportingDocuments ===
+                              (option === 'Yes')
+                            }
+                            onChange={e => {
+                              updateFileDocumentWizardFormValueSequence({
+                                key: e.target.name,
+                                value: e.target.value === 'Yes',
+                              });
+                              validateExternalDocumentInformationSequence();
+                            }}
+                          />
+                          <label
+                            htmlFor={`secondary-supporting-documents-${option}`}
+                          >
+                            {option}
+                          </label>
+                        </li>
+                      ))}
+                    </ul>
+                  </fieldset>
+                  <Text
+                    className="usa-input-error-message"
+                    bind="validationErrors.hasSecondarySupportingDocuments"
+                  />
+                </div>
+              )}
 
               {form.hasSecondarySupportingDocuments && (
                 <div

--- a/web-client/src/views/FileDocument/SecondaryDocumentReadOnly.jsx
+++ b/web-client/src/views/FileDocument/SecondaryDocumentReadOnly.jsx
@@ -26,13 +26,15 @@ export const SecondaryDocumentReadOnly = connect(
         </div>
 
         <div className="blue-container">
-          <div className="ustc-form-group">
-            <label htmlFor="secondary-filing">
-              {form.secondaryDocument.documentTitle}
-            </label>
-            <FontAwesomeIcon icon={['fas', 'file-pdf']} />
-            {form.secondaryDocumentFile.name}
-          </div>
+          {form.secondaryDocumentFile && (
+            <div className="ustc-form-group">
+              <label htmlFor="secondary-filing">
+                {form.secondaryDocument.documentTitle}
+              </label>
+              <FontAwesomeIcon icon={['fas', 'file-pdf']} />
+              {form.secondaryDocumentFile.name}
+            </div>
+          )}
 
           {form.secondarySupportingDocumentFile && (
             <div className="ustc-form-group">
@@ -43,6 +45,10 @@ export const SecondaryDocumentReadOnly = connect(
               {form.secondarySupportingDocumentFile.name}
             </div>
           )}
+
+          {!form.secondaryDocumentFile &&
+            !form.secondarySupportingDocumentFile &&
+            'No file attached'}
         </div>
       </React.Fragment>
     );


### PR DESCRIPTION
* Make sure that if secondary document is not selected that the wizard can continue.
* Display message is secondary document is not attached
* Only require hasSecondardSupportingDocuments when a secondary file has been attached.