### PR TITLE
Don't reset second doc form when category changes

### DIFF
--- a/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.js
+++ b/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.js
@@ -9,6 +9,7 @@ import { state } from 'cerebral';
  */
 export const clearWizardDataAction = ({ store, get, props }) => {
   let pickedDocument;
+  const currentSecondaryFile = get(state.form.supportingDocumentFile);
 
   switch (props.key) {
     case 'category':
@@ -34,7 +35,10 @@ export const clearWizardDataAction = ({ store, get, props }) => {
       break;
     case 'supportingDocument':
       store.set(state.form.supportingDocumentFreeText, null);
-      store.set(state.form.supportingDocumentFile, null);
+      store.set(
+        state.form.supportingDocumentFile,
+        currentSecondaryFile || null,
+      );
 
       break;
     case 'secondaryDocumentFile':

--- a/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.js
+++ b/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.js
@@ -9,7 +9,6 @@ import { state } from 'cerebral';
  */
 export const clearWizardDataAction = ({ store, get, props }) => {
   let pickedDocument;
-  const currentSecondaryFile = get(state.form.supportingDocumentFile);
 
   switch (props.key) {
     case 'category':
@@ -35,10 +34,6 @@ export const clearWizardDataAction = ({ store, get, props }) => {
       break;
     case 'supportingDocument':
       store.set(state.form.supportingDocumentFreeText, null);
-      store.set(
-        state.form.supportingDocumentFile,
-        currentSecondaryFile || null,
-      );
 
       break;
     case 'secondaryDocumentFile':


### PR DESCRIPTION
When adding a supporting document, if you select a document type, then select a file, then change the document type, the file input loses its state causing a bug when trying to submit. This could be the intended behavior - in which case we need to reset the file input completely. Otherwise, this allows the document type to change after a secondary file has been set, and persists that file input state.

<img width="571" alt="Screen Shot 2019-05-22 at 1 27 23 PM" src="https://user-images.githubusercontent.com/1891789/58202684-69e38300-7c95-11e9-8313-a09bfa2e2da9.png">
