### PR TITLE
Increase cypress timeout a bit to hopefully reduce random failures

### DIFF
--- a/web-client/cypress.json
+++ b/web-client/cypress.json
@@ -4,6 +4,6 @@
   "reporterOptions": {
     "toConsole": true
   },
-  "defaultCommandTimeout": 10000,
-  "requestTimeout": 10000
+  "defaultCommandTimeout": 12000,
+  "requestTimeout": 12000
 }


### PR DESCRIPTION
Reseeding the database on the first 2 tests sometimes takes over 9000 ms even locally, and that seems to be what's failing randomly on Circle due to a timeout. 