### PR TITLE
1658: hyperlink outline

### DIFF
--- a/web-client/src/styles/tables.scss
+++ b/web-client/src/styles/tables.scss
@@ -120,6 +120,8 @@ table.work-queue {
     .message-document-title {
       overflow: hidden;
       max-width: units('tablet');
+      padding: 4px;
+      margin: -4px;
       text-overflow: ellipsis;
       white-space: nowrap;
     }


### PR DESCRIPTION
Problem: elements matching `a:active` acquire an outline (much like form inputs), but within the messages table, they're contained within an element which hides overflow and has no padding, resulting in the outline being displayed in odd ways.  This solution trades padding for margin and reveals the entire outline where possible.

![css-before-after](https://user-images.githubusercontent.com/2445917/57888329-7da36b00-77f7-11e9-8daf-bba2702eaab8.gif)
