### PR TITLE
992 Empty String Unset

### DIFF
--- a/web-client/src/presenter/actions/DocketEntry/updateDocketEntryWizardDataAction.js
+++ b/web-client/src/presenter/actions/DocketEntry/updateDocketEntryWizardDataAction.js
@@ -91,5 +91,11 @@ export const updateDocketEntryWizardDataAction = ({ get, store, props }) => {
         }
       }
       break;
+    case 'additionalInfo':
+    case 'additionalInfo2':
+      if (!props.value) {
+        store.unset(state.form[props.key]);
+      }
+      break;
   }
 };

--- a/web-client/src/presenter/actions/DocketEntry/updateDocketEntryWizardDataAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/updateDocketEntryWizardDataAction.test.js
@@ -76,4 +76,23 @@ describe('updateDocketEntryWizardDataAction', () => {
       documentTitle: 'document title',
     });
   });
+
+  it('unsets additionalInfo if empty', async () => {
+    const result = await runAction(updateDocketEntryWizardDataAction, {
+      props: {
+        key: 'additionalInfo',
+      },
+      state: {
+        constants: {
+          INTERNAL_CATEGORY_MAP: ['documentTitle'],
+        },
+        form: {
+          additionalInfo: '',
+          documentTitle: 'document title',
+        },
+      },
+    });
+
+    expect(result.state.form.additionalInfo).toEqual(undefined);
+  });
 });

--- a/web-client/src/presenter/actions/DocketEntry/updateDocketEntryWizardDataAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/updateDocketEntryWizardDataAction.test.js
@@ -95,4 +95,23 @@ describe('updateDocketEntryWizardDataAction', () => {
 
     expect(result.state.form.additionalInfo).toEqual(undefined);
   });
+
+  it('unsets additionalInfo2 if empty', async () => {
+    const result = await runAction(updateDocketEntryWizardDataAction, {
+      props: {
+        key: 'additionalInfo2',
+      },
+      state: {
+        constants: {
+          INTERNAL_CATEGORY_MAP: ['documentTitle'],
+        },
+        form: {
+          additionalInfo2: '',
+          documentTitle: 'document title',
+        },
+      },
+    });
+
+    expect(result.state.form.additionalInfo2).toEqual(undefined);
+  });
 });


### PR DESCRIPTION
ustaxcourt/ef-cms#6778 Joi validation doesn't allow empty string, even for optional items. we can prune the property if it's an empty string. 