### PR TITLE
1566 - allow scrolling for the preview modal

### DIFF
--- a/web-client/src/views/ModalDialog.jsx
+++ b/web-client/src/views/ModalDialog.jsx
@@ -14,15 +14,20 @@ export class ModalDialog extends React.Component {
 
     this.modal = {};
     this.preventCancelOnBlur = !!this.props.preventCancelOnBlur;
+    this.preventScrolling =
+      this.props.preventScrolling !== undefined
+        ? this.props.preventScrolling
+        : true;
     this.blurDialog = this.blurDialog.bind(this);
     this.keydownTriggered = this.keydownTriggered.bind(this);
     if (this.runCancelSequence) {
       this.runCancelSequence = this.runCancelSequence.bind(this);
     }
+    this.toggleNoScroll = this.toggleNoScroll.bind(this);
     this.runConfirmSequence = this.runConfirmSequence.bind(this);
   }
   toggleNoScroll(scrollingOn) {
-    if (scrollingOn) {
+    if (this.preventScrolling && scrollingOn) {
       document.body.classList.add('no-scroll');
       document.addEventListener('touchmove', this.touchmoveTriggered, {
         passive: false,
@@ -156,4 +161,5 @@ ModalDialog.propTypes = {
   confirmSequence: PropTypes.func,
   modal: PropTypes.object,
   preventCancelOnBlur: PropTypes.bool,
+  preventScrolling: PropTypes.bool,
 };

--- a/web-client/src/views/PDFPreviewButton.jsx
+++ b/web-client/src/views/PDFPreviewButton.jsx
@@ -34,7 +34,11 @@ export const PDFPreviewButton = connect(
           (pdfPreviewModalHelper.displayErrorText ? (
             <PDFPreviewErrorModal title={title} />
           ) : (
-            <PDFPreviewModal pdfFile={file} title={title} />
+            <PDFPreviewModal
+              pdfFile={file}
+              preventScrolling={false}
+              title={title}
+            />
           ))}
       </>
     );

--- a/web-client/src/views/PDFPreviewModal.jsx
+++ b/web-client/src/views/PDFPreviewModal.jsx
@@ -11,7 +11,6 @@ class PDFPreviewModalComponent extends ModalDialog {
     super(props);
     this.canvasRef = React.createRef();
     this.modalMounted = this.modalMounted.bind(this);
-
     this.modal = {
       classNames: 'pdf-preview-modal',
       confirmLabel: 'OK',


### PR DESCRIPTION
- we can't scroll on mobile or tablet due to how the modal is preventing scrolling, so I'm adding a property to allow an override to preventing the scrolling