### PR TITLE
1508: UX fixes

### DIFF
--- a/web-client/src/presenter/computeds/fileDocumentHelper.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.js
@@ -71,9 +71,15 @@ export const fileDocumentHelper = (get, applicationContext) => {
   const showAddSupportingDocuments =
     !form.supportingDocumentCount || form.supportingDocumentCount < 5;
 
+  const showSecondaryDocumentInclusionsForm =
+    form.documentType !== 'Motion for Leave to File' ||
+    !!form.secondaryDocumentFile;
+
   const showAddSecondarySupportingDocuments =
-    !form.secondarySupportingDocumentCount ||
-    form.secondarySupportingDocumentCount < 5;
+    (!form.secondarySupportingDocumentCount ||
+      form.secondarySupportingDocumentCount < 5) &&
+    (form.documentType !== 'Motion for Leave to File' ||
+      !!form.secondaryDocumentFile);
 
   let exported = {
     certificateOfServiceDateFormatted,
@@ -94,6 +100,7 @@ export const fileDocumentHelper = (get, applicationContext) => {
     showFilingIncludes,
     showPractitionerParty,
     showPrimaryDocumentValid: !!form.primaryDocumentFile,
+    showSecondaryDocumentInclusionsForm,
     showSecondaryDocumentValid: !!form.secondaryDocumentFile,
     showSecondaryFilingIncludes,
     showSecondaryParty,

--- a/web-client/src/presenter/computeds/fileDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.test.js
@@ -70,6 +70,21 @@ describe('fileDocumentHelper', () => {
     expect(result.isSecondaryDocumentUploadOptional).toBeTruthy();
   });
 
+  it('does not show secondary inclusions if document type is motion for leave to file and a secondary document has not been selected', async () => {
+    state.form = { documentType: 'Motion for Leave to File' };
+    const result = await runCompute(fileDocumentHelper, { state });
+    expect(result.showSecondaryDocumentInclusionsForm).toBeFalsy();
+  });
+
+  it('shows secondary inclusions if document type is motion for leave to file and a secondary document has been selected', async () => {
+    state.form = {
+      documentType: 'Motion for Leave to File',
+      secondaryDocumentFile: 'something',
+    };
+    const result = await runCompute(fileDocumentHelper, { state });
+    expect(result.showSecondaryDocumentInclusionsForm).toBeTruthy();
+  });
+
   it('shows primary objection if primary document type is a motion', async () => {
     state.form = { documentType: 'Motion for Leave to File' };
     const result = await runCompute(fileDocumentHelper, { state });
@@ -292,6 +307,12 @@ describe('fileDocumentHelper', () => {
       it('shows Add Secondary Supporting Document button when secondarySupportingDocumentCount is undefined', async () => {
         const result = await runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeTruthy();
+      });
+
+      it('does not show Add Secondary Supporting Document button when primary document type is Motion for Leave to File and secondary file is not selected', async () => {
+        state.form.documentType = 'Motion for Leave to File';
+        const result = await runCompute(fileDocumentHelper, { state });
+        expect(result.showAddSecondarySupportingDocuments).toBeFalsy();
       });
 
       it('shows Add Secondary Supporting Document button when secondarySupportingDocumentCount is less than 5', async () => {

--- a/web-client/src/views/FileDocument/FileDocumentReviewRedesign.jsx
+++ b/web-client/src/views/FileDocument/FileDocumentReviewRedesign.jsx
@@ -53,7 +53,7 @@ export const FileDocumentReviewRedesign = connect(
                   <h3 className="underlined">Your Document(s)</h3>
                   <div className="grid-row grid-gap">
                     <div className="tablet:grid-col-6 margin-bottom-1">
-                      <div className="margin-bottom-1">
+                      <div className="tablet:margin-bottom-0 margin-bottom-205">
                         <label className="usa-label" htmlFor="primary-filing">
                           {form.documentTitle}
                         </label>
@@ -118,27 +118,29 @@ export const FileDocumentReviewRedesign = connect(
                       <React.Fragment key={idx}>
                         <div className="grid-row grid-gap overline padding-top-105 margin-top-105">
                           <div className="tablet:grid-col-6 margin-bottom-1">
-                            <label
-                              className="usa-label"
-                              htmlFor={`supporting-documents-${idx}`}
-                            >
-                              {item.supportingDocumentMetadata.documentTitle}
-                            </label>
-                            <div className="grid-row">
-                              <div className="grid-col flex-auto">
-                                <FontAwesomeIcon
-                                  className="fa-icon-blue"
-                                  icon={['fas', 'file-pdf']}
-                                />
-                              </div>
-                              <div className="grid-col flex-fill margin-top-neg-05">
-                                <PDFPreviewButton
-                                  file={item.supportingDocumentFile}
-                                  title={
-                                    item.supportingDocumentMetadata
-                                      .documentTitle
-                                  }
-                                />
+                            <div className="tablet:margin-bottom-0 margin-bottom-205">
+                              <label
+                                className="usa-label"
+                                htmlFor={`supporting-documents-${idx}`}
+                              >
+                                {item.supportingDocumentMetadata.documentTitle}
+                              </label>
+                              <div className="grid-row">
+                                <div className="grid-col flex-auto">
+                                  <FontAwesomeIcon
+                                    className="fa-icon-blue"
+                                    icon={['fas', 'file-pdf']}
+                                  />
+                                </div>
+                                <div className="grid-col flex-fill margin-top-neg-05">
+                                  <PDFPreviewButton
+                                    file={item.supportingDocumentFile}
+                                    title={
+                                      item.supportingDocumentMetadata
+                                        .documentTitle
+                                    }
+                                  />
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -177,38 +179,40 @@ export const FileDocumentReviewRedesign = connect(
                   {form.secondaryDocument.documentTitle && (
                     <div className="grid-row grid-gap overline padding-top-105 margin-top-105">
                       <div className="tablet:grid-col-6 margin-bottom-1">
-                        {form.secondaryDocumentFile && (
-                          <div className="">
-                            <label
-                              className="usa-label"
-                              htmlFor="secondary-filing"
-                            >
-                              {form.secondaryDocument.documentTitle}{' '}
-                            </label>
-                            {(form.secondaryDocumentFile &&
-                              form.secondaryDocumentFile.name && (
-                                <React.Fragment>
-                                  <div className="grid-row">
-                                    <div className="grid-col flex-auto">
-                                      <FontAwesomeIcon
-                                        className="fa-icon-blue"
-                                        icon={['fas', 'file-pdf']}
-                                      />
+                        <div className="tablet:margin-bottom-0 margin-bottom-205">
+                          {form.secondaryDocumentFile && (
+                            <div className="">
+                              <label
+                                className="usa-label"
+                                htmlFor="secondary-filing"
+                              >
+                                {form.secondaryDocument.documentTitle}{' '}
+                              </label>
+                              {(form.secondaryDocumentFile &&
+                                form.secondaryDocumentFile.name && (
+                                  <React.Fragment>
+                                    <div className="grid-row">
+                                      <div className="grid-col flex-auto">
+                                        <FontAwesomeIcon
+                                          className="fa-icon-blue"
+                                          icon={['fas', 'file-pdf']}
+                                        />
+                                      </div>
+                                      <div className="grid-col flex-fill margin-top-neg-05">
+                                        <PDFPreviewButton
+                                          file={form.secondaryDocumentFile}
+                                          title={
+                                            form.secondaryDocument.documentTitle
+                                          }
+                                        />
+                                      </div>
                                     </div>
-                                    <div className="grid-col flex-fill margin-top-neg-05">
-                                      <PDFPreviewButton
-                                        file={form.secondaryDocumentFile}
-                                        title={
-                                          form.secondaryDocument.documentTitle
-                                        }
-                                      />
-                                    </div>
-                                  </div>
-                                </React.Fragment>
-                              )) ||
-                              'No file attached'}
-                          </div>
-                        )}
+                                  </React.Fragment>
+                                )) ||
+                                'No file attached'}
+                            </div>
+                          )}
+                        </div>
                       </div>
                       <div className="tablet:grid-col-6 margin-bottom-1">
                         {fileDocumentHelper.showSecondaryFilingIncludes && (
@@ -261,30 +265,32 @@ export const FileDocumentReviewRedesign = connect(
                       <React.Fragment key={idx}>
                         <div className="grid-row grid-gap overline padding-top-105 margin-top-105">
                           <div className="tablet:grid-col-6 margin-bottom-1">
-                            <label
-                              className="usa-label"
-                              htmlFor={`secondary-supporting-documents-${idx}`}
-                            >
-                              {
-                                item.secondarySupportingDocumentMetadata
-                                  .documentTitle
-                              }
-                            </label>
-                            <div className="grid-row">
-                              <div className="grid-col flex-auto">
-                                <FontAwesomeIcon
-                                  className="fa-icon-blue"
-                                  icon={['fas', 'file-pdf']}
-                                />
-                              </div>
-                              <div className="grid-col flex-fill margin-top-neg-05">
-                                <PDFPreviewButton
-                                  file={item.secondarySupportingDocumentFile}
-                                  title={
-                                    item.secondarySupportingDocumentMetadata
-                                      .documentTitle
-                                  }
-                                />
+                            <div className="tablet:margin-bottom-0 margin-bottom-205">
+                              <label
+                                className="usa-label"
+                                htmlFor={`secondary-supporting-documents-${idx}`}
+                              >
+                                {
+                                  item.secondarySupportingDocumentMetadata
+                                    .documentTitle
+                                }
+                              </label>
+                              <div className="grid-row">
+                                <div className="grid-col flex-auto">
+                                  <FontAwesomeIcon
+                                    className="fa-icon-blue"
+                                    icon={['fas', 'file-pdf']}
+                                  />
+                                </div>
+                                <div className="grid-col flex-fill margin-top-neg-05">
+                                  <PDFPreviewButton
+                                    file={item.secondarySupportingDocumentFile}
+                                    title={
+                                      item.secondarySupportingDocumentMetadata
+                                        .documentTitle
+                                    }
+                                  />
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/web-client/src/views/FileDocument/SecondaryDocumentForm.jsx
+++ b/web-client/src/views/FileDocument/SecondaryDocumentForm.jsx
@@ -23,6 +23,10 @@ export const SecondaryDocumentForm = connect(
               validationErrors.secondaryDocumentFile
                 ? 'usa-form-group--error'
                 : ''
+            } ${
+              !fileDocumentHelper.showSecondaryDocumentInclusionsForm
+                ? 'margin-bottom-0'
+                : ''
             }`}
           >
             <label
@@ -61,11 +65,13 @@ export const SecondaryDocumentForm = connect(
             />
           </div>
 
-          <InclusionsForm
-            bind="form.secondaryDocument"
-            type="secondaryDocument"
-            validationBind="validationErrors.secondaryDocument"
-          />
+          {fileDocumentHelper.showSecondaryDocumentInclusionsForm && (
+            <InclusionsForm
+              bind="form.secondaryDocument"
+              type="secondaryDocument"
+              validationBind="validationErrors.secondaryDocument"
+            />
+          )}
         </div>
       </React.Fragment>
     );

--- a/web-client/src/views/FileDocument/SupportingDocumentInclusionsForm.jsx
+++ b/web-client/src/views/FileDocument/SupportingDocumentInclusionsForm.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 export const SupportingDocumentInclusionsForm = connect(
   {
     data: state[props.bind],
+    openCleanModalSequence: sequences.openCleanModalSequence,
     type: props.type,
     updateFileDocumentWizardFormValueSequence:
       sequences.updateFileDocumentWizardFormValueSequence,
@@ -17,6 +18,7 @@ export const SupportingDocumentInclusionsForm = connect(
   },
   ({
     data,
+    openCleanModalSequence,
     type,
     updateFileDocumentWizardFormValueSequence,
     validateExternalDocumentInformationSequence,
@@ -33,7 +35,14 @@ export const SupportingDocumentInclusionsForm = connect(
           <fieldset className="usa-fieldset margin-bottom-0">
             <legend id={`${type}-extra-items-legend`}>
               Select Extra Items Included With Document
-              <button className="usa-button usa-button--unstyled margin-top-2 margin-bottom-105">
+              <button
+                className="usa-button usa-button--unstyled margin-top-2 margin-bottom-105"
+                onClick={() =>
+                  openCleanModalSequence({
+                    value: 'WhatCanIIncludeModalOverlay',
+                  })
+                }
+              >
                 <FontAwesomeIcon
                   className="margin-right-05"
                   icon="question-circle"


### PR DESCRIPTION
* hook up supporting doc `What Can I Include?` modal
* add margin-bottom-2 div around file area on review page for supporting docs on mobile (margin-bottom-0 on desktop)
* hide inclusions and Add Secondary Supporting button on secondary doc unless they upload a doc for optional (only for Motion for Leave to File)