### PR TITLE
1889: case detail screen updates

### DIFF
--- a/efcms-service/storage/fixtures/seed/103-19.json
+++ b/efcms-service/storage/fixtures/seed/103-19.json
@@ -68,7 +68,7 @@
             "document": {
               "createdAt": "2019-03-01T22:54:05.993Z",
               "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
-              "userId": "respondent",
+              "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
               "documentType": "Answer",
               "filedBy": "Test Respondent",
               "workItems": []
@@ -103,7 +103,7 @@
       "role": "respondent",
       "name": "Test Respondent",
       "custom:role": "respondent",
-      "userId": "respondent",
+      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
       "iat": 1551480838,
       "respondentId": "respondent",
       "email": "respondent",
@@ -260,7 +260,7 @@
     "document": {
       "createdAt": "2019-03-01T22:54:05.993Z",
       "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
-      "userId": "respondent",
+      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
       "documentType": "Answer",
       "filedBy": "Test Respondent",
       "workItems": []
@@ -278,7 +278,7 @@
         "createdAt": "2019-03-01T22:54:06.000Z",
         "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
         "message": "Answer filed by Respondent is ready for review.",
-        "userId": "respondent",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
         "from": "Test Respondent",
         "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
       }
@@ -294,7 +294,7 @@
     "document": {
       "createdAt": "2019-03-01T22:54:05.993Z",
       "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
-      "userId": "respondent",
+      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
       "documentType": "Answer",
       "filedBy": "Test Respondent",
       "workItems": []
@@ -312,7 +312,7 @@
         "createdAt": "2019-03-01T22:54:06.000Z",
         "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
         "message": "Answer filed by Respondent is ready for review.",
-        "userId": "respondent",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
         "from": "Test Respondent",
         "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
       }

--- a/efcms-service/storage/fixtures/seed/users.json
+++ b/efcms-service/storage/fixtures/seed/users.json
@@ -89,5 +89,17 @@
     "address": "123 Main Street Los Angeles, CA 98089",
     "barnumber": "12345-67",
     "phone": "111-111-1111"
+  },
+  {
+    "role": "respondent",
+    "sk": "5fb6e815-b5d3-459b-b08b-49c61f0fce5e",
+    "name": "Test Respondent1",
+    "section": "practitioner",
+    "pk": "5fb6e815-b5d3-459b-b08b-49c61f0fce5e",
+    "userId": "5fb6e815-b5d3-459b-b08b-49c61f0fce5e",
+    "email": "respondent1",
+    "address": "123 Main Street Los Angeles, CA 98089",
+    "barnumber": "12345-67",
+    "phone": "111-111-1111"
   }
 ]

--- a/shared/src/persistence/dynamo/users/getUserById.js
+++ b/shared/src/persistence/dynamo/users/getUserById.js
@@ -61,6 +61,16 @@ exports.userMap = {
     section: 'petitions',
     userId: '5805d1ab-18d0-43ec-bafb-654e83405416',
   },
+  respondent1: {
+    addressLine1: '123 Main Street',
+    addressLine2: 'Los Angeles, CA 98089',
+    'custom:role': 'respondent',
+    email: 'respondent1@example.com',
+    name: 'Test Respondent1',
+    role: 'respondent',
+    section: 'petitions',
+    userId: '5fb6e815-b5d3-459b-b08b-49c61f0fce5e',
+  },
   seniorattorney: {
     'custom:role': 'seniorattorney',
     email: 'seniorattorney@example.com',

--- a/web-client/pa11y/pa11y-respondent.js
+++ b/web-client/pa11y/pa11y-respondent.js
@@ -9,6 +9,6 @@ module.exports = [
     ],
     notes: 'checks a11y of revealed form for filing document',
     url:
-      'http://localhost:1234/mock-login?token=respondent&path=/case-detail/101-19&info=can-file-document',
+      'http://localhost:1234/mock-login?token=respondent&path=/case-detail/103-19&info=can-file-document',
   },
 ];

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -1,4 +1,3 @@
-import { some } from 'lodash';
 import { state } from 'cerebral';
 
 export const caseDetailHelper = get => {
@@ -20,33 +19,43 @@ export const caseDetailHelper = get => {
     ['CaseDetailInternal'].includes(currentPage) && userRole === 'docketclerk';
   let showRequestAccessToCaseButton = false;
   let showPendingAccessToCaseButton = false;
+  let showFileFirstDocumentButton = false;
+  let userHasAccessToCase = true;
+
   if (userRole === 'practitioner') {
     if (notAssociated) {
+      userHasAccessToCase = false;
       showFileDocumentButton = false;
       showRequestAccessToCaseButton = true;
       showPendingAccessToCaseButton = false;
-    }
-    if (isAssociated) {
+    } else if (isAssociated) {
       showFileDocumentButton = true;
       showRequestAccessToCaseButton = false;
       showPendingAccessToCaseButton = false;
-    }
-    if (pendingAssociation) {
+    } else if (pendingAssociation) {
+      userHasAccessToCase = false;
       showFileDocumentButton = false;
       showRequestAccessToCaseButton = false;
       showPendingAccessToCaseButton = true;
     }
   }
 
-  let userHasAccessToCase = true;
-  if (userRole === 'practitioner') {
-    userHasAccessToCase = false;
-    if (
-      caseDetail &&
-      caseDetail.practitioners &&
-      some(caseDetail.practitioners, { userId: userId })
-    ) {
-      userHasAccessToCase = true;
+  if (userRole === 'respondent') {
+    const caseHasRespondent = !!caseDetail && !!caseDetail.respondent;
+    if (caseHasRespondent && caseDetail.respondent.userId === userId) {
+      showFileDocumentButton = true;
+      showFileFirstDocumentButton = false;
+      showRequestAccessToCaseButton = false;
+    } else if (caseHasRespondent && caseDetail.respondent.userId !== userId) {
+      userHasAccessToCase = false;
+      showFileDocumentButton = false;
+      showFileFirstDocumentButton = false;
+      showRequestAccessToCaseButton = true;
+    } else {
+      userHasAccessToCase = false;
+      showFileDocumentButton = false;
+      showFileFirstDocumentButton = true;
+      showRequestAccessToCaseButton = false;
     }
   }
 
@@ -65,6 +74,7 @@ export const caseDetailHelper = get => {
     showDocumentDetailLink: !directDocumentLinkDesired,
     showDocumentStatus: !caseDetail.irsSendDate,
     showFileDocumentButton,
+    showFileFirstDocumentButton,
     showIrsServedDate: !!caseDetail.irsSendDate,
     showPayGovIdInput: form.paymentType == 'payGov',
     showPaymentOptions: !(caseDetail.payGovId && !form.paymentType),

--- a/web-client/src/presenter/computeds/caseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.test.js
@@ -135,6 +135,7 @@ describe('case detail computed', () => {
         caseDetail: { practitioners: [{ userId: '123' }] },
         currentPage: 'CaseDetail',
         form: {},
+        screenMetadata: { isAssociated: false },
         user: {
           role: 'practitioner',
           userId: '123',
@@ -150,6 +151,7 @@ describe('case detail computed', () => {
         caseDetail: { practitioners: [{ userId: '234' }] },
         currentPage: 'CaseDetail',
         form: {},
+        screenMetadata: { notAssociated: true },
         user: {
           role: 'practitioner',
           userId: '123',
@@ -157,5 +159,102 @@ describe('case detail computed', () => {
       },
     });
     expect(result.userHasAccessToCase).toEqual(false);
+  });
+
+  it('should set userHasAccessToCase and showFileDocumentButton to true if user role is respondent and the respondent is associated with the case', () => {
+    const result = runCompute(caseDetailHelper, {
+      state: {
+        caseDetail: { respondent: { userId: '789' } },
+        currentPage: 'CaseDetail',
+        form: {},
+        user: {
+          role: 'respondent',
+          userId: '789',
+        },
+      },
+    });
+    expect(result.userHasAccessToCase).toEqual(true);
+    expect(result.showFileDocumentButton).toEqual(true);
+    expect(result.showFileFirstDocumentButton).toEqual(false);
+    expect(result.showRequestAccessToCaseButton).toEqual(false);
+  });
+
+  it('should set showRequestAccessToCaseButton to true if user role is respondent and the respondent is not associated with the case', () => {
+    const result = runCompute(caseDetailHelper, {
+      state: {
+        caseDetail: { respondent: { userId: '123' } },
+        currentPage: 'CaseDetail',
+        form: {},
+        user: {
+          role: 'respondent',
+          userId: '789',
+        },
+      },
+    });
+    expect(result.userHasAccessToCase).toEqual(false);
+    expect(result.showFileDocumentButton).toEqual(false);
+    expect(result.showFileFirstDocumentButton).toEqual(false);
+    expect(result.showRequestAccessToCaseButton).toEqual(true);
+  });
+
+  it('should set showFileFirstDocumentButton to true if user role is respondent and there is no respondent associated with the case', () => {
+    const result = runCompute(caseDetailHelper, {
+      state: {
+        caseDetail: {},
+        currentPage: 'CaseDetail',
+        form: {},
+        user: {
+          role: 'respondent',
+          userId: '789',
+        },
+      },
+    });
+    expect(result.userHasAccessToCase).toEqual(false);
+    expect(result.showFileDocumentButton).toEqual(false);
+    expect(result.showFileFirstDocumentButton).toEqual(true);
+    expect(result.showRequestAccessToCaseButton).toEqual(false);
+  });
+
+  it('should show add docket entry button if current page is CaseDetailInternal and user role is docketclerk', () => {
+    const result = runCompute(caseDetailHelper, {
+      state: {
+        caseDetail: {},
+        currentPage: 'CaseDetailInternal',
+        form: {},
+        user: {
+          role: 'docketclerk',
+          userId: '789',
+        },
+      },
+    });
+    expect(result.showAddDocketEntryButton).toEqual(true);
+  });
+
+  it('should not show add docket entry button if current page is not CaseDetailInternal or user role is not docketclerk', () => {
+    let result = runCompute(caseDetailHelper, {
+      state: {
+        caseDetail: {},
+        currentPage: 'CaseDetail',
+        form: {},
+        user: {
+          role: 'docketclerk',
+          userId: '789',
+        },
+      },
+    });
+    expect(result.showAddDocketEntryButton).toEqual(false);
+
+    result = runCompute(caseDetailHelper, {
+      state: {
+        caseDetail: {},
+        currentPage: 'CaseDetail',
+        form: {},
+        user: {
+          role: 'petitioner',
+          userId: '789',
+        },
+      },
+    });
+    expect(result.showAddDocketEntryButton).toEqual(false);
   });
 });

--- a/web-client/src/views/CaseDetail.jsx
+++ b/web-client/src/views/CaseDetail.jsx
@@ -2,6 +2,7 @@ import { ActionRequired } from './CaseDetail/ActionRequired';
 import { CaseInformationPublic } from './CaseDetail/CaseInformationPublic';
 import { DocketRecord } from './DocketRecord/DocketRecord';
 import { ErrorNotification } from './ErrorNotification';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PartyInformation } from './CaseDetail/PartyInformation';
 import { SuccessNotification } from './SuccessNotification';
 import { Tab, Tabs } from '../ustc-ui/Tabs/Tabs';
@@ -51,6 +52,16 @@ export const CaseDetail = connect(
                   >
                     <span aria-hidden="true">Request for Access Pending</span>
                   </span>
+                )}
+                {caseHelper.showFileFirstDocumentButton && (
+                  <a
+                    className="usa-button tablet-full-width push-right margin-right-0"
+                    href={`/case-detail/${caseDetail.docketNumber}/file-document`}
+                    id="button-first-irs-document"
+                  >
+                    <FontAwesomeIcon icon="file" size="1x" /> File First IRS
+                    Document
+                  </a>
                 )}
               </div>
             </div>

--- a/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
@@ -24,9 +24,7 @@ export const DocketRecordHeader = connect(
               {helper.showAddDocketEntryButton && (
                 <a
                   className="usa-button"
-                  href={`/case-detail/${
-                    caseDetail.docketNumber
-                  }/add-docket-entry`}
+                  href={`/case-detail/${caseDetail.docketNumber}/add-docket-entry`}
                   id="button-add-record"
                 >
                   <FontAwesomeIcon icon="plus-circle" size="1x" /> Add Docket
@@ -36,9 +34,7 @@ export const DocketRecordHeader = connect(
               {helper.showFileDocumentButton && (
                 <a
                   className="usa-button hide-on-mobile"
-                  href={`/case-detail/${
-                    caseDetail.docketNumber
-                  }/file-a-document`}
+                  href={`/case-detail/${caseDetail.docketNumber}/file-a-document`}
                   id="button-file-document"
                 >
                   <FontAwesomeIcon icon="plus-circle" size="1x" /> File a


### PR DESCRIPTION
* Add `File First IRS Document` button if no respondent is associated with the case
* Show `Request Access to Case` button if a different respondent is associated with the case
* Add a second respondent user for local testing

<img width="1409" alt="Screen Shot 2019-06-18 at 4 41 22 PM" src="https://user-images.githubusercontent.com/43251054/59726845-1d358e00-91e8-11e9-8f75-78d97e99d7d0.png">
<img width="1412" alt="Screen Shot 2019-06-18 at 4 38 54 PM" src="https://user-images.githubusercontent.com/43251054/59726846-1d358e00-91e8-11e9-9134-c42a6dc5565f.png">
