### PR TITLE
Prevent call to API before token is set

### DIFF
--- a/web-client/src/views/Header.jsx
+++ b/web-client/src/views/Header.jsx
@@ -83,7 +83,9 @@ export const Header = connect(
     user,
   }) => {
     useEffect(() => {
-      fetchUserNotificationsSequence();
+      if (user && user.userId) {
+        fetchUserNotificationsSequence();
+      }
     }, []);
 
     return (


### PR DESCRIPTION
I believe we don't see this issue locally as the call to the API gets a valid response, even when unauthed. My assumption is `fetchUserNotificationsSequence` is being called before a token gets set in some cases (it affected Rachel every time, where it was an intermittent issue on my end - so clearly waiting on some network requests somewhere), so the request isn't authorized immediately, which returns an unauthed request error, which automatically redirects you to login.

We should also consider handling unauthed requests better in our error handling.