### PR TITLE
Combine UI unit and integration tests on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: docker run --rm efcms /bin/sh -c 'cd web-client && npm run lint'
       - run:
           name: UI - Test
-          command: docker run --rm -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop efcms /bin/sh -c "cd web-api && (npm start &) && ../wait-until.sh http://localhost:3000/api/swagger && cd ../web-client && npm run test"
+          command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage --rm -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop efcms /bin/sh -c "cd web-api && (npm start &) && ../wait-until.sh http://localhost:3000/api/swagger && cd ../web-client && npm run test"
       - run:
           name: UI - SonarQube
           command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage -e "SONAR_KEY=${UI_SONAR_KEY}" -e "branch_name=${CIRCLE_BRANCH}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${UI_SONAR_TOKEN}" --rm efcms /bin/sh -c 'cd web-client && ./verify-sonarqube-passed.sh'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: docker run --rm efcms /bin/sh -c 'cd web-client && npm run lint'
       - run:
           name: UI - Test
-          command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage --rm efcms /bin/sh -c 'cd web-client && npm run test'
+          command: docker run --rm -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop efcms /bin/sh -c "cd web-api && (npm start &) && ../wait-until.sh http://localhost:3000/api/swagger && cd ../web-client && npm run test"
       - run:
           name: UI - SonarQube
           command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage -e "SONAR_KEY=${UI_SONAR_KEY}" -e "branch_name=${CIRCLE_BRANCH}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${UI_SONAR_TOKEN}" --rm efcms /bin/sh -c 'cd web-client && ./verify-sonarqube-passed.sh'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: docker run --rm efcms /bin/sh -c 'cd web-client && npm run lint'
       - run:
           name: UI - Test
-          command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage-unit --rm efcms /bin/sh -c 'cd web-client && npm run test:unit'
+          command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage --rm efcms /bin/sh -c 'cd web-client && npm run test'
       - run:
           name: UI - SonarQube
           command: docker run -v $(pwd)/web-client/coverage:/home/app/web-client/coverage -e "SONAR_KEY=${UI_SONAR_KEY}" -e "branch_name=${CIRCLE_BRANCH}" -e "SONAR_ORG=${SONAR_ORG}" -e "SONAR_TOKEN=${UI_SONAR_TOKEN}" --rm efcms /bin/sh -c 'cd web-client && ./verify-sonarqube-passed.sh'
@@ -62,9 +62,6 @@ jobs:
       - run:
           name: Pa11y
           command: docker run --rm -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop efcms /bin/sh -c 'cd web-api && (npm start &) && ../wait-until.sh http://localhost:3000/api/swagger && cd ../web-client && (npm run dev &) && ../wait-until.sh http://localhost:1234 && npm run test:pa11y'
-      - run:
-          name: Cerebral
-          command: docker run --rm -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop efcms /bin/sh -c "cd web-api && (npm start &) && ../wait-until.sh http://localhost:3000/api/swagger && cd ../web-client && npm run test:integration"
       - run:
           name: Cypress
           command: docker run --rm -e SLS_DEBUG=* -e AWS_ACCESS_KEY_ID=noop -e AWS_SECRET_ACCESS_KEY=noop efcms /bin/sh -c 'cd web-api && (npm start &) && ../wait-until.sh http://localhost:3000/api/swagger && cd ../web-client && (npm run dev:cypress &) && ../wait-until.sh http://localhost:1234 && npm run cypress'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM cypress/base:10.15.3
 
 WORKDIR /home/app
 
-RUN echo "clearing cache - remove this at some point"
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -21,7 +21,7 @@
     "test:pa11y": "pa11y-ci --config pa11y-ci.config.js",
     "test:unit": "jest --runInBand --config jest-unit.config.js ./src/.*test\\.js$",
     "test:watch": "jest --runInBand --watch .*test\\.js$",
-    "test": "AWS_ACCESS_KEY_ID=noop AWS_SECRET_ACCESS_KEY=noop FILE_UPLOAD_MODAL_TIMEOUT=1 jest --runInBand .*test\\.js$"
+    "test": "SKIP_SANITIZE=true SKIP_VIRUS_SCAN=true AWS_ACCESS_KEY_ID=noop AWS_SECRET_ACCESS_KEY=noop FILE_UPLOAD_MODAL_TIMEOUT=1 jest --runInBand .*test\\.js$"
   },
   "repository": {
     "type": "git",

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -200,7 +200,8 @@ const allUseCases = {
   refreshTokenInteractor,
   removeItemInteractor,
   runBatchProcessInteractor,
-  sanitizePdfInteractor,
+  sanitizePdfInteractor: args =>
+    process.env.SKIP_SANITIZE ? null : sanitizePdfInteractor(args),
   sendPetitionToIRSHoldingQueueInteractor,
   setCaseToReadyForTrialInteractor,
   setItemInteractor,
@@ -232,7 +233,8 @@ const allUseCases = {
   validateTrialSessionInteractor,
   verifyCaseForUserInteractor,
   verifyPendingCaseForUserInteractor,
-  virusScanPdfInteractor,
+  virusScanPdfInteractor: args =>
+    process.env.SKIP_VIRUS_SCAN ? null : virusScanPdfInteractor(args),
 };
 tryCatchDecorator(allUseCases);
 


### PR DESCRIPTION
* The build and e2e job run times on Circle aren't evenly split anymore. Moving the integration tests back to the build job should even them out. 
* Also skip sanitize and virus scan PDF steps on UI tests.