### PR TITLE
1889: only show 2 doc types on respondent request access form

### DIFF
--- a/web-client/src/presenter/computeds/requestAccessHelper.js
+++ b/web-client/src/presenter/computeds/requestAccessHelper.js
@@ -3,6 +3,7 @@ import { state } from 'cerebral';
 export const requestAccessHelper = (get, applicationContext) => {
   const { PARTY_TYPES } = get(state.constants);
   const caseDetail = get(state.caseDetail);
+  const userRole = get(state.user.role);
   const form = get(state.form);
   const documentType = get(state.form.documentType);
   const validationErrors = get(state.validationErrors);
@@ -31,31 +32,37 @@ export const requestAccessHelper = (get, applicationContext) => {
       eventCode: 'SOC',
       scenario: 'Standard',
     },
-    {
-      documentTitleTemplate: 'Motion to Substitute Parties and Change Caption',
-      documentType: 'Motion to Substitute Parties and Change Caption',
-      eventCode: 'M107',
-      scenario: 'Standard',
-    },
-    {
-      documentTitleTemplate: 'Notice of Intervention',
-      documentType: 'Notice of Intervention',
-      eventCode: 'NOI',
-      scenario: 'Standard',
-    },
-    {
-      documentTitleTemplate: 'Notice of Election to Participate',
-      documentType: 'Notice of Election to Participate',
-      eventCode: 'NOEP',
-      scenario: 'Standard',
-    },
-    {
-      documentTitleTemplate: 'Notice of Election to Intervene',
-      documentType: 'Notice of Election to Intervene',
-      eventCode: 'NOEI',
-      scenario: 'Standard',
-    },
   ];
+
+  if (userRole === 'practitioner') {
+    documents.push(
+      {
+        documentTitleTemplate:
+          'Motion to Substitute Parties and Change Caption',
+        documentType: 'Motion to Substitute Parties and Change Caption',
+        eventCode: 'M107',
+        scenario: 'Standard',
+      },
+      {
+        documentTitleTemplate: 'Notice of Intervention',
+        documentType: 'Notice of Intervention',
+        eventCode: 'NOI',
+        scenario: 'Standard',
+      },
+      {
+        documentTitleTemplate: 'Notice of Election to Participate',
+        documentType: 'Notice of Election to Participate',
+        eventCode: 'NOEP',
+        scenario: 'Standard',
+      },
+      {
+        documentTitleTemplate: 'Notice of Election to Intervene',
+        documentType: 'Notice of Election to Intervene',
+        eventCode: 'NOEI',
+        scenario: 'Standard',
+      },
+    );
+  }
 
   const documentWithExhibits = [
     'Motion to Substitute Parties and Change Caption',
@@ -95,6 +102,8 @@ export const requestAccessHelper = (get, applicationContext) => {
     (documentWithAttachments && !form.attachments) ||
     (documentWithSupportingDocuments && !form.hasSupportingDocuments);
 
+  const showPartiesRepresenting = userRole === 'practitioner';
+
   let exported = {
     certificateOfServiceDateFormatted,
     documentWithAttachments,
@@ -105,6 +114,7 @@ export const requestAccessHelper = (get, applicationContext) => {
     partyValidationError,
     showFilingIncludes,
     showFilingNotIncludes,
+    showPartiesRepresenting,
     showPrimaryDocumentValid: !!form.primaryDocumentFile,
     showSecondaryParty,
   };

--- a/web-client/src/presenter/computeds/requestAccessHelper.test.js
+++ b/web-client/src/presenter/computeds/requestAccessHelper.test.js
@@ -69,4 +69,16 @@ describe('requestAccessHelper', () => {
     const result = await runCompute(requestAccessHelper, { state });
     expect(result.partyValidationError).toEqual('You did something bad.');
   });
+
+  it('returns correct number of document options for user role practitioner', async () => {
+    state.user = { role: 'practitioner' };
+    const result = await runCompute(requestAccessHelper, { state });
+    expect(result.documents.length).toEqual(6);
+  });
+
+  it('returns correct number of document options for user role respondent', async () => {
+    state.user = { role: 'respondent' };
+    const result = await runCompute(requestAccessHelper, { state });
+    expect(result.documents.length).toEqual(2);
+  });
 });

--- a/web-client/src/views/RequestAccess/RequestAccess.jsx
+++ b/web-client/src/views/RequestAccess/RequestAccess.jsx
@@ -32,7 +32,7 @@ export const RequestAccess = connect(
     return (
       <React.Fragment>
         <Focus>
-          <h1 tabIndex="-1" id="file-a-document-header">
+          <h1 id="file-a-document-header" tabIndex="-1">
             Request Access to This Case
           </h1>
         </Focus>
@@ -51,19 +51,20 @@ export const RequestAccess = connect(
             }`}
           >
             <label
+              className="usa-label"
               htmlFor="document-type"
               id="document-type-label"
-              className="usa-label"
             >
               Document Type
             </label>
             <select
-              name="documentType"
-              id="document-type"
               aria-describedby="document-type-label"
               className={`usa-select ${
                 validationErrors.documentType ? 'usa-select--error' : ''
               }`}
+              id="document-type"
+              name="documentType"
+              value={form.documentType || ''}
               onChange={e => {
                 const documentType = e.target.value;
                 const entry = find(requestAccessHelper.documents, {
@@ -87,7 +88,6 @@ export const RequestAccess = connect(
                 });
                 validateCaseAssociationRequestSequence();
               }}
-              value={form.documentType || ''}
             >
               <option value="">- Select -</option>
               {requestAccessHelper.documents.map(entry => {
@@ -99,18 +99,18 @@ export const RequestAccess = connect(
               })}
             </select>
             <Text
-              className="usa-error-message"
               bind="validationErrors.documentType"
+              className="usa-error-message"
             />
           </div>
         </div>
         <RequestAccessDocumentForm />
-        <PartiesRepresenting />
+        {requestAccessHelper.showPartiesRepresenting && <PartiesRepresenting />}
         <div className="button-box-container">
           <button
+            className="usa-button"
             id="submit-document"
             type="submit"
-            className="usa-button"
             onClick={() => {
               reviewRequestAccessInformationSequence();
             }}
@@ -118,8 +118,8 @@ export const RequestAccess = connect(
             Review Filing
           </button>
           <button
-            type="button"
             className="usa-button usa-button--outline"
+            type="button"
             onClick={() => {
               formCancelToggleCancelSequence();
             }}


### PR DESCRIPTION
Also, remove parties representing from this form when the user role is respondent. 

<img width="661" alt="Screen Shot 2019-06-19 at 10 57 57 AM" src="https://user-images.githubusercontent.com/43251054/59788687-1dce3300-9281-11e9-8183-5e9583dcca38.png">
