### PR TITLE
1659: convert date outputs to 2-digit years

### DIFF
--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -3,7 +3,6 @@ const moment = require('moment-timezone');
 const dateFormats = {
   DATE_TIME: 'MM/DD/YY hh:mm a',
   MMDDYY: 'MM/DD/YY',
-  MMDDYYYY: 'L',
   TIME: 'LT',
 };
 

--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -1,7 +1,7 @@
 const moment = require('moment-timezone');
 
 const dateFormats = {
-  DATE_TIME: 'MM/DD/YYYY hh:mm a',
+  DATE_TIME: 'MM/DD/YY hh:mm a',
   MMDDYY: 'MM/DD/YY',
   MMDDYYYY: 'L',
   TIME: 'LT',
@@ -11,6 +11,7 @@ const USTC_TZ = 'America/New_York';
 
 /**
  * @param {string} dateString a date string to be sent to persistence
+ * @param {string} inputFormat
  * @returns {string} a formatted ISO date string
  */
 module.exports.createISODateString = (dateString, inputFormat) => {

--- a/web-client/src/presenter/computeds/addDocketEntryHelper.js
+++ b/web-client/src/presenter/computeds/addDocketEntryHelper.js
@@ -1,6 +1,5 @@
 import { find, includes, orderBy } from 'lodash';
 import { state } from 'cerebral';
-import moment from 'moment';
 
 import {
   getOptionsForCategory,
@@ -19,7 +18,7 @@ const getInternalDocumentTypes = typeMap => {
   return orderBy(filteredTypeList, ['label'], ['asc']);
 };
 
-export const addDocketEntryHelper = get => {
+export const addDocketEntryHelper = (get, applicationContext) => {
   const { PARTY_TYPES, INTERNAL_CATEGORY_MAP } = get(state.constants);
   const caseDetail = get(state.caseDetail);
   if (!caseDetail.partyType) {
@@ -61,9 +60,9 @@ export const addDocketEntryHelper = get => {
   const certificateOfServiceDate = form.certificateOfServiceDate;
   let certificateOfServiceDateFormatted;
   if (certificateOfServiceDate) {
-    certificateOfServiceDateFormatted = moment
-      .utc(certificateOfServiceDate)
-      .format('L');
+    certificateOfServiceDateFormatted = applicationContext
+      .getUtilities()
+      .formatDateString(certificateOfServiceDate, 'MMDDYY');
   }
 
   const previouslyFiledWizardDocuments = getPreviouslyFiledDocuments(

--- a/web-client/src/presenter/computeds/addDocketEntryHelper.test.js
+++ b/web-client/src/presenter/computeds/addDocketEntryHelper.test.js
@@ -93,7 +93,7 @@ describe('addDocketEntryHelper', () => {
   it('generates correctly formatted service date', async () => {
     state.form.certificateOfServiceDate = '2012-05-31';
     const result = await runCompute(addDocketEntryHelper, { state });
-    expect(result.certificateOfServiceDateFormatted).toEqual('05/31/2012');
+    expect(result.certificateOfServiceDateFormatted).toEqual('05/31/12');
   });
 
   it('does not generate a formatted service date if a service date is not entered on the form', async () => {

--- a/web-client/src/presenter/computeds/computeds.test.js
+++ b/web-client/src/presenter/computeds/computeds.test.js
@@ -35,7 +35,7 @@ describe('formatted case details computed', () => {
         form: {},
       },
     });
-    expect(result.irsDateFormatted).toContain('11/21/2018');
+    expect(result.irsDateFormatted).toContain('11/21/18');
     expect(result.documents[0].isPetition).toEqual(true);
   });
 
@@ -62,7 +62,7 @@ describe('formatted case details computed', () => {
         },
       },
     });
-    expect(result[0].irsDateFormatted).toContain('11/21/2018');
+    expect(result[0].irsDateFormatted).toContain('11/21/18');
   });
 
   it('formats the respondent name to include barnumber', () => {

--- a/web-client/src/presenter/computeds/fileDocumentHelper.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.js
@@ -1,5 +1,4 @@
 import { state } from 'cerebral';
-import moment from 'moment';
 
 export const supportingDocumentFreeTextTypes = [
   'Affidavit in Support',
@@ -7,7 +6,7 @@ export const supportingDocumentFreeTextTypes = [
   'Unsworn Declaration under Penalty of Perjury in Support',
 ];
 
-export const fileDocumentHelper = get => {
+export const fileDocumentHelper = (get, applicationContext) => {
   const { PARTY_TYPES, CATEGORY_MAP } = get(state.constants);
   const caseDetail = get(state.caseDetail);
   if (!caseDetail.partyType) {
@@ -47,9 +46,9 @@ export const fileDocumentHelper = get => {
   const certificateOfServiceDate = form.certificateOfServiceDate;
   let certificateOfServiceDateFormatted;
   if (certificateOfServiceDate) {
-    certificateOfServiceDateFormatted = moment
-      .utc(certificateOfServiceDate)
-      .format('L');
+    certificateOfServiceDateFormatted = applicationContext
+      .getUtilities()
+      .formatDateString(certificateOfServiceDate, 'MMDDYY');
   }
 
   const showFilingIncludes =

--- a/web-client/src/presenter/computeds/fileDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.test.js
@@ -1,8 +1,10 @@
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../withAppContext';
 
 import { CATEGORY_MAP } from '../../../../shared/src/business/entities/Document';
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
 import { PARTY_TYPES } from '../../../../shared/src/business/entities/contacts/PetitionContact';
+import { fileDocumentHelper as fileDocumentHelperComputed } from './fileDocumentHelper';
 
 const state = {
   caseDetail: MOCK_CASE,
@@ -14,7 +16,7 @@ const state = {
   validationErrors: {},
 };
 
-import { fileDocumentHelper } from './fileDocumentHelper';
+const fileDocumentHelper = withAppContextDecorator(fileDocumentHelperComputed);
 
 describe('fileDocumentHelper', () => {
   beforeEach(() => {
@@ -81,7 +83,7 @@ describe('fileDocumentHelper', () => {
   it('generates correctly formatted service date', async () => {
     state.form.certificateOfServiceDate = '2012-05-31';
     const result = await runCompute(fileDocumentHelper, { state });
-    expect(result.certificateOfServiceDateFormatted).toEqual('05/31/2012');
+    expect(result.certificateOfServiceDateFormatted).toEqual('05/31/12');
   });
 
   it('does not generate a formatted service date if a service date is not entered on the form', async () => {

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -5,7 +5,7 @@ export const formatDocument = (document, applicationContext) => {
   const result = _.cloneDeep(document);
   result.createdAtFormatted = applicationContext
     .getUtilities()
-    .formatDateString(result.createdAt, 'MMDDYYYY');
+    .formatDateString(result.createdAt, 'MMDDYY');
   result.showValidationInput = !result.reviewDate;
   result.isStatusServed = result.status === 'served';
   result.isPetition = result.documentType === 'Petition';
@@ -16,7 +16,7 @@ const formatDocketRecord = (docketRecord, applicationContext) => {
   const result = _.cloneDeep(docketRecord);
   result.createdAtFormatted = applicationContext
     .getUtilities()
-    .formatDateString(result.filingDate, 'MMDDYYYY');
+    .formatDateString(result.filingDate, 'MMDDYY');
 
   return result;
 };
@@ -116,7 +116,7 @@ const formatDocketRecordWithDocument = (
       if (document.certificateOfServiceDate) {
         document.certificateOfServiceDateFormatted = applicationContext
           .getUtilities()
-          .formatDateString(document.certificateOfServiceDate, 'L');
+          .formatDateString(document.certificateOfServiceDate, 'MMDDYY');
       }
 
       //filings and proceedings string
@@ -194,16 +194,16 @@ const formatCase = (caseDetail, caseDetailErrors, applicationContext) => {
 
   result.createdAtFormatted = applicationContext
     .getUtilities()
-    .formatDateString(result.createdAt, 'MMDDYYYY');
+    .formatDateString(result.createdAt, 'MMDDYY');
   result.receivedAtFormatted = applicationContext
     .getUtilities()
-    .formatDateString(result.receivedAt, 'MMDDYYYY');
+    .formatDateString(result.receivedAt, 'MMDDYY');
   result.irsDateFormatted = applicationContext
     .getUtilities()
     .formatDateString(result.irsSendDate, 'DATE_TIME');
   result.payGovDateFormatted = applicationContext
     .getUtilities()
-    .formatDateString(result.payGovDate, 'MMDDYYYY');
+    .formatDateString(result.payGovDate, 'MMDDYY');
 
   result.docketNumberWithSuffix = `${
     result.docketNumber
@@ -212,7 +212,7 @@ const formatCase = (caseDetail, caseDetailErrors, applicationContext) => {
   result.irsNoticeDateFormatted = result.irsNoticeDate
     ? applicationContext
         .getUtilities()
-        .formatDateString(result.irsNoticeDate, 'MMDDYYYY')
+        .formatDateString(result.irsNoticeDate, 'MMDDYY')
     : 'No notice provided';
 
   result.datePetitionSentToIrsMessage = `Respondent served ${

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -232,7 +232,7 @@ const formatCase = (caseDetail, caseDetailErrors, applicationContext) => {
     caseDetail.caseCaption || '',
   );
 
-  formatYearAmounts(result, caseDetailErrors);
+  formatYearAmounts(result, caseDetailErrors, applicationContext);
 
   return result;
 };

--- a/web-client/src/presenter/computeds/formattedCaseDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.test.js
@@ -219,7 +219,7 @@ describe('formattedCaseDetail', () => {
         constants,
       },
     });
-    expect(result.docketRecord[0].createdAtFormatted).toEqual('02/28/2019');
+    expect(result.docketRecord[0].createdAtFormatted).toEqual('02/28/19');
   });
 
   it('maps docket record documents', async () => {
@@ -399,7 +399,7 @@ describe('formattedCaseDetail', () => {
     ).toEqual('(Exhibit(s))');
     expect(
       result.docketRecordWithDocument[2].record.filingsAndProceedings,
-    ).toEqual('(C/S 06/07/2018) (Exhibit(s)) (Attachment(s)) (Objection)');
+    ).toEqual('(C/S 06/07/18) (Exhibit(s)) (Attachment(s)) (Objection)');
     expect(
       result.docketRecordWithDocument[3].record.filingsAndProceedings,
     ).toEqual('(Lodged)');

--- a/web-client/src/presenter/computeds/formattedWorkQueue.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.js
@@ -4,10 +4,10 @@ import _ from 'lodash';
 const formatDateIfToday = (date, applicationContext) => {
   const now = applicationContext
     .getUtilities()
-    .formatDateString(undefined, 'MMDDYYYY');
+    .formatDateString(undefined, 'MMDDYY');
   const then = applicationContext
     .getUtilities()
-    .formatDateString(date, 'MMDDYYYY');
+    .formatDateString(date, 'MMDDYY');
   let formattedDate;
   if (now == then) {
     formattedDate = applicationContext
@@ -28,7 +28,7 @@ export const formatWorkItem = (
 
   result.createdAtFormatted = applicationContext
     .getUtilities()
-    .formatDateString(result.createdAt, 'MMDDYYYY');
+    .formatDateString(result.createdAt, 'MMDDYY');
   result.messages = _.orderBy(result.messages, 'createdAt', 'desc');
   result.messages.forEach(message => {
     message.createdAtFormatted = formatDateIfToday(

--- a/web-client/src/presenter/computeds/formattedWorkQueueComputed.test.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueueComputed.test.js
@@ -9,9 +9,9 @@ const FORMATTED_WORK_ITEM = {
   assigneeName: 'Unassigned',
   caseId: 'e631d81f-a579-4de5-b8a8-b3f10ef619fd',
   caseStatus: 'General Docket',
-  createdAtFormatted: '12/27/2018',
+  createdAtFormatted: '12/27/18',
   currentMessage: {
-    createdAtFormatted: '12/27/2018',
+    createdAtFormatted: '12/27/18',
     from: 'Test Respondent',
     fromUserId: 'respondent',
     message: 'Answer filed by respondent is ready for review',
@@ -25,7 +25,7 @@ const FORMATTED_WORK_ITEM = {
   },
   historyMessages: [
     {
-      createdAtFormatted: '12/27/2018',
+      createdAtFormatted: '12/27/18',
       from: 'Test Docketclerk',
       fromUserId: 'docketclerk',
       message: 'a message',
@@ -35,7 +35,7 @@ const FORMATTED_WORK_ITEM = {
   ],
   messages: [
     {
-      createdAtFormatted: '12/27/2018',
+      createdAtFormatted: '12/27/18',
       from: 'Test Respondent',
       fromUserId: 'respondent',
       message: 'Answer filed by respondent is ready for review',
@@ -43,7 +43,7 @@ const FORMATTED_WORK_ITEM = {
       to: 'Unassigned',
     },
     {
-      createdAtFormatted: '12/27/2018',
+      createdAtFormatted: '12/27/18',
       from: 'Test Docketclerk',
       fromUserId: 'docketclerk',
       message: 'a message',

--- a/web-client/src/presenter/computeds/requestAccessHelper.js
+++ b/web-client/src/presenter/computeds/requestAccessHelper.js
@@ -1,7 +1,6 @@
 import { state } from 'cerebral';
-import moment from 'moment';
 
-export const requestAccessHelper = get => {
+export const requestAccessHelper = (get, applicationContext) => {
   const { PARTY_TYPES } = get(state.constants);
   const caseDetail = get(state.caseDetail);
   const form = get(state.form);
@@ -13,9 +12,9 @@ export const requestAccessHelper = get => {
   const certificateOfServiceDate = form.certificateOfServiceDate;
   let certificateOfServiceDateFormatted;
   if (certificateOfServiceDate) {
-    certificateOfServiceDateFormatted = moment
-      .utc(certificateOfServiceDate)
-      .format('L');
+    certificateOfServiceDateFormatted = applicationContext
+      .getUtilities()
+      .formatDateString(certificateOfServiceDate, 'MMDDYY');
   }
 
   const partyValidationError =

--- a/web-client/src/presenter/computeds/requestAccessHelper.test.js
+++ b/web-client/src/presenter/computeds/requestAccessHelper.test.js
@@ -1,8 +1,10 @@
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../withAppContext';
 
 import { CATEGORY_MAP } from '../../../../shared/src/business/entities/Document';
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
 import { PARTY_TYPES } from '../../../../shared/src/business/entities/contacts/PetitionContact';
+import { requestAccessHelper as requestAccessHelperComputed } from './requestAccessHelper';
 
 const state = {
   caseDetail: MOCK_CASE,
@@ -14,7 +16,9 @@ const state = {
   validationErrors: {},
 };
 
-import { requestAccessHelper } from './requestAccessHelper';
+const requestAccessHelper = withAppContextDecorator(
+  requestAccessHelperComputed,
+);
 
 describe('requestAccessHelper', () => {
   beforeEach(() => {
@@ -47,7 +51,7 @@ describe('requestAccessHelper', () => {
   it('generates correctly formatted service date', async () => {
     state.form.certificateOfServiceDate = '2012-05-31';
     const result = await runCompute(requestAccessHelper, { state });
-    expect(result.certificateOfServiceDateFormatted).toEqual('05/31/2012');
+    expect(result.certificateOfServiceDateFormatted).toEqual('05/31/12');
   });
 
   it('does not generate a formatted service date if a service date is not entered on the form', async () => {


### PR DESCRIPTION
* Convert date outputs to 2-digit years
* Fix bug `applicationContext is undefined` when viewing petitioner dashboard and doc detail page
* Convert a few uses of `moment` in computeds to use the new date functions