### PR TITLE
937: add optional params to entities

### DIFF
--- a/shared/src/business/entities/DocketRecord.js
+++ b/shared/src/business/entities/DocketRecord.js
@@ -32,6 +32,10 @@ joiValidationDecorator(
       .max('now')
       .iso()
       .required(),
+    index: joi
+      .number()
+      .integer()
+      .optional(),
     status: joi
       .string()
       .allow(null)

--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -58,7 +58,10 @@ joiValidationDecorator(
       .string()
       .valid(getDocumentTypes())
       .required(),
+    eventCode: joi.string().optional(),
     filedBy: joi.string().optional(),
+    isPaper: joi.boolean().optional(),
+    lodged: joi.boolean().optional(),
     processingStatus: joi.string().optional(),
     reviewDate: joi
       .date()


### PR DESCRIPTION
These fields aren't validated in any way, but we'll add them to the joi validation object for clarity. 