### PR TITLE
Main header responsive styling fix

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -678,7 +678,7 @@ nav.usa-nav {
   .user-dropdown {
     position: relative;
     top: -4px;
-    margin: -4px 0 0 50px;
+    margin: -4px 0 0 30px;
   }
 
   .button-account-login {

--- a/web-client/src/views/Header.jsx
+++ b/web-client/src/views/Header.jsx
@@ -184,7 +184,7 @@ export const Header = connect(
                   />
                 </button>
                 <div className="header-search-container">
-                  <ul className="usa-unstyled-list">
+                  <ul className="usa-unstyled-list padding-left-0">
                     {helper.showSearchInHeader && (
                       <li role="search" className="usa-search">
                         <SearchBox />


### PR DESCRIPTION
At the smallest screen size before the mobile breakpoint: 

<img width="1022" alt="Screen Shot 2019-06-14 at 9 23 40 AM" src="https://user-images.githubusercontent.com/43251054/59523482-4cfe3200-8e86-11e9-8ef8-29b6c169df49.png">
