### PR TITLE
1614 clear circle docker cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: (Temporary) clear circle's docker cache
+          command: docker images --no-trunc --format '{{.ID}}' | xargs docker rmi
+      - run:
           name: Build Docker Image
-          command: docker build --no-cache -t efcms -f Dockerfile .
+          command: docker build -t efcms -f Dockerfile .
 
       - run:
           name: Shared - Shellcheck
@@ -57,7 +60,7 @@ jobs:
       - checkout
       - run:
           name: Build Docker Image
-          command: docker build --no-cache -t efcms -f Dockerfile .
+          command: docker build -t efcms -f Dockerfile .
 
       - run:
           name: Pa11y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: (Temporary) clear circle's docker cache
-          command: docker images --no-trunc --format '{{.ID}}' | xargs docker rmi
-      - run:
           name: Build Docker Image
           command: docker build -t efcms -f Dockerfile .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM cypress/base:8
 
 WORKDIR /home/app
 
+RUN echo "clearing cache - remove this at some point"
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 


### PR DESCRIPTION
Added this code temporarily to `config.yml` build steps to reset all of circle's docker containers (for future reference): 
```      
      - run:
          name: (Temporary) clear circle's docker cache
          command: docker images --no-trunc --format '{{.ID}}' | xargs docker rmi
```

Found here: https://support.circleci.com/hc/en-us/articles/360007406013-How-can-I-remove-my-cached-docker-layers-