### PR TITLE
Fix hover styling of dismiss button in ie11

### DIFF
--- a/web-client/src/styles/buttons.scss
+++ b/web-client/src/styles/buttons.scss
@@ -58,6 +58,7 @@ button.text-style {
   &:hover,
   &:active {
     background: inherit;
+    background-color: transparent;
     color: inherit;
   }
   &.heading-1 {


### PR DESCRIPTION
Ie11 precedence resulted in dark blue background on hover/active; this brings styling consistent with chrome behavior, others

Screenshot showing display problem this change addresses:
<img width="869" alt="Screen Shot 2019-04-30 at 11 04 16 AM" src="https://user-images.githubusercontent.com/2445917/56976390-74987580-6b38-11e9-893e-77e89a49577d.png">
