### PR TITLE
437: order entities - with and without body

### DIFF
--- a/shared/src/business/entities/orders/Order.js
+++ b/shared/src/business/entities/orders/Order.js
@@ -1,0 +1,37 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ * @param rawOrder
+ * @constructor
+ */
+function Order(rawOrder) {
+  Object.assign(this, {
+    orderBody: rawOrder.orderBody,
+    orderTitle: rawOrder.orderTitle,
+    orderType: rawOrder.orderType,
+  });
+}
+
+Order.errorToMessageMap = {
+  orderBody: 'Order body is required.',
+  orderTitle: 'Order title is required.',
+  orderType: 'Order type is required.',
+};
+
+joiValidationDecorator(
+  Order,
+  joi.object().keys({
+    orderBody: joi.string().required(),
+    orderTitle: joi.string().required(),
+    orderType: joi.string().required(),
+  }),
+  function() {
+    return !this.getFormattedValidationErrors();
+  },
+  Order.errorToMessageMap,
+);
+
+module.exports = { Order };

--- a/shared/src/business/entities/orders/Order.test.js
+++ b/shared/src/business/entities/orders/Order.test.js
@@ -1,0 +1,18 @@
+const { Order } = require('./Order');
+
+describe('Order', () => {
+  describe('validation', () => {
+    it('returns true if required fields are passed in', () => {
+      expect(
+        new Order({
+          orderBody: 'some text',
+          orderTitle: 'Order to Eat Cake',
+          orderType: 'Order',
+        }).isValid(),
+      ).toBeTruthy();
+    });
+    it('returns false if nothing is passed in', () => {
+      expect(new Order({}).isValid()).toBeFalsy();
+    });
+  });
+});

--- a/shared/src/business/entities/orders/OrderWithoutBody.js
+++ b/shared/src/business/entities/orders/OrderWithoutBody.js
@@ -1,0 +1,34 @@
+const joi = require('joi-browser');
+const {
+  joiValidationDecorator,
+} = require('../../../utilities/JoiValidationDecorator');
+
+/**
+ * @param rawOrder
+ * @constructor
+ */
+function OrderWithoutBody(rawOrder) {
+  Object.assign(this, {
+    orderTitle: rawOrder.orderTitle,
+    orderType: rawOrder.orderType,
+  });
+}
+
+OrderWithoutBody.errorToMessageMap = {
+  orderTitle: 'Order title is required.',
+  orderType: 'Order type is required.',
+};
+
+joiValidationDecorator(
+  OrderWithoutBody,
+  joi.object().keys({
+    orderTitle: joi.string().required(),
+    orderType: joi.string().required(),
+  }),
+  function() {
+    return !this.getFormattedValidationErrors();
+  },
+  OrderWithoutBody.errorToMessageMap,
+);
+
+module.exports = { OrderWithoutBody };

--- a/shared/src/business/entities/orders/OrderWithoutBody.test.js
+++ b/shared/src/business/entities/orders/OrderWithoutBody.test.js
@@ -1,0 +1,17 @@
+const { OrderWithoutBody } = require('./OrderWithoutBody');
+
+describe('OrderWithoutBody', () => {
+  describe('validation', () => {
+    it('returns true if required fields are passed in', () => {
+      expect(
+        new OrderWithoutBody({
+          orderTitle: 'Order to Eat Cake',
+          orderType: 'Order',
+        }).isValid(),
+      ).toBeTruthy();
+    });
+    it('returns false if nothing is passed in', () => {
+      expect(new OrderWithoutBody({}).isValid()).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
I'm not sure if we actually need both of these. There may be a more clever way to validate the order type/title in the modal, and then validate the full order on the Create Order page. I was following the model of `PetitionWithoutFiles`. 