### PR TITLE
992: fix widths on inputs/selects with errors

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -394,6 +394,10 @@ label.ustc-upload {
   }
 }
 
+.usa-input-error .select-react-element {
+  width: calc(100% + 1.9rem);
+}
+
 .docket-entry-form {
   .service-date {
     margin-left: 30px;

--- a/web-client/src/styles/overrides.scss
+++ b/web-client/src/styles/overrides.scss
@@ -146,7 +146,7 @@ option:first-child {
 .usa-input-error input,
 .usa-input-error textarea,
 .usa-input-error select {
-  width: calc(100%);
+  width: calc(100% + 1.9rem);
 }
 
 .no-bottom-margin {


### PR DESCRIPTION
Is there any reason _not_ to make this change globally in `overrides.scss`?

<img width="422" alt="Screen Shot 2019-05-07 at 8 55 59 AM" src="https://user-images.githubusercontent.com/43251054/57314271-2ccc9d80-70a6-11e9-80ae-cd37676ed157.png">
<img width="442" alt="Screen Shot 2019-05-07 at 8 56 14 AM" src="https://user-images.githubusercontent.com/43251054/57314278-2fc78e00-70a6-11e9-92d9-c4e74f03119d.png">
