### PR TITLE
Use document creation date for date filed

### DIFF
--- a/shared/src/business/useCases/addCoverToPDFDocumentInteractor.js
+++ b/shared/src/business/useCases/addCoverToPDFDocumentInteractor.js
@@ -59,7 +59,7 @@ exports.addCoverToPDFDocument = async ({
     minute: '2-digit',
     timeZone: 'America/New_York',
   })}`;
-  const dateFiled = new Date(caseEntity.createdAt);
+  const dateFiled = new Date(documentEntity.createdAt);
   const dateFiledFormatted = dateFiled.toLocaleDateString('en-US', {
     day: '2-digit',
     month: '2-digit',


### PR DESCRIPTION
Use document's `createdAt` for date filed on cover page.