### PR TITLE
1191 start time fields update

### DIFF
--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -1,10 +1,11 @@
 import { state } from 'cerebral';
 
-const computeTerm = ({ form }) => {
-  const selectedMonth = +form.month;
-  let term;
+const computeTerm = ({ month, year }) => {
+  const selectedMonth = +month;
+  let term, termYear;
 
-  if (selectedMonth) {
+  if (selectedMonth && year) {
+    termYear = year;
     const termsByMonth = {
       fall: [9, 10, 11, 12],
       spring: [4, 5, 6],
@@ -20,28 +21,37 @@ const computeTerm = ({ form }) => {
     }
   }
 
-  const termYear = form.year;
   return { term, termYear };
 };
 
-const computeStartTime = ({ form }) => {
-  if (!form.startTimeInput) return undefined;
-  const HOUR_INVALID = '99'; // force time validation error
+const compute24HrTime = ({ hours, minutes, extension }) => {
+  if (!hours && !minutes) return undefined;
+  const TIME_INVALID = '99:99'; // force time validation error
 
-  let [hours, minutes] = form.startTimeInput.split(':');
-  if (form.startTimeExtension == 'pm') {
-    hours = `${+hours + 12}`;
-  } else if (form.startTimeExtension == 'am') {
-    if (+hours > 12) hours = HOUR_INVALID;
-    hours = hours.padStart(2, '0');
-  } else {
-    // neither 'am' nor 'pm' selected
-    hours = HOUR_INVALID;
+  const VALID_HOUR_RE = /^((0?[1-9])|([1][0-2]))$/; // 1-9, 01-09, 10-12
+  const VALID_MINUTE_RE = /^([0-5][0-9])$/; // 00-59
+
+  if (
+    !VALID_HOUR_RE.test(hours) ||
+    !VALID_MINUTE_RE.test(minutes) ||
+    !['am', 'pm'].includes(extension)
+  ) {
+    return TIME_INVALID;
   }
-  minutes = (minutes && minutes.padStart(2, '0')) || '00';
 
-  let computedTime = `${hours}:${minutes}`;
-  return computedTime;
+  if (extension == 'pm') {
+    if (+hours <= 11) {
+      hours = `${+hours + 12}`;
+    }
+  } else if (extension == 'am') {
+    if (+hours == 12) {
+      hours = '00';
+    } else {
+      hours = hours.padStart(2, '0');
+    }
+  }
+
+  return `${hours}:${minutes}`;
 };
 
 /**
@@ -54,10 +64,17 @@ const computeStartTime = ({ form }) => {
 export const computeTrialSessionFormDataAction = ({ get, store }) => {
   const form = get(state.form);
 
-  const { term, termYear } = computeTerm({ form });
+  const { term, termYear } = computeTerm({
+    month: form.month,
+    year: form.year,
+  });
   store.set(state.form.term, term);
   store.set(state.form.termYear, termYear);
 
-  const startTime = computeStartTime({ form });
+  const startTime = compute24HrTime({
+    extension: form.startTimeExtension,
+    hours: form.startTimeHours,
+    minutes: form.startTimeMinutes,
+  });
   store.set(state.form.startTime, startTime);
 };

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
@@ -1,0 +1,143 @@
+import { computeTrialSessionFormDataAction } from './computeTrialSessionFormDataAction';
+import { runAction } from 'cerebral/test';
+
+describe('computeTrialSessionFormDataAction', () => {
+  let form;
+  const TIME_INVALID = '99:99';
+
+  beforeEach(() => {
+    form = {
+      month: '12',
+      startTimeExtension: 'am',
+      startTimeHours: '11',
+      startTimeMinutes: '00',
+      year: '2019',
+    };
+  });
+
+  it('should store term and time when provided valid inputs', async () => {
+    let result;
+
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      startTime: '11:00',
+      term: 'Fall',
+      termYear: '2019',
+    });
+
+    form.month = '5';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      term: 'Spring',
+    });
+
+    form.month = '2';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      term: 'Winter',
+    });
+  });
+
+  it('should store empty term and termYear if month is invalid or year is empty', async () => {
+    let result;
+
+    form.month = 'June';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      term: undefined,
+      termYear: undefined,
+    });
+
+    form.month = '5';
+    form.year = '';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      term: undefined,
+      termYear: undefined,
+    });
+  });
+
+  it('should store an afternoon (pm) startTime in 24hr format', async () => {
+    let result;
+    form.startTimeHours = '6';
+    form.startTimeMinutes = '15';
+    form.startTimeExtension = 'pm';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      startTime: '18:15',
+    });
+  });
+
+  it('should store a morning (am) startTime in 24hr format', async () => {
+    let result;
+    form.startTimeHours = '6';
+    form.startTimeMinutes = '15';
+    form.startTimeExtension = 'am';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      startTime: '06:15',
+    });
+  });
+
+  describe('should store a startTime deliberately created as invalid', () => {
+    it('if hours are invalid', async () => {
+      let result;
+
+      form.startTimeHours = '13';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeHours = '0';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeHours = '24';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeHours = undefined;
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+    });
+    
+    it('if minutes are invalid', () => {
+      form.startTimeMinutes = undefined;
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+    });
+  });
+});

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
@@ -56,6 +56,16 @@ describe('computeTrialSessionFormDataAction', () => {
       termYear: undefined,
     });
 
+    form.month = '7';
+    form.year = '2019';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      term: undefined,
+      termYear: '2019',
+    });
+
     form.month = '5';
     form.year = '';
     result = await runAction(computeTrialSessionFormDataAction, {
@@ -93,11 +103,41 @@ describe('computeTrialSessionFormDataAction', () => {
     });
   });
 
+  it('should store a midnight startTime in 24hr format', async () => {
+    let result;
+    form.startTimeHours = '12';
+    form.startTimeMinutes = '00';
+    form.startTimeExtension = 'am';
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form },
+    });
+    expect(result.state.form).toMatchObject({
+      startTime: '00:00',
+    });
+  });
+
+  it('should not store a time if hours and minutes are not set', async () => {
+    let result;
+    result = await runAction(computeTrialSessionFormDataAction, {
+      state: { form: {} },
+    });
+    expect(result.state.startTime).toBeUndefined();
+  });
+
   describe('should store a startTime deliberately created as invalid', () => {
     it('if hours are invalid', async () => {
       let result;
 
       form.startTimeHours = '13';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeHours = '13';
+      form.startTimeExtension = 'pm';
       result = await runAction(computeTrialSessionFormDataAction, {
         state: { form },
       });
@@ -128,10 +168,56 @@ describe('computeTrialSessionFormDataAction', () => {
       expect(result.state.form).toMatchObject({
         startTime: TIME_INVALID,
       });
+
+      form.startTimeHours = 'abc';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
     });
-    
-    it('if minutes are invalid', () => {
+
+    it('if minutes are invalid', async () => {
+      let result;
+
       form.startTimeMinutes = undefined;
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeMinutes = '61';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeMinutes = 'abc';
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+    });
+
+    it('if extension is invalid', async () => {
+      let result;
+
+      form.startTimeExtension = undefined;
+      result = await runAction(computeTrialSessionFormDataAction, {
+        state: { form },
+      });
+      expect(result.state.form).toMatchObject({
+        startTime: TIME_INVALID,
+      });
+
+      form.startTimeExtension = 'abc';
       result = await runAction(computeTrialSessionFormDataAction, {
         state: { form },
       });

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -974,8 +974,3 @@ nav.usa-nav {
   top: -10px;
   right: -7px;
 }
-
-.radio-container {
-  position: absolute;
-  bottom: 0;
-}

--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -4,6 +4,24 @@
   margin-bottom: 30px;
 }
 
+.ustc-time-of-day {
+  display: flex;
+}
+.ustc-time-of-day--hour,
+.ustc-time-of-day--minute {
+  width: 3em;
+  flex: 0 0 auto;
+  margin-right: 1rem;  
+  margin-bottom: 0;
+}
+.ustc-time-of-day--am-pm {
+  position: absolute;
+  bottom: 0;
+  width: 9em;
+  margin-right: 1rem;  
+  margin-bottom: 0;
+}
+
 .usa-label,
 .usa-legend,
 label,

--- a/web-client/src/views/TrialSessions/SessionInformationForm.jsx
+++ b/web-client/src/views/TrialSessions/SessionInformationForm.jsx
@@ -151,7 +151,7 @@ export const SessionInformationForm = connect(
                       type="number"
                       min="0"
                       max="59"
-                      placeholder="30"
+                      placeholder="00"
                       onChange={e => {
                         updateTrialSessionFormDataSequence({
                           key: e.target.name,

--- a/web-client/src/views/TrialSessions/SessionInformationForm.jsx
+++ b/web-client/src/views/TrialSessions/SessionInformationForm.jsx
@@ -115,32 +115,54 @@ export const SessionInformationForm = connect(
             }`}
           >
             <fieldset className="start-time usa-fieldset margin-bottom-0">
-              <legend id="start-time-legend" className="usa-legend with-hint">
+              <legend id="start-time-legend" className="usa-legend">
                 Time <span className="usa-hint">(optional)</span>
               </legend>
-              <span className="usa-hint">
-                Enter time as hour : minutes (e.g. 10:30)
-              </span>
-              <div className="grid-row grid-gap-3">
-                <div className="grid-col-3">
-                  <input
-                    className="usa-input usa-input-inline usa-input--medium"
-                    id="start-time"
-                    aria-label="time"
-                    aria-describedby="start-time-legend"
-                    name="startTimeInput"
-                    value={form.startTimeInput || ''}
-                    type="text"
-                    onChange={e => {
-                      updateTrialSessionFormDataSequence({
-                        key: e.target.name,
-                        value: e.target.value,
-                      });
-                    }}
-                  />
+              <div className="grid-row grid-gap-6">
+                <div className="grid-col-3 ustc-time-of-day">
+                  <div className="usa-form-group ustc-time-of-day--hour">
+                    <input
+                      className="usa-input usa-input-inline"
+                      id="start-time-hours"
+                      aria-label="hour"
+                      aria-describedby="start-time-legend"
+                      name="startTimeHours"
+                      value={form.startTimeHours || ''}
+                      type="number"
+                      min="1"
+                      max="12"
+                      placeholder="10"
+                      onChange={e => {
+                        updateTrialSessionFormDataSequence({
+                          key: e.target.name,
+                          value: e.target.value,
+                        });
+                      }}
+                    />
+                  </div>
+                  <div className="usa-form-group ustc-time-of-day--minute">
+                    <input
+                      className="usa-input usa-input-inline"
+                      id="start-time-minutes"
+                      aria-label="minutes"
+                      aria-describedby="start-time-legend"
+                      name="startTimeMinutes"
+                      value={form.startTimeMinutes || ''}
+                      type="number"
+                      min="0"
+                      max="59"
+                      placeholder="30"
+                      onChange={e => {
+                        updateTrialSessionFormDataSequence({
+                          key: e.target.name,
+                          value: e.target.value,
+                        });
+                      }}
+                    />
+                  </div>
                 </div>
-                <div className="grid-col-9">
-                  <div className="radio-container">
+                <div className="grid-col-6 ustc-time-of-day">
+                  <div className="ustc-time-of-day--am-pm">
                     {['am', 'pm'].map(option => (
                       <div className="usa-radio usa-radio__inline" key={option}>
                         <input


### PR DESCRIPTION
![Screen Shot 2019-06-11 at 1 21 03 PM](https://user-images.githubusercontent.com/2445917/59296523-ca8a2e00-8c4b-11e9-9bea-9d068940fecb.png)

The approach taken within shows how we are taking inputs from three fields in the view to compose a single field stored on the business entity and in the database.  This does result in entity-validation sort of occurring on two different layers and I look forward to feedback on this.