### PR TITLE
437 dev fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ web-client/node_modules
 web-client/reports
 web-client/tests_output/
 puppeteer_lambda_layer.tar.gz
+parcel-debug-*

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -8,7 +8,7 @@ const AWS =
 
 // ^ must come first --------------------
 
-const chromium = require('chrome-aws-lambda');
+const chromium = require('chrome-' + 'aws-lambda');
 const docketNumberGenerator = require('../../shared/src/persistence/dynamo/cases/docketNumberGenerator');
 const irsGateway = require('../../shared/src/external/irsGateway');
 const util = require('util');


### PR DESCRIPTION
* allow lambda to use 'chrome-aws-lambda' from layer
* this removes 'chrome-aws-lambda' from parcel bundle