### PR TITLE
437: customize toolbar for quill editor

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -980,3 +980,58 @@ nav.usa-nav {
 .quill {
   background: $color-white;
 }
+
+.ql-editor {
+  font-family: 'Times New Roman', Times, serif;
+  font-size: 14px;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='10px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='10px']::before {
+  content: '10px';
+  font-size: 10px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='12px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='12px']::before {
+  content: '12px';
+  font-size: 12px !important;
+}
+
+/* default */
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='14px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='14px']::before,
+.ql-snow .ql-picker.ql-size .ql-picker-label:not(.ql-active)::before {
+  content: '14px';
+  font-size: 14px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='16px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='16px']::before {
+  content: '16px';
+  font-size: 16px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='18px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='18px']::before {
+  content: '18px';
+  font-size: 18px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='20px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='20px']::before {
+  content: '20px';
+  font-size: 20px !important;
+}

--- a/web-client/src/views/CreateOrder/TextEditor.jsx
+++ b/web-client/src/views/CreateOrder/TextEditor.jsx
@@ -3,7 +3,11 @@ import 'react-quill/dist/quill.snow.css';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
-import ReactQuill from 'react-quill';
+import ReactQuill, { Quill } from 'react-quill';
+
+const Size = Quill.import('attributors/style/size');
+Size.whitelist = ['10px', '12px', '14px', '16px', '18px', '20px'];
+Quill.register(Size, true);
 
 export const TextEditor = connect(
   {
@@ -21,6 +25,31 @@ export const TextEditor = connect(
               value: e,
             });
           }}
+          modules={{
+            toolbar: [
+              [
+                {
+                  size: ['10px', '12px', '14px', '16px', '18px', '20px'],
+                },
+              ],
+              ['bold', 'italic', 'underline'],
+              [
+                { list: 'bullet' },
+                { list: 'ordered' },
+                { indent: '-1' },
+                { indent: '+1' },
+              ],
+            ],
+          }}
+          formats={[
+            'size',
+            'bold',
+            'italic',
+            'underline',
+            'bullet',
+            'list',
+            'indent',
+          ]}
         />
       );
     }


### PR DESCRIPTION
The CSS is yucky, I know. This was the only way I could find to display actual font sizes instead of Quill's defaults of Small, Regular, Large, Huge. 

<img width="509" alt="Screen Shot 2019-06-24 at 9 39 20 AM" src="https://user-images.githubusercontent.com/43251054/60036538-4c268680-9664-11e9-8c83-b0f7889da1a5.png">
