### PR TITLE
Fix aligment of docket number in invdividual queueueueueu

### DIFF
--- a/web-client/src/views/IndividualWorkQueueInbox.jsx
+++ b/web-client/src/views/IndividualWorkQueueInbox.jsx
@@ -20,7 +20,7 @@ export const IndividualWorkQueueInbox = connect(
           <thead>
             <tr>
               <th aria-label="Docket Number" colSpan="2">
-                Docket
+                <span className="padding-left-2px">Docket</span>
               </th>
               <th>Received</th>
               <th aria-label="Status Icon" className="padding-right-0">


### PR DESCRIPTION
Fixes the Docket label in the TH, as the content in the following rows gets pushed over by the hover indicator.