### PR TITLE
1659: mobile document details overlay

### DIFF
--- a/web-client/src/styles/modals.scss
+++ b/web-client/src/styles/modals.scss
@@ -162,3 +162,15 @@
   font-size: 30px;
   text-align: center;
 }
+
+.mobile-document-details-overlay {
+  .usa-button.heading-2.usa-button--unstyled {
+    color: color($theme-color-base-darkest);
+    text-decoration: none;
+
+    svg {
+      margin-right: 15px;
+      font-size: 20px;
+    }
+  }
+}

--- a/web-client/src/views/DocketRecord/DocketRecordOverlay.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecordOverlay.jsx
@@ -69,7 +69,10 @@ class DocketRecordOverlayComponent extends React.Component {
     const { baseUrl, token } = this.props;
     return (
       <FocusLock>
-        <dialog open className="modal-screen overlay">
+        <dialog
+          open
+          className="modal-screen overlay mobile-document-details-overlay"
+        >
           <div
             className={'modal-overlay'}
             data-aria-live="assertive"
@@ -77,15 +80,15 @@ class DocketRecordOverlayComponent extends React.Component {
             role="dialog"
           >
             <button
-              className="heading-1 text-style usa-button usa-button--unstyled"
+              className="heading-2 usa-button usa-button--unstyled"
               onClick={() => closeFunc()}
               aria-roledescription="button to return to docket record"
             >
               <FontAwesomeIcon icon="caret-left" />
               Document Details
             </button>
-            <hr />
-            <h2 tabIndex="-1">{record.description}</h2>
+            <hr className="margin-top-1 margin-bottom-2" />
+            <h3 tabIndex="-1">{record.description}</h3>
             <a
               className="usa-button view-pdf-button tablet-full-width"
               href={`${baseUrl}/documents/${


### PR DESCRIPTION
<img width="384" alt="Screen Shot 2019-05-16 at 9 50 21 AM" src="https://user-images.githubusercontent.com/43251054/57872271-2cc45000-77c0-11e9-9054-a60e44742930.png">
