### PR TITLE
1658 1659: bolder text

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -610,8 +610,9 @@ header.usa-header {
       padding: 0 0 6px 0;
       background: none;
       color: color($theme-color-primary);
+      font-family: $font-serif;
       font-size: 20px;
-      font-weight: $font-semibold;
+      font-weight: $font-bold;
       :hover {
         background: none;
         color: color($theme-color-primary);
@@ -874,6 +875,7 @@ nav.usa-nav {
   .usa-tag {
     background: $color-white;
     color: color($theme-color-primary-darker);
+    font-weight: $font-bold;
   }
   .unread {
     position: relative;


### PR DESCRIPTION
correcting nav font, weight of .usa-tag
<img width="425" alt="Screen Shot 2019-05-16 at 12 02 26 PM" src="https://user-images.githubusercontent.com/2445917/57872932-85044d80-77d2-11e9-9d91-a2a759c05575.png">
