### PR TITLE
Prevent caseDetail from crashing when no contactPrimary

### DIFF
--- a/web-client/src/views/CaseDetailInternal.jsx
+++ b/web-client/src/views/CaseDetailInternal.jsx
@@ -88,18 +88,20 @@ export const CaseDetailInternal = connect(
         <section className="usa-section grid-container">
           {caseDetail.status === 'General Docket - Not at Issue' && (
             <>
-              <a
-                href={`${baseUrl}/documents/${
-                  caseDetail.docketNumber
-                }_${caseDetail.contactPrimary.name.replace(
-                  /\s/g,
-                  '_',
-                )}.zip/documentDownloadUrl?token=${token}`}
-                aria-label="View PDF"
-              >
-                <FontAwesomeIcon icon={['far', 'file-pdf']} />
-                Batch Zip Download
-              </a>
+              {caseDetail.contactPrimary && (
+                <a
+                  href={`${baseUrl}/documents/${
+                    caseDetail.docketNumber
+                  }_${caseDetail.contactPrimary.name.replace(
+                    /\s/g,
+                    '_',
+                  )}.zip/documentDownloadUrl?token=${token}`}
+                  aria-label="View PDF"
+                >
+                  <FontAwesomeIcon icon={['far', 'file-pdf']} />
+                  Batch Zip Download
+                </a>
+              )}
               <button
                 className="usa-button usa-button--outline margin-left-1"
                 onClick={() => setCaseToReadyForTrialSequence()}


### PR DESCRIPTION
This should be fixed in a later story, but for now it'd be nice if the app didn't crash when this case comes up.