### PR TITLE
437 make require dynamic

### DIFF
--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -8,7 +8,6 @@ const AWS =
 
 // ^ must come first --------------------
 
-const chromium = require('chrome-' + 'aws-lambda');
 const docketNumberGenerator = require('../../shared/src/persistence/dynamo/cases/docketNumberGenerator');
 const irsGateway = require('../../shared/src/external/irsGateway');
 const util = require('util');
@@ -341,7 +340,11 @@ module.exports = (appContextUser = {}) => {
   return {
     docketNumberGenerator,
     environment,
-    getChromium: () => chromium,
+    getChromium: () => {
+      // eslint-disable-next-line security/detect-non-literal-require
+      const chromium = require('chrome-' + 'aws-lambda');
+      return chromium;
+    },
     getCurrentUser,
     getDocumentClient: ({ useMasterRegion = false } = {}) => {
       const type = useMasterRegion ? 'master' : 'region';


### PR DESCRIPTION
dev currently break because 'chrome-aws-lambda' isn't included in parcel build.

Which is exactly what we want we just don't want other lambda to require it.