### PR TITLE
Add grab cursor to sig element

### DIFF
--- a/web-client/src/views/PDFSigner.jsx
+++ b/web-client/src/views/PDFSigner.jsx
@@ -151,6 +151,11 @@ class PDFSignerComponent extends React.Component {
                 <div className="grid-col-8">
                   <div className="sign-pdf-interface">
                     <span
+                      className={
+                        !this.props.signatureData && this.state.signatureApplied
+                          ? 'cursor-grab'
+                          : ''
+                      }
                       id="signature"
                       ref={this.signatureRef}
                       style={{


### PR DESCRIPTION
In addition to adding the grab cursor to the canvas, we need to add it to the signature element as the element will fall between the cursor and canvas causing the cursor to switch back to default.