### PR TITLE
437: clean up pdf styles

### DIFF
--- a/shared/src/business/useCases/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlInteractor.js
@@ -37,7 +37,7 @@ exports.createCourtIssuedOrderPdfFromHtml = async ({
       <!doctype html>
       <html>
         <body>
-          <div style="font-size: 14px; font-family: 'Times New Roman', Times, serif; width: 100%; margin: 20px 62px 20px 62px;">
+          <div style="font-size: 10px; font-family: 'Times New Roman', Times, serif; width: 100%; margin: 20px 62px 20px 62px;">
             <div style="float: right">
               Page <span class="pageNumber"></span>
               of <span class="totalPages"></span>
@@ -54,7 +54,7 @@ exports.createCourtIssuedOrderPdfFromHtml = async ({
       <!doctype html>
       <html>
         <body>
-          <div style="font-size: 14px; font-family: 'Times New Roman', Times, serif; width: 100%; margin: 20px 62px 20px 62px;">
+          <div style="font-size: 10px; font-family: 'Times New Roman', Times, serif; width: 100%; margin: 20px 62px 20px 62px;">
           </div>
         </body>
       </html>

--- a/web-client/src/presenter/actions/CourtIssuedOrder/createOrderAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/createOrderAction.js
@@ -12,18 +12,22 @@ const replaceWithID = (replacements, domString) => {
   return doc;
 };
 
-export const createOrderAction = ({ get }) => {
+export const createOrderAction = ({ applicationContext, get }) => {
   let richText = get(state.form.richText) || '';
-  let documentTitle = get(state.form.documentTitle);
+  let documentTitle = (get(state.form.documentTitle) || '').toUpperCase();
   richText = richText.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
-  const caseCaption = get(state.caseDetail.caseCaption);
+  const caseCaption = get(state.caseDetail.caseCaption) || '';
+  const caseCaptionNames =
+    applicationContext.getCaseCaptionNames(caseCaption) + ', ';
+  const caseCaptionPostfix = caseCaption.replace(caseCaptionNames, '');
   const docketNumberWithSuffix = get(
     state.formattedCaseDetail.docketNumberWithSuffix,
   );
 
   const doc = replaceWithID(
     {
-      '#caseCaption': caseCaption,
+      '#caseCaptionNames': caseCaptionNames,
+      '#caseCaptionPostfix': caseCaptionPostfix,
       '#docketNumber': docketNumberWithSuffix,
       '#orderBody': richText,
       '#orderTitleHeader': documentTitle,

--- a/web-client/src/views/CreateOrder/orderTemplate.html
+++ b/web-client/src/views/CreateOrder/orderTemplate.html
@@ -11,29 +11,32 @@
         font-size: 14px;
       }
       .court-header {
+        font-family: 'Arial', sans-serif;
+        font-size: 14px;
         text-align: center;
       }
+      .address-header {
+        font-size: 12px;
+      }
       .order-title-header {
-        clear: both;
         font-weight: bold;
         text-align: center;
       }
-      .caption-header {
-        margin-bottom: 20px;
+      table {
+        width: 100%;
+        margin-top: 20px;
+        margin-bottom: 40px;
+      }
+      td {
+        width: 50%;
+        padding: 7px 20px;
+        border-left: 1px dashed black;
+      }
+      table td:first-child {
+        border-left: none;
       }
       .more-indent {
-        margin-left: 100px;
-      }
-      .caption-header .caption {
-        display: inline-block;
-        width: 50%;
-        margin: 25px 0;
-      }
-      .caption.left {
-        float: left;
-      }
-      .caption.right {
-        float: right;
+        padding-left: 100px;
       }
     </style>
   </head>
@@ -41,26 +44,35 @@
     <div class="main">
       <div class="content-header">
         <div class="court-header">
-          UNITED STATES TAX COURT<br />
-          Washington, DC 20217
-        </div>
-        <div class="caption-header">
-          <div class="caption left">
-            <span id="caseCaption"></span>
-            <br />
-            <div class="more-indent">
-              v.
-            </div>
-            Commissioner of Internal Revenue
-            <br />
-            <div class="more-indent">
-              Respondent
-            </div>
-          </div>
-          <div class="caption right">
-            <p>Docket Number: <span id="docketNumber"></span></p>
+          UNITED STATES TAX COURT
+          <div class="address-header">
+            Washington, DC 20217
           </div>
         </div>
+        <table>
+          <tbody>
+            <tr>
+              <td id="caseCaptionNames"></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td id="caseCaptionPostfix" class="more-indent"></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td class="more-indent">v.</td>
+              <td>Docket Number: <span id="docketNumber"></span></td>
+            </tr>
+            <tr>
+              <td>Commissioner of Internal Revenue,</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td class="more-indent">Respondent</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
         <div class="order-title-header" id="orderTitleHeader"></div>
       </div>
       <div id="orderBody"></div>

--- a/web-client/src/views/CreateOrder/orderTemplate.html
+++ b/web-client/src/views/CreateOrder/orderTemplate.html
@@ -3,8 +3,12 @@
   <head>
     <style type="text/css">
       @page {
-        margin: 3cm 2cm 2cm;
+        margin: 2.25cm 2cm 6cm;
         size: 8.5in 11in;
+      }
+      @page :first {
+        margin-top: 1cm;
+        margin-bottom: 2cm;
       }
       body {
         font-family: 'Times New Roman', Times, serif;
@@ -29,11 +33,16 @@
       }
       td {
         width: 50%;
-        padding: 7px 20px;
+        padding-top: 7px;
+        padding-right: 20px;
+        padding-bottom: 7px;
         border-left: 1px dashed black;
       }
       table td:first-child {
         border-left: none;
+      }
+      table td:nth-child(2) {
+        padding-left: 30px;
       }
       .more-indent {
         padding-left: 100px;


### PR DESCRIPTION
* Convert PDF header to use table instead of divs (because the `Docket Number` line needs to be lined up with the `v.` line)
* Convert order title to upper case
* Reduce font size on docket number/page number header
* Change USTC header to use Arial font
* Hide the docket number/page number header on the first page
<img width="933" alt="Screen Shot 2019-07-02 at 8 50 45 AM" src="https://user-images.githubusercontent.com/43251054/60527129-80262b00-9ca6-11e9-8a0c-4d4f46a1c28e.png">
