### PR TITLE
enforce us-east-1 region for S3

### DIFF
--- a/efcms-service/serverless.yml
+++ b/efcms-service/serverless.yml
@@ -98,7 +98,7 @@ provider:
   memorySize: 768
   timeout: 30
   logRetentionInDays: 7
-  s3Endpoint: s3.${opt:region}.amazonaws.com
+  s3Endpoint: s3.us-east-1.amazonaws.com
   dynamodbEndpoint: dynamodb.${opt:region}.amazonaws.com
   masterRegion: us-east-1
   userPoolId: us-east-1_7uRkF0Axn

--- a/efcms-service/src/applicationContext.js
+++ b/efcms-service/src/applicationContext.js
@@ -417,7 +417,7 @@ module.exports = (appContextUser = {}) => {
       if (!s3Cache) {
         s3Cache = new S3({
           endpoint: environment.s3Endpoint,
-          region: environment.region,
+          region: 'us-east-1',
           s3ForcePathStyle: true,
         });
       }


### PR DESCRIPTION
Since S3's replication is taking longer than expected for uploaded documents, we're enforcing the region for S3 for now