### PR TITLE
1192: computed to format trial session details

### DIFF
--- a/efcms-service/storage/fixtures/seed/trial-sessions.json
+++ b/efcms-service/storage/fixtures/seed/trial-sessions.json
@@ -13,7 +13,9 @@
     "swingSession": true,
     "swingSessionId": "208a959f-9526-4db5-b262-e58c476a4604",
     "trialLocation": "Houston, Texas",
-    "trialSessionId": "959c4338-0fac-42eb-b0eb-d53b8d0195cc"
+    "trialSessionId": "959c4338-0fac-42eb-b0eb-d53b8d0195cc",
+    "isCalendared": false,
+    "status": "Upcoming"
   },
   {
     "pk": "trial-session-208a959f-9526-4db5-b262-e58c476a4604",
@@ -29,7 +31,9 @@
     "swingSession": true,
     "swingSessionId": "959c4338-0fac-42eb-b0eb-d53b8d0195cc",
     "trialLocation": "Austin, Texas",
-    "trialSessionId": "208a959f-9526-4db5-b262-e58c476a4604"
+    "trialSessionId": "208a959f-9526-4db5-b262-e58c476a4604",
+    "isCalendared": false,
+    "status": "Upcoming"
   },
   {
     "pk": "trial-session-f3b04943-8ea8-422b-8990-dec3ca644c83",
@@ -43,7 +47,9 @@
     "term": "Fall",
     "termYear": "2019",
     "trialLocation": "Seattle, Washington",
-    "trialSessionId": "f3b04943-8ea8-422b-8990-dec3ca644c83"
+    "trialSessionId": "f3b04943-8ea8-422b-8990-dec3ca644c83",
+    "isCalendared": false,
+    "status": "Upcoming"
   },
   {
     "pk": "trial-session-5b18af9e-4fbd-459b-8db7-7b15108c7fa5",
@@ -57,7 +63,9 @@
     "term": "Fall",
     "termYear": "2019",
     "trialLocation": "Las Vegas, Nevada",
-    "trialSessionId": "5b18af9e-4fbd-459b-8db7-7b15108c7fa5"
+    "trialSessionId": "5b18af9e-4fbd-459b-8db7-7b15108c7fa5",
+    "isCalendared": false,
+    "status": "Upcoming"
   },
   {
     "pk": "trial-session-6b6975cf-2b10-4e84-bcae-91e162d2f9d1",
@@ -71,7 +79,9 @@
     "term": "Fall",
     "termYear": "2019",
     "trialLocation": "Kansas City, Kansas",
-    "trialSessionId": "6b6975cf-2b10-4e84-bcae-91e162d2f9d1"
+    "trialSessionId": "6b6975cf-2b10-4e84-bcae-91e162d2f9d1",
+    "isCalendared": false,
+    "status": "Upcoming"
   },
   {
     "pk": "trial-session-9c943468-bc2e-4631-84e3-b084cf5b1faa",
@@ -85,7 +95,9 @@
     "term": "Fall",
     "termYear": "2019",
     "trialLocation": "Denver, Colorado",
-    "trialSessionId": "9c943468-bc2e-4631-84e3-b084cf5b1faa"
+    "trialSessionId": "9c943468-bc2e-4631-84e3-b084cf5b1faa",
+    "isCalendared": false,
+    "status": "Upcoming"
   },
   {
     "pk": "trial-session-149159ca-f4a1-4b2b-bc24-bd1fbe6defdc",
@@ -99,6 +111,8 @@
     "term": "Fall",
     "termYear": "2019",
     "trialLocation": "Birmingham, Alabama",
-    "trialSessionId": "149159ca-f4a1-4b2b-bc24-bd1fbe6defdc"
+    "trialSessionId": "149159ca-f4a1-4b2b-bc24-bd1fbe6defdc",
+    "isCalendared": false,
+    "status": "Upcoming"
   }
 ]

--- a/shared/src/business/entities/TrialSession.js
+++ b/shared/src/business/entities/TrialSession.js
@@ -17,8 +17,8 @@ const SESSION_TYPES = [
 ];
 
 const STATUS_TYPES = {
-  calendared: 'calendared',
-  new: 'new',
+  closed: 'Closed',
+  upcoming: 'Upcoming',
 };
 
 exports.STATUS_TYPES = STATUS_TYPES;
@@ -38,6 +38,7 @@ function TrialSession(rawSession) {
     courthouseName: rawSession.courthouseName,
     createdAt: rawSession.createdAt || new Date().toISOString(),
     irsCalendarAdministrator: rawSession.irsCalendarAdministrator,
+    isCalendared: rawSession.isCalendared || false,
     judge: rawSession.judge,
     maxCases: rawSession.maxCases,
     notes: rawSession.notes,
@@ -46,7 +47,7 @@ function TrialSession(rawSession) {
     startDate: rawSession.startDate,
     startTime: rawSession.startTime || '10:00',
     state: rawSession.state,
-    status: rawSession.status || STATUS_TYPES.new,
+    status: rawSession.status || STATUS_TYPES.upcoming,
     swingSession: rawSession.swingSession,
     swingSessionId: rawSession.swingSessionId,
     term: rawSession.term,
@@ -98,6 +99,7 @@ joiValidationDecorator(
       .iso()
       .optional(),
     irsCalendarAdministrator: joi.string().optional(),
+    isCalendared: joi.boolean().required(),
     judge: joi.string().optional(),
     maxCases: joi
       .number()
@@ -185,7 +187,7 @@ TrialSession.prototype.generateSortKeyPrefix = function() {
  * @returns {TrialSession}
  */
 TrialSession.prototype.setAsCalendared = function() {
-  this.status = STATUS_TYPES.calendared;
+  this.isCalendared = true;
   return this;
 };
 

--- a/shared/src/business/entities/TrialSession.test.js
+++ b/shared/src/business/entities/TrialSession.test.js
@@ -1,4 +1,4 @@
-const { TrialSession, STATUS_TYPES } = require('./TrialSession');
+const { TrialSession } = require('./TrialSession');
 
 const VALID_TRIAL_SESSION = {
   maxCases: 100,
@@ -90,7 +90,7 @@ describe('TrialSession entity', () => {
         sessionType: 'Hybrid',
       });
       trialSession.setAsCalendared();
-      expect(trialSession.status).toEqual(STATUS_TYPES.calendared);
+      expect(trialSession.isCalendared).toEqual(true);
     });
   });
 

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
@@ -1,0 +1,37 @@
+import { compact } from 'lodash';
+import { state } from 'cerebral';
+
+export const formattedTrialSessionDetails = (get, applicationContext) => {
+  const result = get(state.trialSession);
+
+  result.formattedTerm = `${result.term} ${result.termYear.substr(-2)}`;
+
+  result.formattedStartDate = applicationContext
+    .getUtilities()
+    .formatDateString(result.startDate, 'MMDDYY');
+
+  let [hour, min] = result.startTime.split(':');
+  let startTimeExtension = 'am';
+
+  if (+hour > 12) {
+    startTimeExtension = 'pm';
+    hour = +hour - 12;
+  }
+  result.formattedStartTime = `${hour}:${min} ${startTimeExtension}`;
+  result.formattedJudge = result.judge || 'Not assigned';
+  result.formattedTrialClerk = result.trialClerk || 'Not assigned';
+  result.formattedCourtReporter = result.courtReporter || 'Not assigned';
+  result.formattedIrsCalendarAdministrator =
+    result.irsCalendarAdministrator || 'Not assigned';
+
+  result.formattedCity = undefined;
+  if (result.city) result.formattedCity = `${result.city},`;
+
+  result.formattedCityStateZip = compact([
+    result.formattedCity,
+    result.state,
+    result.postalCode,
+  ]).join(' ');
+
+  return result;
+};

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
@@ -1,0 +1,119 @@
+import { formattedTrialSessionDetails as formattedTrialSessionDetailsComputed } from './formattedTrialSessionDetails';
+import { omit } from 'lodash';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../withAppContext';
+
+const formattedTrialSessionDetails = withAppContextDecorator(
+  formattedTrialSessionDetailsComputed,
+);
+
+describe('formattedTrialSessionDetails', () => {
+  const TRIAL_SESSION = {
+    city: 'Hartford',
+    courtReporter: 'Test Court Reporter',
+    irsCalendarAdministrator: 'Test Calendar Admin',
+    judge: 'Test Judge',
+    postalCode: '12345',
+    startDate: '2019-11-25T15:00:00.000Z',
+    startTime: '10:00',
+    state: 'CT',
+    term: 'Fall',
+    termYear: '2019',
+    trialClerk: 'Test Trial Clerk',
+    trialLocation: 'Hartford, Connecticut',
+  };
+
+  it('formats trial session when all fields have values', async () => {
+    const result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: TRIAL_SESSION,
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCityStateZip: 'Hartford, CT 12345',
+      formattedCourtReporter: 'Test Court Reporter',
+      formattedIrsCalendarAdministrator: 'Test Calendar Admin',
+      formattedJudge: 'Test Judge',
+      formattedStartTime: '10:00 am',
+      formattedTerm: 'Fall 19',
+      formattedTrialClerk: 'Test Trial Clerk',
+    });
+  });
+
+  it('formats trial session when address fields are empty', async () => {
+    let result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: omit(TRIAL_SESSION, ['city', 'state', 'postalCode']),
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCityStateZip: '',
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: omit(TRIAL_SESSION, ['city']),
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCityStateZip: 'CT 12345',
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: omit(TRIAL_SESSION, ['state']),
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCityStateZip: 'Hartford, 12345',
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: omit(TRIAL_SESSION, ['state']),
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCityStateZip: 'Hartford, 12345',
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: omit(TRIAL_SESSION, ['postalCode']),
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCityStateZip: 'Hartford, CT',
+    });
+  });
+
+  it('formats trial session when session assignments are empty', async () => {
+    let result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: omit(TRIAL_SESSION, [
+          'courtReporter',
+          'irsCalendarAdministrator',
+          'judge',
+          'trialClerk',
+        ]),
+      },
+    });
+    expect(result).toMatchObject({
+      formattedCourtReporter: 'Not assigned',
+      formattedIrsCalendarAdministrator: 'Not assigned',
+      formattedJudge: 'Not assigned',
+      formattedTrialClerk: 'Not assigned',
+    });
+  });
+
+  it('formats trial session start time', async () => {
+    let result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: { ...TRIAL_SESSION, startTime: '14:00' },
+      },
+    });
+    expect(result).toMatchObject({
+      formattedStartTime: '2:00 pm',
+    });
+  });
+});

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -19,6 +19,7 @@ import { extractedDocument } from './computeds/extractDocument';
 import { extractedPendingMessagesFromCaseDetail } from './computeds/extractPendingMessagesFromCaseDetail';
 import { fileDocumentHelper } from './computeds/fileDocumentHelper';
 import { fileUploadStatusHelper } from './computeds/fileUploadStatusHelper';
+import { formattedTrialSessionDetails } from './computeds/formattedTrialSessionDetails';
 import { formattedTrialSessions } from './computeds/formattedTrialSessions';
 import { formattedWorkQueue } from './computeds/formattedWorkQueue';
 import { getTrialCityName } from './computeds/formattedTrialCity';
@@ -74,6 +75,7 @@ export const state = {
   form: {},
   formattedCaseDetail,
   formattedCases,
+  formattedTrialSessionDetails,
   formattedTrialSessions,
   formattedWorkQueue,
   getTrialCityName,

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
@@ -11,24 +11,29 @@ import React from 'react';
 
 export const TrialSessionDetail = connect(
   {
+    formattedTrialSession: state.formattedTrialSessionDetails,
     openSetCalendarModalSequence: sequences.openSetCalendarModalSequence,
     showModal: state.showModal,
-    trialSession: state.trialSession,
   },
-  ({ showModal, openSetCalendarModalSequence, trialSession }) => (
+  ({ showModal, openSetCalendarModalSequence, formattedTrialSession }) => (
     <>
       <div className="big-blue-header">
         <div className="grid-container">
           <div className="margin-bottom-1">
-            <h1 tabIndex="-1">{trialSession.trialLocation}</h1>
-            <span className="usa-tag ustc-tag--yellow">
+            <h1 tabIndex="-1">{formattedTrialSession.trialLocation}</h1>
+            <span
+              className={`usa-tag ${
+                !formattedTrialSession.isCalendared ? 'ustc-tag--yellow' : ''
+              }`}
+            >
               <span aria-hidden="true">
-                {trialSession.term} {trialSession.termYear}: Upcoming
+                {formattedTrialSession.formattedTerm}:{' '}
+                {formattedTrialSession.status}
               </span>
             </span>
           </div>
           <p id="case-title" className="margin-y-0">
-            <span>{trialSession.startDate}</span>
+            <span>{formattedTrialSession.formattedStartDate}</span>
           </p>
         </div>
       </div>

--- a/web-client/src/views/TrialSessionDetail/TrialSessionInformation.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionInformation.jsx
@@ -3,8 +3,8 @@ import { state } from 'cerebral';
 import React from 'react';
 
 export const TrialSessionInformation = connect(
-  { trialSession: state.trialSession },
-  ({ trialSession }) => {
+  { formattedTrialSession: state.formattedTrialSessionDetails },
+  ({ formattedTrialSession }) => {
     return (
       <>
         <h1>Session Information</h1>
@@ -19,13 +19,11 @@ export const TrialSessionInformation = connect(
                       <div className="grid-row grid-gap">
                         <div className="grid-col-6">
                           <p className="label">Term</p>
-                          <p>
-                            {trialSession.term} {trialSession.termYear}
-                          </p>
+                          <p>{formattedTrialSession.formattedTerm}</p>
                         </div>
                         <div className="grid-col-6">
                           <p className="label">Type</p>
-                          <p>{trialSession.sessionType}</p>
+                          <p>{formattedTrialSession.sessionType}</p>
                         </div>
                       </div>
 
@@ -33,12 +31,13 @@ export const TrialSessionInformation = connect(
                         <div className="grid-col-6">
                           <p className="label">Date</p>
                           <p>
-                            {trialSession.startDate} {trialSession.startTime}
+                            {formattedTrialSession.formattedStartDate}{' '}
+                            {formattedTrialSession.formattedStartTime}
                           </p>
                         </div>
                         <div className="grid-col-6">
                           <p className="label">Max # of Cases</p>
-                          <p>{trialSession.maxCases}</p>
+                          <p>{formattedTrialSession.maxCases}</p>
                         </div>
                       </div>
                     </div>
@@ -53,22 +52,26 @@ export const TrialSessionInformation = connect(
                       <div className="grid-row grid-gap">
                         <div className="grid-col-6">
                           <p className="label">Judge</p>
-                          <p>{trialSession.judge}</p>
+                          <p>{formattedTrialSession.formattedJudge}</p>
                         </div>
                         <div className="grid-col-6">
                           <p className="label">Trial Clerk</p>
-                          <p>{trialSession.trialClerk}</p>
+                          <p>{formattedTrialSession.formattedTrialClerk}</p>
                         </div>
                       </div>
 
                       <div className="grid-row grid-gap">
                         <div className="grid-col-6">
                           <p className="label">Court Report</p>
-                          <p>{trialSession.courtReporter}</p>
+                          <p>{formattedTrialSession.formattedCourtReporter}</p>
                         </div>
                         <div className="grid-col-6">
                           <p className="label">IRS Calendar Administrator</p>
-                          <p>{trialSession.irsCalendarAdministrator}</p>
+                          <p>
+                            {
+                              formattedTrialSession.formattedIrsCalendarAdministrator
+                            }
+                          </p>
                         </div>
                       </div>
                     </div>
@@ -82,17 +85,16 @@ export const TrialSessionInformation = connect(
                   <div className="content-wrapper">
                     <h3 className="underlined">Location</h3>
                     <p className="label">Location</p>
-                    <p>{trialSession.courthouseName}</p>
+                    <p>{formattedTrialSession.courthouseName}</p>
                     <p>
                       <span className="address-line">
-                        {trialSession.address1}
+                        {formattedTrialSession.address1}
                       </span>
                       <span className="address-line">
-                        {trialSession.address2}
+                        {formattedTrialSession.address2}
                       </span>
                       <span className="address-line">
-                        {trialSession.city}, {trialSession.state}{' '}
-                        {trialSession.postalCode}
+                        {formattedTrialSession.formattedCityStateZip}
                       </span>
                     </p>
                   </div>
@@ -102,7 +104,7 @@ export const TrialSessionInformation = connect(
                 <div className="card height-full">
                   <div className="content-wrapper">
                     <h3 className="underlined">Notes</h3>
-                    {trialSession.notes}
+                    {formattedTrialSession.notes}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
The trial session data currently on dev will have to be wiped after this is merged due to entity validation changing. I'll take care of that after merge. 
<img width="1134" alt="Screen Shot 2019-06-13 at 2 49 21 PM" src="https://user-images.githubusercontent.com/43251054/59469767-9c8f2000-8dea-11e9-9d24-983aa58a92b0.png">
