### PR TITLE
Move pdf preview link to component with modal

### DIFF
--- a/web-client/src/views/FileDocument/PrimaryDocumentReadOnly.jsx
+++ b/web-client/src/views/FileDocument/PrimaryDocumentReadOnly.jsx
@@ -3,23 +3,15 @@ import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
 
-import { PDFPreviewModal } from '../PDFPreviewModal';
+import { PDFPreviewButton } from '../PDFPreviewButton';
 
 export const PrimaryDocumentReadOnly = connect(
   {
     chooseWizardStepSequence: sequences.chooseWizardStepSequence,
     fileDocumentHelper: state.fileDocumentHelper,
     form: state.form,
-    openPdfPreviewModalSequence: sequences.openPdfPreviewModalSequence,
-    showModal: state.showModal,
   },
-  ({
-    chooseWizardStepSequence,
-    fileDocumentHelper,
-    form,
-    openPdfPreviewModalSequence,
-    showModal,
-  }) => {
+  ({ chooseWizardStepSequence, fileDocumentHelper, form }) => {
     return (
       <React.Fragment>
         <div>
@@ -44,15 +36,7 @@ export const PrimaryDocumentReadOnly = connect(
               {form.documentTitle}
             </label>
             <FontAwesomeIcon icon={['fas', 'file-pdf']} />
-            <button
-              className="usa-button usa-button--unstyled"
-              type="button"
-              onClick={() =>
-                openPdfPreviewModalSequence({ file: form.primaryDocumentFile })
-              }
-            >
-              {form.primaryDocumentFile.name}
-            </button>
+            <PDFPreviewButton file={form.primaryDocumentFile} />
           </div>
 
           {form.supportingDocumentFile && (
@@ -114,9 +98,6 @@ export const PrimaryDocumentReadOnly = connect(
             </div>
           )}
         </div>
-        {showModal === 'PDFPreviewModal' && (
-          <PDFPreviewModal pdfFile={form.primaryDocumentFile} />
-        )}
       </React.Fragment>
     );
   },

--- a/web-client/src/views/PDFPreviewButton.jsx
+++ b/web-client/src/views/PDFPreviewButton.jsx
@@ -1,0 +1,26 @@
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+import { PDFPreviewModal } from './PDFPreviewModal';
+
+export const PDFPreviewButton = connect(
+  {
+    openPdfPreviewModalSequence: sequences.openPdfPreviewModalSequence,
+    showModal: state.showModal,
+  },
+  ({ file, openPdfPreviewModalSequence, showModal }) => {
+    return (
+      <>
+        <button
+          className="usa-button usa-button--unstyled"
+          type="button"
+          onClick={() => openPdfPreviewModalSequence({ file })}
+        >
+          {file.name}
+        </button>
+        {showModal === 'PDFPreviewModal' && <PDFPreviewModal pdfFile={file} />}
+      </>
+    );
+  },
+);


### PR DESCRIPTION
Small refactor replaces the preview button with a component that also contains the modal / cerebral deps for preview. This makes our current review screens easier to refactor.