### PR TITLE
438: case deadline views

### DIFF
--- a/shared/src/persistence/dynamo/caseDeadlines/getCaseDeadlinesByCaseId.js
+++ b/shared/src/persistence/dynamo/caseDeadlines/getCaseDeadlinesByCaseId.js
@@ -10,8 +10,8 @@ const { stripInternalKeys } = require('../../dynamo/helpers/stripInternalKeys');
  * @param applicationContext
  * @returns {*}
  */
-exports.getCaseDeadlinesByCaseId = ({ applicationContext, caseId }) => {
-  return getRecordsViaMapping({
+exports.getCaseDeadlinesByCaseId = async ({ applicationContext, caseId }) => {
+  return await getRecordsViaMapping({
     applicationContext,
     key: caseId,
     type: 'case-deadline',

--- a/web-client/integration-tests/journey/petitionsClerkDeletesCaseDeadline.js
+++ b/web-client/integration-tests/journey/petitionsClerkDeletesCaseDeadline.js
@@ -22,8 +22,6 @@ export default (test, overrides = {}) => {
     expect(test.getState('form.year')).toBeTruthy();
     expect(test.getState('form.description')).toBeTruthy();
 
-    await test.runSequence('deleteCaseDeadlineSequence', {
-      caseDeadlineId: helper.caseDeadlines[0].caseDeadlineId,
-    });
+    await test.runSequence('deleteCaseDeadlineSequence');
   });
 };

--- a/web-client/src/app.jsx
+++ b/web-client/src/app.jsx
@@ -16,6 +16,7 @@ import {
 } from '@fortawesome/free-regular-svg-icons';
 import {
   faArrowAltCircleLeft as faArrowAltCircleLeftSolid,
+  faCalendarAlt,
   faCalendarCheck,
   faCaretDown,
   faCaretLeft,
@@ -52,6 +53,7 @@ import {
   faSpinner,
   faSync,
   faTimesCircle,
+  faTrash,
 } from '@fortawesome/free-solid-svg-icons';
 import { isFunction, mapValues } from 'lodash';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -97,6 +99,7 @@ const app = {
     library.add(
       faArrowAltCircleLeftRegular,
       faArrowAltCircleLeftSolid,
+      faCalendarAlt,
       faCalendarCheck,
       faCaretDown,
       faCaretLeft,
@@ -141,6 +144,7 @@ const app = {
       faSpinner,
       faSync,
       faTimesCircle,
+      faTrash,
       faUser,
     );
     presenter.providers.applicationContext = applicationContext;

--- a/web-client/src/presenter/actions/CaseDeadline/deleteCaseDeadlineAction.js
+++ b/web-client/src/presenter/actions/CaseDeadline/deleteCaseDeadlineAction.js
@@ -8,17 +8,15 @@ import { state } from 'cerebral';
  * @param {object} providers.applicationContext the application context
  * @param {Function} providers.get the cerebral get helper function
  * @param {object} providers.path the next object in the path
- * @param {object} providers.props the cerebral props object
  * @returns {object} the success path
  */
 export const deleteCaseDeadlineAction = async ({
   applicationContext,
   get,
   path,
-  props,
 }) => {
   const caseId = get(state.caseDetail.caseId);
-  const { caseDeadlineId } = props;
+  const caseDeadlineId = get(state.form.caseDeadlineId);
 
   await applicationContext.getUseCases().deleteCaseDeadlineInteractor({
     applicationContext,

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -21,6 +21,19 @@ const formatDocketRecord = (applicationContext, docketRecord) => {
   return result;
 };
 
+const formatCaseDeadline = (applicationContext, caseDeadline) => {
+  const result = _.cloneDeep(caseDeadline);
+  result.deadlineDateFormatted = applicationContext
+    .getUtilities()
+    .formatDateString(result.deadlineDate, 'MMDDYY');
+
+  if (new Date(result.deadlineDate) < new Date()) {
+    result.overdue = true;
+  }
+
+  return result;
+};
+
 const processArrayErrors = (yearAmount, caseDetailErrors, idx) => {
   const yearAmountError = caseDetailErrors.yearAmounts.find(error => {
     return error.index === idx;
@@ -176,6 +189,12 @@ const formatCase = (applicationContext, caseDetail, caseDetailErrors) => {
   result.docketRecordWithDocument.sort((a, b) => {
     return a.index - b.index;
   });
+
+  if (result.caseDeadlines) {
+    result.caseDeadlines = result.caseDeadlines.map(d =>
+      formatCaseDeadline(applicationContext, d),
+    );
+  }
 
   const formatRespondent = respondent => {
     respondent.formattedName = `${respondent.name} ${

--- a/web-client/src/presenter/sequences/refreshCaseSequence.js
+++ b/web-client/src/presenter/sequences/refreshCaseSequence.js
@@ -1,3 +1,7 @@
+import { getCaseDeadlinesForCaseAction } from '../actions/CaseDeadline/getCaseDeadlinesForCaseAction';
 import { refreshCaseAction } from '../actions/refreshCaseAction';
 
-export const refreshCaseSequence = [refreshCaseAction];
+export const refreshCaseSequence = [
+  refreshCaseAction,
+  getCaseDeadlinesForCaseAction,
+];

--- a/web-client/src/styles/tables.scss
+++ b/web-client/src/styles/tables.scss
@@ -505,3 +505,18 @@ table.case-list tbody tr:nth-child(even) td {
     }
   }
 }
+
+.deadlines {
+  .smaller-column {
+    width: 130px;
+  }
+
+  .center-column {
+    text-align: center;
+  }
+
+  .overdue {
+    color: color($theme-color-secondary);
+    font-weight: $font-semibold;
+  }
+}

--- a/web-client/src/views/CaseDetail/CaseDeadlines.jsx
+++ b/web-client/src/views/CaseDetail/CaseDeadlines.jsx
@@ -1,0 +1,82 @@
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+
+export const CaseDeadlines = connect(
+  {
+    caseDeadlines: state.formattedCaseDetail.caseDeadlines,
+    openDeleteCaseDeadlineModalSequence:
+      sequences.openDeleteCaseDeadlineModalSequence,
+    openEditCaseDeadlineModalSequence:
+      sequences.openEditCaseDeadlineModalSequence,
+  },
+  function CaseDeadlines({
+    caseDeadlines,
+    openDeleteCaseDeadlineModalSequence,
+    openEditCaseDeadlineModalSequence,
+  }) {
+    return (
+      <>
+        {!caseDeadlines ||
+          (caseDeadlines.length === 0 && (
+            <p className="heading-2 margin-bottom-10">
+              There are no deadlines for this case.
+            </p>
+          ))}
+        {caseDeadlines && caseDeadlines.length > 0 && (
+          <table className="usa-table row-border-only subsection deadlines">
+            <tbody>
+              {caseDeadlines.map((item, idx) => (
+                <tr key={idx}>
+                  <td className="overdue smaller-column center-column">
+                    {item.overdue ? 'Overdue' : ''}
+                  </td>
+                  <td className="smaller-column center-column">
+                    {item.deadlineDateFormatted}
+                  </td>
+                  <td className="padding-extra">{item.description}</td>
+                  <td className="smaller-column center-column">
+                    <button
+                      className="usa-button usa-button--unstyled"
+                      onClick={() => {
+                        openDeleteCaseDeadlineModalSequence({
+                          caseDeadlineId: item.caseDeadlineId,
+                        });
+                      }}
+                    >
+                      <FontAwesomeIcon
+                        className="margin-right-05"
+                        icon="trash"
+                        size="1x"
+                      />
+                      Remove
+                    </button>
+                  </td>
+                  <td className="smaller-column center-column">
+                    <button
+                      className="usa-button usa-button--unstyled"
+                      onClick={() => {
+                        openEditCaseDeadlineModalSequence({
+                          caseDeadlineId: item.caseDeadlineId,
+                        });
+                      }}
+                    >
+                      <FontAwesomeIcon
+                        className="margin-right-05"
+                        icon="edit"
+                        size="1x"
+                      />
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </>
+    );
+  },
+);

--- a/web-client/src/views/CaseDetail/CreateCaseDeadlineModalDialog.jsx
+++ b/web-client/src/views/CaseDetail/CreateCaseDeadlineModalDialog.jsx
@@ -1,0 +1,167 @@
+import { ModalDialog } from '../ModalDialog';
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+class CreateCaseDeadlineModalDialogComponent extends ModalDialog {
+  constructor(props) {
+    super(props);
+    this.modal = {
+      cancelLabel: 'Cancel',
+      classNames: '',
+      confirmLabel: 'Save',
+      title: 'Add Deadline',
+    };
+  }
+  renderBody() {
+    return (
+      <div className="ustc-create-order-modal">
+        <div
+          className={
+            'usa-form-group ' +
+            (this.props.validationErrors.deadlineDate
+              ? 'usa-form-group--error'
+              : '')
+          }
+        >
+          <fieldset className="usa-fieldset margin-bottom-0">
+            <legend className="usa-legend" id="deadline-date-legend">
+              Due Date
+            </legend>
+            <div className="usa-memorable-date">
+              <div className="usa-form-group usa-form-group--month margin-bottom-0">
+                <input
+                  aria-describedby="deadline-date-legend"
+                  aria-label="month, two digits"
+                  className={
+                    'usa-input usa-input--inline ' +
+                    (this.props.validationErrors.deadlineDate
+                      ? 'usa-input--error'
+                      : '')
+                  }
+                  id="deadline-date-month"
+                  max="12"
+                  min="1"
+                  name="month"
+                  placeholder="MM"
+                  type="number"
+                  value={this.props.form.month || ''}
+                  onChange={e => {
+                    this.props.updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                    this.props.validateCaseDeadlineSequence();
+                  }}
+                />
+              </div>
+              <div className="usa-form-group usa-form-group--day margin-bottom-0">
+                <input
+                  aria-describedby="deadline-date-legend"
+                  aria-label="day, two digits"
+                  className={
+                    'usa-input usa-input--inline ' +
+                    (this.props.validationErrors.deadlineDate
+                      ? 'usa-input--error'
+                      : '')
+                  }
+                  id="deadline-date-day"
+                  max="31"
+                  min="1"
+                  name="day"
+                  placeholder="DD"
+                  type="number"
+                  value={this.props.form.day || ''}
+                  onChange={e => {
+                    this.props.updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                    this.props.validateCaseDeadlineSequence();
+                  }}
+                />
+              </div>
+              <div className="usa-form-group usa-form-group--year margin-bottom-0">
+                <input
+                  aria-describedby="deadline-date-legend"
+                  aria-label="year, four digits"
+                  className={
+                    'usa-input usa-input--inline ' +
+                    (this.props.validationErrors.deadlineDate
+                      ? 'usa-input--error'
+                      : '')
+                  }
+                  id="deadline-date-year"
+                  max="2100"
+                  min="1900"
+                  name="year"
+                  placeholder="YYYY"
+                  type="number"
+                  value={this.props.form.year || ''}
+                  onChange={e => {
+                    this.props.updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                    this.props.validateCaseDeadlineSequence();
+                  }}
+                />
+              </div>
+            </div>
+          </fieldset>
+          {this.props.validationErrors.deadlineDate && (
+            <div className="usa-error-message beneath">
+              {this.props.validationErrors.deadlineDate}
+            </div>
+          )}
+        </div>
+
+        <div
+          className={
+            'usa-form-group ' +
+            (this.props.validationErrors.description
+              ? 'usa-form-group--error'
+              : '')
+          }
+        >
+          <label className="usa-label" htmlFor="description">
+            What is this deadline for?
+          </label>
+          <textarea
+            className="usa-textarea"
+            id="description"
+            maxLength="120"
+            name="description"
+            type="text"
+            onChange={e => {
+              this.props.updateFormValueSequence({
+                key: e.target.name,
+                value: e.target.value,
+              });
+              this.props.validateCaseDeadlineSequence();
+            }}
+          />
+          {this.props.validationErrors.description && (
+            <div className="usa-error-message beneath">
+              {this.props.validationErrors.description}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export const CreateCaseDeadlineModalDialog = connect(
+  {
+    cancelSequence: sequences.dismissModalSequence,
+    confirmSequence: sequences.createCaseDeadlineSequence,
+    constants: state.constants,
+    form: state.form,
+    modal: state.modal,
+    updateFormValueSequence: sequences.updateFormValueSequence,
+    validateCaseDeadlineSequence: sequences.validateCaseDeadlineSequence,
+    validationErrors: state.validationErrors,
+  },
+  CreateCaseDeadlineModalDialogComponent,
+);

--- a/web-client/src/views/CaseDetail/DeleteCaseDeadlineModalDialog.jsx
+++ b/web-client/src/views/CaseDetail/DeleteCaseDeadlineModalDialog.jsx
@@ -1,0 +1,35 @@
+import { ModalDialog } from '../ModalDialog';
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+class DeleteCaseDeadlineModalDialogComponent extends ModalDialog {
+  constructor(props) {
+    super(props);
+    this.modal = {
+      cancelLabel: 'No, cancel',
+      classNames: '',
+      confirmLabel: 'Yes, remove',
+      title: 'Are you sure you want to delete this deadline?',
+    };
+  }
+  renderBody() {
+    return (
+      <>
+        <label className="margin-right-2" htmlFor="deadline-to-delete">
+          {this.props.form.month}/{this.props.form.day}/{this.props.form.year}
+        </label>
+        <span id="deadline-to-delete">{this.props.form.description}</span>
+      </>
+    );
+  }
+}
+
+export const DeleteCaseDeadlineModalDialog = connect(
+  {
+    cancelSequence: sequences.dismissModalSequence,
+    confirmSequence: sequences.deleteCaseDeadlineSequence,
+    form: state.form,
+  },
+  DeleteCaseDeadlineModalDialogComponent,
+);

--- a/web-client/src/views/CaseDetail/EditCaseDeadlineModalDialog.jsx
+++ b/web-client/src/views/CaseDetail/EditCaseDeadlineModalDialog.jsx
@@ -1,0 +1,168 @@
+import { ModalDialog } from '../ModalDialog';
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+class EditCaseDeadlineModalDialogComponent extends ModalDialog {
+  constructor(props) {
+    super(props);
+    this.modal = {
+      cancelLabel: 'Cancel',
+      classNames: '',
+      confirmLabel: 'Save',
+      title: 'Edit Deadline',
+    };
+  }
+  renderBody() {
+    return (
+      <div className="ustc-create-order-modal">
+        <div
+          className={
+            'usa-form-group ' +
+            (this.props.validationErrors.deadlineDate
+              ? 'usa-form-group--error'
+              : '')
+          }
+        >
+          <fieldset className="usa-fieldset margin-bottom-0">
+            <legend className="usa-legend" id="deadline-date-legend">
+              Due Date
+            </legend>
+            <div className="usa-memorable-date">
+              <div className="usa-form-group usa-form-group--month margin-bottom-0">
+                <input
+                  aria-describedby="deadline-date-legend"
+                  aria-label="month, two digits"
+                  className={
+                    'usa-input usa-input--inline ' +
+                    (this.props.validationErrors.deadlineDate
+                      ? 'usa-input--error'
+                      : '')
+                  }
+                  id="deadline-date-month"
+                  max="12"
+                  min="1"
+                  name="month"
+                  placeholder="MM"
+                  type="number"
+                  value={this.props.form.month || ''}
+                  onChange={e => {
+                    this.props.updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                    this.props.validateCaseDeadlineSequence();
+                  }}
+                />
+              </div>
+              <div className="usa-form-group usa-form-group--day margin-bottom-0">
+                <input
+                  aria-describedby="deadline-date-legend"
+                  aria-label="day, two digits"
+                  className={
+                    'usa-input usa-input--inline ' +
+                    (this.props.validationErrors.deadlineDate
+                      ? 'usa-input--error'
+                      : '')
+                  }
+                  id="deadline-date-day"
+                  max="31"
+                  min="1"
+                  name="day"
+                  placeholder="DD"
+                  type="number"
+                  value={this.props.form.day || ''}
+                  onChange={e => {
+                    this.props.updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                    this.props.validateCaseDeadlineSequence();
+                  }}
+                />
+              </div>
+              <div className="usa-form-group usa-form-group--year margin-bottom-0">
+                <input
+                  aria-describedby="deadline-date-legend"
+                  aria-label="year, four digits"
+                  className={
+                    'usa-input usa-input--inline ' +
+                    (this.props.validationErrors.deadlineDate
+                      ? 'usa-input--error'
+                      : '')
+                  }
+                  id="deadline-date-year"
+                  max="2100"
+                  min="1900"
+                  name="year"
+                  placeholder="YYYY"
+                  type="number"
+                  value={this.props.form.year || ''}
+                  onChange={e => {
+                    this.props.updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                    this.props.validateCaseDeadlineSequence();
+                  }}
+                />
+              </div>
+            </div>
+          </fieldset>
+          {this.props.validationErrors.deadlineDate && (
+            <div className="usa-error-message beneath">
+              {this.props.validationErrors.deadlineDate}
+            </div>
+          )}
+        </div>
+
+        <div
+          className={
+            'usa-form-group ' +
+            (this.props.validationErrors.description
+              ? 'usa-form-group--error'
+              : '')
+          }
+        >
+          <label className="usa-label" htmlFor="description">
+            What is this deadline for?
+          </label>
+          <textarea
+            className="usa-textarea"
+            id="description"
+            maxLength="120"
+            name="description"
+            type="text"
+            value={this.props.form.description}
+            onChange={e => {
+              this.props.updateFormValueSequence({
+                key: e.target.name,
+                value: e.target.value,
+              });
+              this.props.validateCaseDeadlineSequence();
+            }}
+          />
+          {this.props.validationErrors.description && (
+            <div className="usa-error-message beneath">
+              {this.props.validationErrors.description}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export const EditCaseDeadlineModalDialog = connect(
+  {
+    cancelSequence: sequences.dismissModalSequence,
+    confirmSequence: sequences.updateCaseDeadlineSequence,
+    constants: state.constants,
+    form: state.form,
+    modal: state.modal,
+    updateFormValueSequence: sequences.updateFormValueSequence,
+    validateCaseDeadlineSequence: sequences.validateCaseDeadlineSequence,
+    validationErrors: state.validationErrors,
+  },
+  EditCaseDeadlineModalDialogComponent,
+);

--- a/web-client/src/views/CaseDetailInternal.jsx
+++ b/web-client/src/views/CaseDetailInternal.jsx
@@ -1,6 +1,10 @@
+import { CaseDeadlines } from './CaseDetail/CaseDeadlines';
 import { CaseDetailHeader } from './CaseDetailHeader';
 import { CaseInformationInternal } from './CaseDetail/CaseInformationInternal';
+import { CreateCaseDeadlineModalDialog } from './CaseDetail/CreateCaseDeadlineModalDialog';
+import { DeleteCaseDeadlineModalDialog } from './CaseDetail/DeleteCaseDeadlineModalDialog';
 import { DocketRecord } from './DocketRecord/DocketRecord';
+import { EditCaseDeadlineModalDialog } from './CaseDetail/EditCaseDeadlineModalDialog';
 import { ErrorNotification } from './ErrorNotification';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MessagesInProgress } from './CaseDetail/MessagesInProgress';
@@ -16,16 +20,21 @@ export const CaseDetailInternal = connect(
     baseUrl: state.baseUrl,
     caseDetail: state.formattedCaseDetail,
     caseHelper: state.caseDetailHelper,
+    openCreateCaseDeadlineModalSequence:
+      sequences.openCreateCaseDeadlineModalSequence,
     setCaseToReadyForTrialSequence: sequences.setCaseToReadyForTrialSequence,
     setDocumentDetailTabSequence: sequences.setDocumentDetailTabSequence,
+    showModal: state.showModal,
     token: state.token,
   },
   ({
     baseUrl,
     caseDetail,
     caseHelper,
+    openCreateCaseDeadlineModalSequence,
     setCaseToReadyForTrialSequence,
     setDocumentDetailTabSequence,
+    showModal,
     token,
   }) => {
     return (
@@ -34,6 +43,20 @@ export const CaseDetailInternal = connect(
         <section className="usa-section grid-container">
           <SuccessNotification />
           <ErrorNotification />
+          <div>
+            <div className="title">
+              <h1>Deadlines</h1>
+              <button
+                className="usa-button push-right"
+                onClick={() => {
+                  openCreateCaseDeadlineModalSequence();
+                }}
+              >
+                <FontAwesomeIcon icon="calendar-alt" size="1x" /> Add Deadline
+              </button>
+            </div>
+            <CaseDeadlines />
+          </div>
           <div>
             <div className="title">
               <h1>Messages in Progress</h1>
@@ -111,6 +134,16 @@ export const CaseDetailInternal = connect(
             </>
           )}
         </section>
+
+        {showModal === 'CreateCaseDeadlineModalDialog' && (
+          <CreateCaseDeadlineModalDialog />
+        )}
+        {showModal === 'EditCaseDeadlineModalDialog' && (
+          <EditCaseDeadlineModalDialog />
+        )}
+        {showModal === 'DeleteCaseDeadlineModalDialog' && (
+          <DeleteCaseDeadlineModalDialog />
+        )}
       </>
     );
   },


### PR DESCRIPTION
Current issues that will be fixed in later PRs:

* Remove deadline is not working - not sure how to pass in props to the sequence the way the modals are set up.
* Deadline table is flashing on the screen when the case is refreshed. Does this need to be part of the refresh? If not, it will need to be moved outside of the case detail in the state.
<img width="1409" alt="Screen Shot 2019-07-05 at 6 53 05 PM" src="https://user-images.githubusercontent.com/43251054/60749987-f2249b80-9f56-11e9-86eb-e77c7f618379.png">
<img width="515" alt="Screen Shot 2019-07-05 at 6 53 11 PM" src="https://user-images.githubusercontent.com/43251054/60749988-f486f580-9f56-11e9-8302-ab1c1eb83a0e.png">
