### PR TITLE
CA - Refactoring the approach for the reassign endpoint

### DIFF
--- a/efcms-service/src/workitems/assignWorkItemsLambda.js
+++ b/efcms-service/src/workitems/assignWorkItemsLambda.js
@@ -13,10 +13,9 @@ exports.handler = event =>
     const user = getUserFromAuthHeader(event);
     const applicationContext = createApplicationContext(user);
     try {
-      const workItems = JSON.parse(event.body);
       const results = await applicationContext.getUseCases().assignWorkItems({
         applicationContext,
-        workItems: workItems,
+        ...JSON.parse(event.body),
       });
       applicationContext.logger.info('User', user);
       applicationContext.logger.info('Results', results);

--- a/shared/src/business/test/assignWorkItemsInteractor.e2e.test.js
+++ b/shared/src/business/test/assignWorkItemsInteractor.e2e.test.js
@@ -84,13 +84,9 @@ describe('assignWorkItemsInteractor integration test', () => {
 
     await assignWorkItems({
       applicationContext,
-      workItems: [
-        {
-          assigneeId: '3805d1ab-18d0-43ec-bafb-654e83405416',
-          assigneeName: 'richard',
-          workItemId: workItem.workItemId,
-        },
-      ],
+      assigneeId: '3805d1ab-18d0-43ec-bafb-654e83405416',
+      assigneeName: 'richard',
+      workItemId: workItem.workItemId,
     });
     inbox = await getWorkItemsForUser({
       applicationContext,

--- a/shared/src/business/test/sendPetitionToIRSHoldingQueueInteractor.e2e.test.js
+++ b/shared/src/business/test/sendPetitionToIRSHoldingQueueInteractor.e2e.test.js
@@ -115,13 +115,9 @@ describe('sendPetitionToIRSHoldingQueueInteractor integration test', () => {
 
     await assignWorkItems({
       applicationContext,
-      workItems: [
-        {
-          assigneeId: '3805d1ab-18d0-43ec-bafb-654e83405416',
-          assigneeName: 'Test Petitionsclerk',
-          workItemId,
-        },
-      ],
+      assigneeId: '3805d1ab-18d0-43ec-bafb-654e83405416',
+      assigneeName: 'Test Petitionsclerk',
+      workItemId,
     });
     const petitionsUserInbox = await getWorkItemsForUser({
       applicationContext,

--- a/shared/src/business/test/setMessageAsReadInteractor.e2e.test.js
+++ b/shared/src/business/test/setMessageAsReadInteractor.e2e.test.js
@@ -90,13 +90,9 @@ describe('setMessageAsReadInteractor integration test', () => {
 
     await assignWorkItems({
       applicationContext,
-      workItems: [
-        {
-          assigneeId: '3805d1ab-18d0-43ec-bafb-654e83405416',
-          assigneeName: 'richard',
-          workItemId: workItem.workItemId,
-        },
-      ],
+      assigneeId: '3805d1ab-18d0-43ec-bafb-654e83405416',
+      assigneeName: 'richard',
+      workItemId: workItem.workItemId,
     });
     inbox = await getWorkItemsForUser({
       applicationContext,

--- a/shared/src/business/useCases/workitems/assignWorkItemsInteractor.js
+++ b/shared/src/business/useCases/workitems/assignWorkItemsInteractor.js
@@ -3,6 +3,7 @@ const {
   WORKITEM,
 } = require('../../../authorization/authorizationClientService');
 const { Case } = require('../../entities/Case');
+const { cloneDeep } = require('lodash');
 const { Message } = require('../../entities/Message');
 const { UnauthorizedError } = require('../../../errors/errors');
 const { WorkItem } = require('../../entities/WorkItem');
@@ -15,75 +16,80 @@ const { WorkItem } = require('../../entities/WorkItem');
  * @param applicationContext
  * @returns {Promise<*>}
  */
-exports.assignWorkItems = async ({ workItems, applicationContext }) => {
+exports.assignWorkItems = async ({
+  workItemId,
+  assigneeId,
+  assigneeName,
+  applicationContext,
+}) => {
   const user = applicationContext.getCurrentUser();
   if (!isAuthorized(user, WORKITEM)) {
     throw new UnauthorizedError('Unauthorized to assign work item');
   }
 
-  for (let workItem of workItems) {
-    const fullWorkItem = await applicationContext
-      .getPersistenceGateway()
-      .getWorkItemById({
-        applicationContext,
-        workItemId: workItem.workItemId,
-      });
-
-    const caseObject = await applicationContext
-      .getPersistenceGateway()
-      .getCaseByCaseId({
-        applicationContext,
-        caseId: fullWorkItem.caseId,
-      });
-
-    const caseToUpdate = new Case(caseObject);
-
-    const workItemEntity = new WorkItem(fullWorkItem);
-
-    await applicationContext.getPersistenceGateway().deleteWorkItemFromInbox({
+  const fullWorkItem = await applicationContext
+    .getPersistenceGateway()
+    .getWorkItemById({
       applicationContext,
-      messageId: workItemEntity.getLatestMessageEntity().messageId,
-      workItem: fullWorkItem,
+      workItemId,
     });
 
-    const newMessage = new Message({
-      createdAt: new Date().toISOString(),
-      from: user.name,
-      fromUserId: user.userId,
-      message: workItemEntity.getLatestMessageEntity().message,
-      to: workItem.assigneeName,
-      toUserId: workItem.assigneeId,
+  const caseObject = await applicationContext
+    .getPersistenceGateway()
+    .getCaseByCaseId({
+      applicationContext,
+      caseId: fullWorkItem.caseId,
     });
 
-    workItemEntity
-      .assignToUser({
-        assigneeId: workItem.assigneeId,
-        assigneeName: workItem.assigneeName,
-        role: user.role,
-        sentBy: user.name,
-        sentByUserId: user.userId,
-        sentByUserRole: user.role,
-      })
-      .addMessage(newMessage);
+  const caseToUpdate = new Case(caseObject);
+  const workItemEntity = new WorkItem(fullWorkItem);
+  const originalWorkItem = new WorkItem(cloneDeep(fullWorkItem));
+  const latestMessageId = originalWorkItem.getLatestMessageEntity().messageId;
 
-    caseToUpdate.documents.forEach(
-      document =>
-        (document.workItems = document.workItems.map(item => {
-          return item.workItemId === workItemEntity.workItemId
-            ? workItemEntity
-            : item;
-        })),
-    );
+  const newMessage = new Message({
+    createdAt: new Date().toISOString(),
+    from: user.name,
+    fromUserId: user.userId,
+    message: workItemEntity.getLatestMessageEntity().message,
+    to: assigneeName,
+    toUserId: assigneeId,
+  });
 
-    await applicationContext.getPersistenceGateway().updateCase({
+  workItemEntity
+    .assignToUser({
+      assigneeId,
+      assigneeName,
+      role: user.role,
+      sentBy: user.name,
+      sentByUserId: user.userId,
+      sentByUserRole: user.role,
+    })
+    .addMessage(newMessage);
+
+  caseToUpdate.documents.forEach(
+    document =>
+      (document.workItems = document.workItems.map(item => {
+        return item.workItemId === workItemEntity.workItemId
+          ? workItemEntity
+          : item;
+      })),
+  );
+
+  await Promise.all([
+    applicationContext.getPersistenceGateway().deleteWorkItemFromInbox({
+      applicationContext,
+      deleteFromSection: false,
+      messageId: latestMessageId,
+      workItem: originalWorkItem,
+    }),
+    applicationContext.getPersistenceGateway().updateCase({
       applicationContext,
       caseToUpdate: caseToUpdate.validate().toRawObject(),
-    });
-
-    await applicationContext.getPersistenceGateway().saveWorkItemForPaper({
+    }),
+    applicationContext.getPersistenceGateway().saveWorkItemForPaper({
       applicationContext,
       messageId: newMessage.messageId,
       workItem: workItemEntity.validate().toRawObject(),
-    });
-  }
+    }),
+  ]);
 };

--- a/shared/src/business/useCases/workitems/assignWorkItemsInteractor.test.js
+++ b/shared/src/business/useCases/workitems/assignWorkItemsInteractor.test.js
@@ -68,7 +68,6 @@ describe('assignWorkItems', () => {
       await assignWorkItems({
         applicationContext,
         userId: 'docketclerk',
-        workItems: [{}],
       });
     } catch (err) {
       error = err;

--- a/shared/src/persistence/dynamo/cases/createCase.js
+++ b/shared/src/persistence/dynamo/cases/createCase.js
@@ -13,25 +13,25 @@ const { stripInternalKeys } = require('../../dynamo/helpers/stripInternalKeys');
  * @returns {*}
  */
 exports.createCase = async ({ caseToCreate, applicationContext }) => {
-  await createMappingRecord({
-    applicationContext,
-    pkId: caseToCreate.userId,
-    skId: caseToCreate.caseId,
-    type: 'case',
-  });
-
-  await createMappingRecord({
-    applicationContext,
-    pkId: caseToCreate.docketNumber,
-    skId: caseToCreate.caseId,
-    type: 'case',
-  });
-
-  const results = await saveVersionedCase({
-    applicationContext,
-    caseToSave: caseToCreate,
-    existingVersion: (caseToCreate || {}).currentVersion,
-  });
+  const [results] = await Promise.all([
+    saveVersionedCase({
+      applicationContext,
+      caseToSave: caseToCreate,
+      existingVersion: (caseToCreate || {}).currentVersion,
+    }),
+    createMappingRecord({
+      applicationContext,
+      pkId: caseToCreate.userId,
+      skId: caseToCreate.caseId,
+      type: 'case',
+    }),
+    createMappingRecord({
+      applicationContext,
+      pkId: caseToCreate.docketNumber,
+      skId: caseToCreate.caseId,
+      type: 'case',
+    }),
+  ]);
 
   return stripWorkItems(
     stripInternalKeys(results),

--- a/shared/src/persistence/dynamo/cases/getCaseByCaseId.js
+++ b/shared/src/persistence/dynamo/cases/getCaseByCaseId.js
@@ -8,17 +8,19 @@ const client = require('../../dynamodbClientService');
  * @param applicationContext
  * @returns {*}
  */
-exports.getCaseByCaseId = async ({ caseId, applicationContext }) => {
-  const results = await client.get({
-    Key: {
-      pk: caseId,
-      sk: '0',
-    },
-    applicationContext,
-  });
-
-  return stripWorkItems(
-    stripInternalKeys(results),
-    applicationContext.isAuthorizedForWorkItems(),
-  );
+exports.getCaseByCaseId = ({ caseId, applicationContext }) => {
+  return client
+    .get({
+      Key: {
+        pk: caseId,
+        sk: '0',
+      },
+      applicationContext,
+    })
+    .then(results =>
+      stripWorkItems(
+        stripInternalKeys(results),
+        applicationContext.isAuthorizedForWorkItems(),
+      ),
+    );
 };

--- a/shared/src/persistence/dynamo/cases/saveCase.js
+++ b/shared/src/persistence/dynamo/cases/saveCase.js
@@ -9,25 +9,26 @@ exports.saveVersionedCase = async ({
   const currentVersion = existingVersion;
   const nextVersionToSave = parseInt(currentVersion || '0') + 1;
 
-  // update the current history
-  await client.put({
-    Item: {
-      pk: caseToSave.caseId,
-      sk: '0',
-      ...caseToSave,
-      currentVersion: `${nextVersionToSave}`,
-    },
-    applicationContext,
-  });
+  const [, latest] = await Promise.all([
+    client.put({
+      Item: {
+        pk: caseToSave.caseId,
+        sk: '0',
+        ...caseToSave,
+        currentVersion: `${nextVersionToSave}`,
+      },
+      applicationContext,
+    }),
+    client.put({
+      Item: {
+        pk: caseToSave.caseId,
+        sk: `${nextVersionToSave}`,
+        ...caseToSave,
+        currentVersion: `${nextVersionToSave}`,
+      },
+      applicationContext,
+    }),
+  ]);
 
-  // add a history entry
-  return await client.put({
-    Item: {
-      pk: caseToSave.caseId,
-      sk: `${nextVersionToSave}`,
-      ...caseToSave,
-      currentVersion: `${nextVersionToSave}`,
-    },
-    applicationContext,
-  });
+  return latest;
 };

--- a/shared/src/persistence/dynamo/helpers/deleteMappingRecord.js
+++ b/shared/src/persistence/dynamo/helpers/deleteMappingRecord.js
@@ -1,12 +1,7 @@
 const client = require('../../dynamodbClientService');
 
-exports.deleteMappingRecord = async ({
-  applicationContext,
-  pkId,
-  skId,
-  type,
-}) => {
-  await client.delete({
+exports.deleteMappingRecord = ({ applicationContext, pkId, skId, type }) => {
+  return client.delete({
     applicationContext,
     key: {
       pk: `${pkId}|${type}`,

--- a/shared/src/persistence/dynamo/workitems/deleteWorkItemFromInbox.js
+++ b/shared/src/persistence/dynamo/workitems/deleteWorkItemFromInbox.js
@@ -1,30 +1,41 @@
 const { deleteMappingRecord } = require('../helpers/deleteMappingRecord');
 
-exports.deleteWorkItemFromInbox = async ({
+exports.deleteWorkItemFromInbox = ({
   workItem,
   messageId,
   applicationContext,
+  deleteFromSection = true,
 }) => {
+  const requests = [];
   if (workItem.assigneeId) {
-    await deleteMappingRecord({
-      applicationContext,
-      pkId: workItem.assigneeId,
-      skId: workItem.workItemId,
-      type: 'workItem',
-    });
-
-    await deleteMappingRecord({
-      applicationContext,
-      pkId: workItem.assigneeId,
-      skId: messageId,
-      type: 'unread-message',
-    });
+    requests.push(
+      deleteMappingRecord({
+        applicationContext,
+        pkId: workItem.assigneeId,
+        skId: workItem.workItemId,
+        type: 'workItem',
+      }),
+    );
+    requests.push(
+      deleteMappingRecord({
+        applicationContext,
+        pkId: workItem.assigneeId,
+        skId: messageId,
+        type: 'unread-message',
+      }),
+    );
   }
 
-  await deleteMappingRecord({
-    applicationContext,
-    pkId: workItem.section,
-    skId: workItem.workItemId,
-    type: 'workItem',
-  });
+  if (deleteFromSection) {
+    requests.push(
+      deleteMappingRecord({
+        applicationContext,
+        pkId: workItem.section,
+        skId: workItem.workItemId,
+        type: 'workItem',
+      }),
+    );
+  }
+
+  return Promise.all(requests);
 };

--- a/shared/src/persistence/dynamo/workitems/getWorkItemById.js
+++ b/shared/src/persistence/dynamo/workitems/getWorkItemById.js
@@ -1,13 +1,14 @@
 const client = require('../../dynamodbClientService');
 const { stripInternalKeys } = require('../../dynamo/helpers/stripInternalKeys');
 
-exports.getWorkItemById = async ({ workItemId, applicationContext }) => {
-  const workItem = await client.get({
-    Key: {
-      pk: workItemId,
-      sk: workItemId,
-    },
-    applicationContext,
-  });
-  return stripInternalKeys(workItem);
+exports.getWorkItemById = ({ workItemId, applicationContext }) => {
+  return client
+    .get({
+      Key: {
+        pk: workItemId,
+        sk: workItemId,
+      },
+      applicationContext,
+    })
+    .then(stripInternalKeys);
 };

--- a/shared/src/persistence/dynamo/workitems/saveWorkItemForPaper.js
+++ b/shared/src/persistence/dynamo/workitems/saveWorkItemForPaper.js
@@ -17,46 +17,41 @@ exports.saveWorkItemForPaper = async ({
   workItem,
   applicationContext,
 }) => {
-  // create the work item
-  await put({
-    Item: {
-      pk: workItem.workItemId,
-      sk: workItem.workItemId,
-      ...workItem,
-    },
-    applicationContext,
-  });
-
-  await createMappingRecord({
-    applicationContext,
-    pkId: workItem.caseId,
-    skId: workItem.workItemId,
-    type: 'workItem',
-  });
-
-  // individual inbox
-  await createMappingRecord({
-    applicationContext,
-    pkId: workItem.assigneeId,
-    skId: workItem.workItemId,
-    type: 'workItem',
-  });
-
-  await createMappingRecord({
-    applicationContext,
-    item: {
-      messageId,
-    },
-    pkId: workItem.assigneeId,
-    skId: messageId,
-    type: 'unread-message',
-  });
-
-  // section inbox
-  await createMappingRecord({
-    applicationContext,
-    pkId: workItem.section,
-    skId: workItem.workItemId,
-    type: 'workItem',
-  });
+  return Promise.all([
+    put({
+      Item: {
+        pk: workItem.workItemId,
+        sk: workItem.workItemId,
+        ...workItem,
+      },
+      applicationContext,
+    }),
+    createMappingRecord({
+      applicationContext,
+      pkId: workItem.caseId,
+      skId: workItem.workItemId,
+      type: 'workItem',
+    }),
+    createMappingRecord({
+      applicationContext,
+      pkId: workItem.assigneeId,
+      skId: workItem.workItemId,
+      type: 'workItem',
+    }),
+    createMappingRecord({
+      applicationContext,
+      item: {
+        messageId,
+      },
+      pkId: workItem.assigneeId,
+      skId: messageId,
+      type: 'unread-message',
+    }),
+    createMappingRecord({
+      applicationContext,
+      pkId: workItem.section,
+      skId: workItem.workItemId,
+      type: 'workItem',
+    }),
+  ]);
 };

--- a/shared/src/proxies/workitems/assignWorkItemsProxy.js
+++ b/shared/src/proxies/workitems/assignWorkItemsProxy.js
@@ -7,10 +7,19 @@ const { put } = require('../requests');
  * @param applicationContext
  * @returns {Promise<*>}
  */
-exports.assignWorkItems = ({ workItems, applicationContext }) => {
+exports.assignWorkItems = ({
+  workItemId,
+  assigneeId,
+  assigneeName,
+  applicationContext,
+}) => {
   return put({
     applicationContext,
-    body: workItems,
+    body: {
+      assigneeId,
+      assigneeName,
+      workItemId,
+    },
     endpoint: '/workitems',
   });
 };

--- a/web-client/src/presenter/actions/assignSelectedWorkItemsAction.js
+++ b/web-client/src/presenter/actions/assignSelectedWorkItemsAction.js
@@ -20,14 +20,16 @@ export const assignSelectedWorkItemsAction = async ({
   const assigneeId = get(state.assigneeId);
   const assigneeName = get(state.assigneeName);
 
-  await applicationContext.getUseCases().assignWorkItems({
-    applicationContext,
-    workItems: selectedWorkItems.map(workItem => ({
-      assigneeId,
-      assigneeName,
-      workItemId: workItem.workItemId,
-    })),
-  });
+  await Promise.all(
+    selectedWorkItems.map(workItem =>
+      applicationContext.getUseCases().assignWorkItems({
+        applicationContext,
+        assigneeId,
+        assigneeName,
+        workItemId: workItem.workItemId,
+      }),
+    ),
+  );
 
   store.set(
     state.workQueue,


### PR DESCRIPTION
- doing more Promise.all instead of awaiting on everything to speed up this endpoint
- the UI makes a separate request for each work item it is trying to reassign; this will prevent the lambda from timing out due to large reassignments