### PR TITLE
316 update pdflib

### DIFF
--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -2309,8 +2309,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2331,14 +2330,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2353,20 +2350,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2483,8 +2477,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2496,7 +2489,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2511,7 +2503,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2519,14 +2510,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2545,7 +2534,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2626,8 +2614,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2639,7 +2626,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2725,8 +2711,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2762,7 +2747,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2782,7 +2766,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2826,14 +2809,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4852,9 +4833,9 @@
       }
     },
     "pdf-lib": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-0.6.1.tgz",
-      "integrity": "sha512-26TtILsc+tsAEeK7zaSgc4AXKS+zZ6THssHFQRNGPymhy7OiPhCTXXJSwAdU2mBAnGpGfl/A2d9iW1P25kGDlg==",
+      "version": "0.6.2-rc1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-0.6.2-rc1.tgz",
+      "integrity": "sha512-xB8Aey8kaOcGpmCe+hVD1vwOqGCZreQ1JavH1itVproTnddaIXItYv9R7MH88bMe3hbWJkUnv6emOKv/Gbpktg==",
       "requires": {
         "@pdf-lib/fontkit": "^0.0.4",
         "@pdf-lib/standard-fonts": "^0.0.4",

--- a/shared/package.json
+++ b/shared/package.json
@@ -50,7 +50,7 @@
     "joi-browser": "^13.4.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
-    "pdf-lib": "^0.6.1",
+    "pdf-lib": "^0.6.2-rc1",
     "s3-zip": "^2.0.4",
     "sanitize-filename": "^1.6.1",
     "uuid": "^3.3.2"

--- a/shared/src/business/useCases/addCoverToPDFDocumentInteractor.js
+++ b/shared/src/business/useCases/addCoverToPDFDocumentInteractor.js
@@ -545,7 +545,9 @@ exports.addCoverToPDFDocument = async ({
   // Write our pdfDoc object to byte array, ready to physically write to disk or upload
   // to file server
   applicationContext.logger.time('Saving Bytes');
-  const newPdfData = PDFDocumentWriter.saveToBytes(pdfDoc);
+  const newPdfData = PDFDocumentWriter.saveToBytes(pdfDoc, {
+    useObjectStreams: false,
+  });
   applicationContext.logger.timeEnd('Saving Bytes');
 
   documentEntity.processingStatus = 'complete';


### PR DESCRIPTION
- Update `pdf-lib` per a bug fix by the developer re: VERY SLOW parsing of certain PDFs
- Per `pdf-lib` developer, disabling objectStream when writing should be done as an optimization step for larger PDFs.