### PR TITLE
1661: update color green on file success icons

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -341,7 +341,7 @@ select[disabled] {
 }
 
 .mini-success {
-  color: $color-success;
+  color: $color-green;
 
   svg {
     margin-right: 5px;

--- a/web-client/src/styles/variables.scss
+++ b/web-client/src/styles/variables.scss
@@ -18,8 +18,7 @@ $font-source-sans: 'Source Sans Pro', sans-serif;
 $color-primary-alt: #61e5ff;
 $color-primary-alt-lightest: #f1f9fc;
 $color-white: #fff;
-$color-green: #538200;
-$color-success: #2e8540;
+$color-green: #2e8540;
 
 $small-screen: 480px;
 $medium-screen: 640px;


### PR DESCRIPTION
New green color (#538200) will not be used anywhere according to UX. Replaced variable with old green color (#2e8540) to apply throughout. 
<img width="369" alt="Screen Shot 2019-05-20 at 10 25 04 AM" src="https://user-images.githubusercontent.com/43251054/58040171-aa9e9900-7ae9-11e9-9d9f-dce868af51c7.png">
