### PR TITLE
1660: no label:hover on file inputs

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -85,7 +85,7 @@ select {
 
 .usa-label:hover {
   +.usa-hint {
-    +.usa-input,
+    +.usa-input:not([type=file]),
     +.usa-textarea,
     +.usa-select,
     +.usa-range {
@@ -95,7 +95,7 @@ select {
       }
     }
   }
-  +.usa-input,
+  +.usa-input:not([type=file]),
   +.usa-textarea,
   +.usa-select,
   +.usa-range {


### PR DESCRIPTION
![Screen Shot 2019-05-22 at 1 37 43 PM](https://user-images.githubusercontent.com/2445917/58200092-93051300-7c97-11e9-9563-b10dfb7c5597.png)

screenshot shows forcing of `:hover` state on label with no border shown on file input itself