### PR TITLE
Account for items marked complete in unread count

### DIFF
--- a/shared/src/business/useCases/getNotificationsInteractor.js
+++ b/shared/src/business/useCases/getNotificationsInteractor.js
@@ -10,7 +10,9 @@ exports.getNotifications = async ({ applicationContext }) => {
     .getUseCases()
     .getWorkItemsForUser({ applicationContext });
 
-  const unreadCount = workItems.filter(item => !item.readAt).length;
+  const unreadCount = workItems.filter(
+    item => !item.readAt && !item.completedAt,
+  ).length;
 
   return { unreadCount };
 };

--- a/shared/src/business/useCases/getNotificationsInteractor.test.js
+++ b/shared/src/business/useCases/getNotificationsInteractor.test.js
@@ -35,4 +35,24 @@ describe('getWorkItemsForUser', () => {
     });
     expect(result).toEqual({ unreadCount: 1 });
   });
+
+  it('returns an accurate unread count for legacy items marked complete', async () => {
+    applicationContext = {
+      environment: { stage: 'local' },
+      getPersistenceGateway: () => ({
+        getReadMessagesForUser: async () => [],
+        getWorkItemsForUser: async () => [],
+      }),
+      getUseCases: () => ({
+        getWorkItemsForUser: () => {
+          return [{ ...mockWorkItem, completedAt: new Date() }];
+        },
+      }),
+    };
+    const result = await getNotifications({
+      applicationContext,
+      userId: 'docketclerk',
+    });
+    expect(result).toEqual({ unreadCount: 0 });
+  });
 });


### PR DESCRIPTION
In some rare cases, an item could be marked as complete and not be read. This has really only showed up in test data, but is a concern for the PO, so this PR seeks to cover that case.