### PR TITLE
1192: UI fixes and updates

### DIFF
--- a/shared/src/business/entities/TrialSession.js
+++ b/shared/src/business/entities/TrialSession.js
@@ -106,7 +106,10 @@ joiValidationDecorator(
       .greater(0)
       .integer()
       .required(),
-    notes: joi.string().optional(),
+    notes: joi
+      .string()
+      .max(400)
+      .optional(),
     postalCode: joi
       .string()
       .regex(/^\d{5}(-\d{4})?$/)

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionDetailsAction.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionDetailsAction.js
@@ -18,5 +18,16 @@ export const getTrialSessionDetailsAction = async ({
       trialSessionId,
     });
 
+  if (trialSession.swingSession && trialSession.swingSessionId) {
+    const swingSession = await applicationContext
+      .getUseCases()
+      .getTrialSessionDetails({
+        applicationContext,
+        trialSessionId: trialSession.swingSessionId,
+      });
+
+    trialSession.swingSessionLocation = swingSession.trialLocation;
+  }
+
   return { trialSession };
 };

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionDetailsAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionDetailsAction.test.js
@@ -7,10 +7,6 @@ let getTrialSessionDetailsStub;
 
 describe('getTrialSessionDetailsAction', () => {
   beforeEach(() => {
-    getTrialSessionDetailsStub = sinon.stub().resolves({
-      trialSessionId: '123',
-    });
-
     presenter.providers.applicationContext = {
       getUseCases: () => ({
         getTrialSessionDetails: getTrialSessionDetailsStub,
@@ -18,7 +14,11 @@ describe('getTrialSessionDetailsAction', () => {
     };
   });
 
-  it('call the use case to get the eligible cases', async () => {
+  it('call the use case to get the trial details', async () => {
+    getTrialSessionDetailsStub = sinon.stub().resolves({
+      trialSessionId: '123',
+    });
+
     await runAction(getTrialSessionDetailsAction, {
       modules: {
         presenter,
@@ -29,5 +29,33 @@ describe('getTrialSessionDetailsAction', () => {
       state: {},
     });
     expect(getTrialSessionDetailsStub.calledOnce).toEqual(true);
+    expect(
+      getTrialSessionDetailsStub.getCall(0).args[0].trialSessionId,
+    ).toEqual('123');
+  });
+
+  it('call the use case a second time if the trial session is a swing session', async () => {
+    getTrialSessionDetailsStub = sinon.stub().resolves({
+      swingSession: true,
+      swingSessionId: '234',
+      trialSessionId: '123',
+    });
+
+    await runAction(getTrialSessionDetailsAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        trialSessionId: '123',
+      },
+      state: {},
+    });
+    expect(getTrialSessionDetailsStub.calledTwice).toEqual(true);
+    expect(
+      getTrialSessionDetailsStub.getCall(0).args[0].trialSessionId,
+    ).toEqual('123');
+    expect(
+      getTrialSessionDetailsStub.getCall(1).args[0].trialSessionId,
+    ).toEqual('234');
   });
 });

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
@@ -33,5 +33,21 @@ export const formattedTrialSessionDetails = (get, applicationContext) => {
     result.postalCode,
   ]).join(' ');
 
+  result.noLocationEntered =
+    !result.courthouseName &&
+    !result.address1 &&
+    !result.address2 &&
+    !result.formattedCityStateZip;
+
+  result.showSwingSession =
+    !!result.swingSession &&
+    !!result.swingSessionId &&
+    !!result.swingSessionLocation;
+
+  result.showEligibleCases =
+    result.sessionType !== 'Motion/Hearing' &&
+    result.sessionType !== 'Special' &&
+    !result.isCalendared;
+
   return result;
 };

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
@@ -37,6 +37,8 @@ describe('formattedTrialSessionDetails', () => {
       formattedStartTime: '10:00 am',
       formattedTerm: 'Fall 19',
       formattedTrialClerk: 'Test Trial Clerk',
+      noLocationEntered: false,
+      showSwingSession: false,
     });
   });
 
@@ -48,6 +50,7 @@ describe('formattedTrialSessionDetails', () => {
     });
     expect(result).toMatchObject({
       formattedCityStateZip: '',
+      noLocationEntered: true,
     });
 
     result = await runCompute(formattedTrialSessionDetails, {
@@ -57,6 +60,7 @@ describe('formattedTrialSessionDetails', () => {
     });
     expect(result).toMatchObject({
       formattedCityStateZip: 'CT 12345',
+      noLocationEntered: false,
     });
 
     result = await runCompute(formattedTrialSessionDetails, {
@@ -66,6 +70,7 @@ describe('formattedTrialSessionDetails', () => {
     });
     expect(result).toMatchObject({
       formattedCityStateZip: 'Hartford, 12345',
+      noLocationEntered: false,
     });
 
     result = await runCompute(formattedTrialSessionDetails, {
@@ -75,6 +80,7 @@ describe('formattedTrialSessionDetails', () => {
     });
     expect(result).toMatchObject({
       formattedCityStateZip: 'Hartford, 12345',
+      noLocationEntered: false,
     });
 
     result = await runCompute(formattedTrialSessionDetails, {
@@ -84,6 +90,7 @@ describe('formattedTrialSessionDetails', () => {
     });
     expect(result).toMatchObject({
       formattedCityStateZip: 'Hartford, CT',
+      noLocationEntered: false,
     });
   });
 
@@ -114,6 +121,104 @@ describe('formattedTrialSessionDetails', () => {
     });
     expect(result).toMatchObject({
       formattedStartTime: '2:00 pm',
+    });
+  });
+
+  it('displays swing session area if session is a swing session', async () => {
+    let result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          swingSession: true,
+          swingSessionId: '1234',
+          swingSessionLocation: 'Honolulu, Hawaii',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showSwingSession: true,
+    });
+  });
+
+  it('displays eliglble cases table and set calendar button for Regular, Small, and Hybrid sessions that are not yet calendared', async () => {
+    let result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          isCalendared: false,
+          sessionType: 'Regular',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showEligibleCases: true,
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          isCalendared: false,
+          sessionType: 'Small',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showEligibleCases: true,
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          isCalendared: false,
+          sessionType: 'Hybrid',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showEligibleCases: true,
+    });
+  });
+
+  it('does not display eliglble cases table if session type is Motion/Hearing or Special, or session is calendared', async () => {
+    let result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          isCalendared: false,
+          sessionType: 'Motion/Hearing',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showEligibleCases: false,
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          isCalendared: false,
+          sessionType: 'Special',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showEligibleCases: false,
+    });
+
+    result = await runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          isCalendared: true,
+          sessionType: 'Hybrid',
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      showEligibleCases: false,
     });
   });
 });

--- a/web-client/src/styles/cards.scss
+++ b/web-client/src/styles/cards.scss
@@ -70,6 +70,10 @@
       }
     }
   }
+
+  &.trial-session-card {
+    height: 230px;
+  }
 }
 
 .petitions-details,

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
@@ -44,7 +44,7 @@ export const TrialSessionDetail = connect(
 
         <TrialSessionInformation />
 
-        {!formattedTrialSession.isCalendared && (
+        {formattedTrialSession.showEligibleCases && (
           <Tabs
             defaultActiveTab="EligibleCases"
             bind="trialsessiondetails.caseList"

--- a/web-client/src/views/TrialSessionDetail/TrialSessionInformation.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionInformation.jsx
@@ -32,7 +32,7 @@ export const TrialSessionInformation = connect(
                           <p className="label">Date</p>
                           <p
                             className={
-                              !formattedTrialSession.showSwingSession &&
+                              formattedTrialSession.showSwingSession ||
                               'margin-bottom-0'
                             }
                           >
@@ -44,7 +44,7 @@ export const TrialSessionInformation = connect(
                           <p className="label">Max # of Cases</p>
                           <p
                             className={
-                              !formattedTrialSession.showSwingSession &&
+                              formattedTrialSession.showSwingSession ||
                               'margin-bottom-0'
                             }
                           >
@@ -115,8 +115,7 @@ export const TrialSessionInformation = connect(
               <div className="grid-col-6">
                 <div className="card trial-session-card">
                   <div className="content-wrapper">
-                    <h3 className="underlined">Location</h3>
-                    <p className="label">Location</p>
+                    <h3 className="underlined">Courthouse Location</h3>
                     {formattedTrialSession.noLocationEntered && (
                       <p>No location entered</p>
                     )}

--- a/web-client/src/views/TrialSessionDetail/TrialSessionInformation.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionInformation.jsx
@@ -8,11 +8,11 @@ export const TrialSessionInformation = connect(
     return (
       <>
         <h1>Session Information</h1>
-        <div className="trial-session-details margin-bottom-6">
+        <div className="trial-session-details margin-bottom-4">
           <div className="grid-container padding-x-0">
-            <div className="grid-row grid-gap margin-bottom-4">
+            <div className="grid-row grid-gap margin-bottom-2">
               <div className="grid-col-6">
-                <div className="card height-full">
+                <div className="card">
                   <div className="content-wrapper">
                     <h3 className="underlined">Details</h3>
                     <div className="grid-container padding-x-0">
@@ -30,22 +30,49 @@ export const TrialSessionInformation = connect(
                       <div className="grid-row grid-gap">
                         <div className="grid-col-6">
                           <p className="label">Date</p>
-                          <p>
+                          <p
+                            className={
+                              !formattedTrialSession.showSwingSession &&
+                              'margin-bottom-0'
+                            }
+                          >
                             {formattedTrialSession.formattedStartDate}{' '}
                             {formattedTrialSession.formattedStartTime}
                           </p>
                         </div>
                         <div className="grid-col-6">
                           <p className="label">Max # of Cases</p>
-                          <p>{formattedTrialSession.maxCases}</p>
+                          <p
+                            className={
+                              !formattedTrialSession.showSwingSession &&
+                              'margin-bottom-0'
+                            }
+                          >
+                            {formattedTrialSession.maxCases}
+                          </p>
                         </div>
                       </div>
+
+                      {formattedTrialSession.showSwingSession && (
+                        <div className="grid-row grid-gap">
+                          <div className="grid-col-6">
+                            <p className="label">Swing Session</p>
+                            <p className="margin-bottom-0">
+                              <a
+                                href={`/trial-session-detail/${formattedTrialSession.swingSessionId}`}
+                              >
+                                {formattedTrialSession.swingSessionLocation}
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>
               </div>
               <div className="grid-col-6">
-                <div className="card height-full">
+                <div className="card">
                   <div className="content-wrapper">
                     <h3 className="underlined">Assignments</h3>
                     <div className="grid-container padding-x-0">
@@ -60,14 +87,19 @@ export const TrialSessionInformation = connect(
                         </div>
                       </div>
 
-                      <div className="grid-row grid-gap">
+                      <div
+                        className={`grid-row grid-gap ${formattedTrialSession.showSwingSession &&
+                          'margin-bottom-8'}`}
+                      >
                         <div className="grid-col-6">
-                          <p className="label">Court Report</p>
-                          <p>{formattedTrialSession.formattedCourtReporter}</p>
+                          <p className="label">Court Reporter</p>
+                          <p className="margin-bottom-0">
+                            {formattedTrialSession.formattedCourtReporter}
+                          </p>
                         </div>
                         <div className="grid-col-6">
                           <p className="label">IRS Calendar Administrator</p>
-                          <p>
+                          <p className="margin-bottom-0">
                             {
                               formattedTrialSession.formattedIrsCalendarAdministrator
                             }
@@ -81,10 +113,13 @@ export const TrialSessionInformation = connect(
             </div>
             <div className="grid-row grid-gap">
               <div className="grid-col-6">
-                <div className="card height-full">
+                <div className="card trial-session-card">
                   <div className="content-wrapper">
                     <h3 className="underlined">Location</h3>
                     <p className="label">Location</p>
+                    {formattedTrialSession.noLocationEntered && (
+                      <p>No location entered</p>
+                    )}
                     <p>{formattedTrialSession.courthouseName}</p>
                     <p>
                       <span className="address-line">
@@ -101,7 +136,7 @@ export const TrialSessionInformation = connect(
                 </div>
               </div>
               <div className="grid-col-6">
-                <div className="card height-full">
+                <div className="card trial-session-card">
                   <div className="content-wrapper">
                     <h3 className="underlined">Notes</h3>
                     {formattedTrialSession.notes}

--- a/web-client/src/views/TrialSessions/AddTrialSession.jsx
+++ b/web-client/src/views/TrialSessions/AddTrialSession.jsx
@@ -63,6 +63,7 @@ export const AddTrialSession = connect(
                   id="notes"
                   name="notes"
                   value={form.notes}
+                  maxLength="400"
                   onChange={e => {
                     updateTrialSessionFormDataSequence({
                       key: e.target.name,


### PR DESCRIPTION
* Set max string length for notes field to 400
* Add swing session info to detail page
* Display "No location entered" if location is empty
* Styling fixes on detail page

<img width="1264" alt="Screen Shot 2019-06-14 at 9 34 00 AM" src="https://user-images.githubusercontent.com/43251054/59524014-a31fa500-8e87-11e9-9c4f-05f7b5619a04.png">