### PR TITLE
1192: E2E Scenario 6

### DIFF
--- a/web-client/e2e/journey/taxpayerCreatesNewCase.js
+++ b/web-client/e2e/journey/taxpayerCreatesNewCase.js
@@ -5,7 +5,7 @@ const {
 
 import { startCaseHelper } from '../../src/presenter/computeds/startCaseHelper';
 
-export default (test, fakeFile, overrides) => {
+export default (test, fakeFile, overrides = {}) => {
   return it('Taxpayer creates a new case', async () => {
     await test.runSequence('updatePetitionValueSequence', {
       key: 'petitionFile',

--- a/web-client/e2e/journey/taxpayerCreatesNewCase.js
+++ b/web-client/e2e/journey/taxpayerCreatesNewCase.js
@@ -5,7 +5,7 @@ const {
 
 import { startCaseHelper } from '../../src/presenter/computeds/startCaseHelper';
 
-export default (test, fakeFile) => {
+export default (test, fakeFile, overrides) => {
   return it('Taxpayer creates a new case', async () => {
     await test.runSequence('updatePetitionValueSequence', {
       key: 'petitionFile',
@@ -750,7 +750,7 @@ export default (test, fakeFile) => {
 
     await test.runSequence('updateFormValueSequence', {
       key: 'caseType',
-      value: 'Whistleblower',
+      value: overrides.caseType || 'Whistleblower',
     });
 
     await test.runSequence('updateFormValueSequence', {

--- a/web-client/e2e/trialSessionEligibleCasesScenario6.test.js
+++ b/web-client/e2e/trialSessionEligibleCasesScenario6.test.js
@@ -1,0 +1,270 @@
+import { CerebralTest } from 'cerebral/test';
+import { isFunction, mapValues } from 'lodash';
+import FormData from 'form-data';
+
+import {
+  CASE_CAPTION_POSTFIX,
+  STATUS_TYPES,
+} from '../../shared/src/business/entities/Case';
+import {
+  CATEGORIES,
+  CATEGORY_MAP,
+  INTERNAL_CATEGORY_MAP,
+} from '../../shared/src/business/entities/Document';
+import { Document } from '../../shared/src/business/entities/Document';
+import { TRIAL_CITIES } from '../../shared/src/business/entities/TrialCities';
+
+import { applicationContext } from '../src/applicationContext';
+import { presenter } from '../src/presenter/presenter';
+import { withAppContextDecorator } from '../src/withAppContext';
+
+import captureCreatedCase from './journey/captureCreatedCase';
+import docketClerkCreatesATrialSession from './journey/docketClerkCreatesATrialSession';
+import docketClerkLogIn from './journey/docketClerkLogIn';
+import docketClerkViewsAnUpcomingTrialSession from './journey/docketClerkViewsAnUpcomingTrialSession';
+import docketClerkViewsTrialSessionList from './journey/docketClerkViewsTrialSessionList';
+import petitionsClerkLogIn from './journey/petitionsClerkLogIn';
+import petitionsClerkRunsBatchProcess from './journey/petitionsClerkRunsBatchProcess';
+import petitionsClerkSendsCaseToIRSHoldingQueue from './journey/petitionsClerkSendsCaseToIRSHoldingQueue';
+import petitionsClerkSetsATrialSessionsSchedule from './journey/petitionsClerkSetsATrialSessionsSchedule';
+import petitionsClerkSetsCaseReadyForTrial from './journey/petitionsClerkSetsCaseReadyForTrial';
+import petitionsClerkUpdatesFiledBy from './journey/petitionsClerkUpdatesFiledBy';
+import taxpayerChoosesCaseType from './journey/taxpayerChoosesCaseType';
+import taxpayerChoosesProcedureType from './journey/taxpayerChoosesProcedureType';
+import taxpayerCreatesNewCase from './journey/taxpayerCreatesNewCase';
+import taxpayerLogin from './journey/taxpayerLogIn';
+import taxpayerNavigatesToCreateCase from './journey/taxpayerCancelsCreateCase';
+import taxpayerViewsDashboard from './journey/taxpayerViewsDashboard';
+import userSignsOut from './journey/taxpayerSignsOut';
+
+const {
+  PARTY_TYPES,
+  COUNTRY_TYPES,
+} = require('../../shared/src/business/entities/contacts/PetitionContact');
+
+let test;
+global.FormData = FormData;
+global.Blob = () => {};
+presenter.providers.applicationContext = applicationContext;
+presenter.providers.router = {
+  externalRoute: () => {},
+  route: async url => {
+    if (url === `/case-detail/${test.docketNumber}`) {
+      await test.runSequence('gotoCaseDetailSequence', {
+        docketNumber: test.docketNumber,
+      });
+    }
+
+    if (url === '/') {
+      await test.runSequence('gotoDashboardSequence');
+    }
+  },
+};
+
+presenter.state = mapValues(presenter.state, value => {
+  if (isFunction(value)) {
+    return withAppContextDecorator(value, applicationContext);
+  }
+  return value;
+});
+
+const fakeData =
+  'JVBERi0xLjEKJcKlwrHDqwoKMSAwIG9iagogIDw8IC9UeXBlIC9DYXRhbG9nCiAgICAgL1BhZ2VzIDIgMCBSCiAgPj4KZW5kb2JqCgoyIDAgb2JqCiAgPDwgL1R5cGUgL1BhZ2VzCiAgICAgL0tpZHMgWzMgMCBSXQogICAgIC9Db3VudCAxCiAgICAgL01lZGlhQm94IFswIDAgMzAwIDE0NF0KICA+PgplbmRvYmoKCjMgMCBvYmoKICA8PCAgL1R5cGUgL1BhZ2UKICAgICAgL1BhcmVudCAyIDAgUgogICAgICAvUmVzb3VyY2VzCiAgICAgICA8PCAvRm9udAogICAgICAgICAgIDw8IC9GMQogICAgICAgICAgICAgICA8PCAvVHlwZSAvRm9udAogICAgICAgICAgICAgICAgICAvU3VidHlwZSAvVHlwZTEKICAgICAgICAgICAgICAgICAgL0Jhc2VGb250IC9UaW1lcy1Sb21hbgogICAgICAgICAgICAgICA+PgogICAgICAgICAgID4+CiAgICAgICA+PgogICAgICAvQ29udGVudHMgNCAwIFIKICA+PgplbmRvYmoKCjQgMCBvYmoKICA8PCAvTGVuZ3RoIDg0ID4+CnN0cmVhbQogIEJUCiAgICAvRjEgMTggVGYKICAgIDUgODAgVGQKICAgIChDb25ncmF0aW9ucywgeW91IGZvdW5kIHRoZSBFYXN0ZXIgRWdnLikgVGoKICBFVAplbmRzdHJlYW0KZW5kb2JqCgp4cmVmCjAgNQowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMTggMDAwMDAgbiAKMDAwMDAwMDA3NyAwMDAwMCBuIAowMDAwMDAwMTc4IDAwMDAwIG4gCjAwMDAwMDA0NTcgMDAwMDAgbiAKdHJhaWxlcgogIDw8ICAvUm9vdCAxIDAgUgogICAgICAvU2l6ZSA1CiAgPj4Kc3RhcnR4cmVmCjU2NQolJUVPRgo=';
+
+const fakeFile = Buffer.from(fakeData, 'base64');
+fakeFile.name = 'fakeFile.pdf';
+
+test = CerebralTest(presenter);
+
+describe('Trial Session Eligible Cases - Scenario 6 - L and P case types get prioritized before any other type of case; and then sequentially based upon the date petition was filed (FIFO)', () => {
+  beforeEach(() => {
+    jest.setTimeout(300000);
+    global.window = {
+      localStorage: {
+        removeItem: () => null,
+        setItem: () => null,
+      },
+    };
+
+    test.setState('constants', {
+      CASE_CAPTION_POSTFIX,
+      CATEGORIES,
+      CATEGORY_MAP,
+      COUNTRY_TYPES,
+      DOCUMENT_TYPES_MAP: Document.initialDocumentTypes,
+      INTERNAL_CATEGORY_MAP,
+      PARTY_TYPES,
+      STATUS_TYPES,
+      TRIAL_CITIES,
+    });
+  });
+
+  const trialLocation = `Las Vegas, Nevada, ${Date.now()}`;
+  const overrides = {
+    maxCases: 3,
+    preferredTrialCity: trialLocation,
+    sessionType: 'Regular',
+    trialLocation,
+  };
+  const createdCases = [];
+
+  describe(`Create trial session with Regular session type for '${trialLocation}' with max case count = 3`, () => {
+    docketClerkLogIn(test);
+    docketClerkCreatesATrialSession(test, overrides);
+    docketClerkViewsTrialSessionList(test, overrides);
+    docketClerkViewsAnUpcomingTrialSession(test);
+    userSignsOut(test);
+  });
+
+  describe('Create cases', () => {
+    describe(`Case 'L' type with status “General Docket - At Issue (Ready For Trial)” for '${trialLocation}' with Regular case type with filed date 5/1/2019`, () => {
+      const caseOverrides = {
+        ...overrides,
+        procedureType: 'Regular',
+        receivedAtYear: '2019',
+        receivedAtMonth: '05',
+        receivedAtDay: '01',
+        caseType: 'CDP (Lien/Levy)',
+      };
+      taxpayerLogin(test);
+      taxpayerNavigatesToCreateCase(test);
+      taxpayerChoosesProcedureType(test, caseOverrides);
+      taxpayerChoosesCaseType(test);
+      taxpayerCreatesNewCase(test, fakeFile, caseOverrides);
+      taxpayerViewsDashboard(test);
+      captureCreatedCase(test, createdCases);
+      userSignsOut(test);
+      petitionsClerkLogIn(test);
+      petitionsClerkUpdatesFiledBy(test, caseOverrides);
+      petitionsClerkSendsCaseToIRSHoldingQueue(test);
+      petitionsClerkRunsBatchProcess(test);
+      petitionsClerkSetsCaseReadyForTrial(test);
+      userSignsOut(test);
+    });
+
+    describe(`Case 'P' type with status “General Docket - At Issue (Ready For Trial)” for '${trialLocation}' with Regular case type with filed date 3/1/2019`, () => {
+      const caseOverrides = {
+        ...overrides,
+        procedureType: 'Regular',
+        receivedAtYear: '2019',
+        receivedAtMonth: '03',
+        receivedAtDay: '01',
+        caseType: 'Passport',
+      };
+      taxpayerLogin(test);
+      taxpayerNavigatesToCreateCase(test);
+      taxpayerChoosesProcedureType(test, caseOverrides);
+      taxpayerChoosesCaseType(test);
+      taxpayerCreatesNewCase(test, fakeFile, caseOverrides);
+      taxpayerViewsDashboard(test);
+      captureCreatedCase(test, createdCases);
+      userSignsOut(test);
+      petitionsClerkLogIn(test);
+      petitionsClerkUpdatesFiledBy(test, caseOverrides);
+      petitionsClerkSendsCaseToIRSHoldingQueue(test);
+      petitionsClerkRunsBatchProcess(test);
+      petitionsClerkSetsCaseReadyForTrial(test);
+      userSignsOut(test);
+    });
+
+    describe(`Case with Deficiency type with status “General Docket - At Issue (Ready For Trial)” for '${trialLocation}' with Regular case type with filed date 1/1/2019`, () => {
+      const caseOverrides = {
+        ...overrides,
+        procedureType: 'Regular',
+        receivedAtYear: '2019',
+        receivedAtMonth: '01',
+        receivedAtDay: '01',
+        caseType: 'Deficiency',
+      };
+      taxpayerLogin(test);
+      taxpayerNavigatesToCreateCase(test);
+      taxpayerChoosesProcedureType(test, caseOverrides);
+      taxpayerChoosesCaseType(test);
+      taxpayerCreatesNewCase(test, fakeFile, caseOverrides);
+      taxpayerViewsDashboard(test);
+      captureCreatedCase(test, createdCases);
+      userSignsOut(test);
+      petitionsClerkLogIn(test);
+      petitionsClerkUpdatesFiledBy(test, caseOverrides);
+      petitionsClerkSendsCaseToIRSHoldingQueue(test);
+      petitionsClerkRunsBatchProcess(test);
+      petitionsClerkSetsCaseReadyForTrial(test);
+      userSignsOut(test);
+    });
+
+    describe(`Case with Deficiency type with status “General Docket - At Issue (Ready For Trial)” for '${trialLocation}' with Regular case type with filed date 2/1/2019`, () => {
+      const caseOverrides = {
+        ...overrides,
+        procedureType: 'Regular',
+        receivedAtYear: '2019',
+        receivedAtMonth: '02',
+        receivedAtDay: '01',
+        caseType: 'Deficiency',
+      };
+      taxpayerLogin(test);
+      taxpayerNavigatesToCreateCase(test);
+      taxpayerChoosesProcedureType(test, caseOverrides);
+      taxpayerChoosesCaseType(test);
+      taxpayerCreatesNewCase(test, fakeFile, caseOverrides);
+      taxpayerViewsDashboard(test);
+      captureCreatedCase(test, createdCases);
+      userSignsOut(test);
+      petitionsClerkLogIn(test);
+      petitionsClerkUpdatesFiledBy(test, caseOverrides);
+      petitionsClerkSendsCaseToIRSHoldingQueue(test);
+      petitionsClerkRunsBatchProcess(test);
+      petitionsClerkSetsCaseReadyForTrial(test);
+      userSignsOut(test);
+    });
+  });
+
+  describe(`Result: Cases #1-4 should show as eligible for '${trialLocation}' session`, () => {
+    petitionsClerkLogIn(test);
+
+    it(`Cases #1-4 should show as eligible for '${trialLocation}' session`, async () => {
+      await test.runSequence('gotoTrialSessionDetailSequence', {
+        trialSessionId: test.trialSessionId,
+      });
+
+      expect(test.getState('eligibleCases').length).toEqual(4);
+      expect(test.getState('eligibleCases.0.caseId')).toEqual(createdCases[1]);
+      expect(test.getState('eligibleCases.1.caseId')).toEqual(createdCases[0]);
+      expect(test.getState('eligibleCases.2.caseId')).toEqual(createdCases[2]);
+      expect(test.getState('eligibleCases.3.caseId')).toEqual(createdCases[3]);
+      expect(test.getState('trialSession.status')).toEqual('Upcoming');
+      expect(test.getState('trialSession.isCalendared')).toEqual(false);
+    });
+
+    userSignsOut(test);
+  });
+
+  describe(`Set calendar for '${trialLocation}' session`, () => {
+    petitionsClerkLogIn(test);
+    petitionsClerkSetsATrialSessionsSchedule(test);
+    userSignsOut(test);
+  });
+
+  describe(`Result: Cases #1-3 are assigned to '${trialLocation}' session`, () => {
+    petitionsClerkLogIn(test);
+
+    it(`Cases #1-3 are assigned to '${trialLocation}' session`, async () => {
+      await test.runSequence('gotoTrialSessionDetailSequence', {
+        trialSessionId: test.trialSessionId,
+      });
+
+      expect(test.getState('trialSession.caseOrder').length).toEqual(3);
+      expect(test.getState('trialSession.isCalendared')).toEqual(true);
+      expect(test.getState('trialSession.caseOrder.0.caseId')).toEqual(
+        createdCases[1],
+      );
+      expect(test.getState('trialSession.caseOrder.1.caseId')).toEqual(
+        createdCases[0],
+      );
+      expect(test.getState('trialSession.caseOrder.2.caseId')).toEqual(
+        createdCases[2],
+      );
+    });
+
+    userSignsOut(test);
+  });
+});


### PR DESCRIPTION
Scenario 6

I believe case ustaxcourt/ef-cms#6492 should come before case ustaxcourt/ef-cms#6491 in this scenario, but I need some clarification on whether L should be prioritized over P, or if they're equal.

AC: L and P case types get prioritized before any other type of case; and then sequentially based upon the date petition was filed (FIFO)

```
    Create trial session with “Regular” session type for [trial location] with a max case count of 3

    Create cases
        Case “L” type with status “General Docket- At Issue” for [trial location] with Regular case type filed on 5/1/2019
        Case “P” type with status “General Docket- At Issue” for [trial location] with Regular case type filed on 3/1/2019
        Case with deficiency type with status “General Docket- At Issue” for [trial location] with Regular case type filed on 1/1/2019
        Case with deficiency type with status “General Docket- At Issue” for [trial location] with Regular case type filed on 2/1/2019
```

Result: Cases ustaxcourt/ef-cms#6491, ustaxcourt/ef-cms#6492, ustaxcourt/ef-cms#6493, ustaxcourt/ef-cms-flexion#4 will show as eligible for [trial location] session in sequential order (1,2,3,4)

```
    Set calendar for session
```

Result: Cases ustaxcourt/ef-cms#6491, ustaxcourt/ef-cms#6492, ustaxcourt/ef-cms#6493 are assigned to [trial session]