### PR TITLE
1508: supporting document validation message updates

### DIFF
--- a/web-client/src/presenter/actions/FileDocument/setFileDocumentValidationAlertErrorsAction.js
+++ b/web-client/src/presenter/actions/FileDocument/setFileDocumentValidationAlertErrorsAction.js
@@ -1,0 +1,57 @@
+import { flattenDeep } from 'lodash';
+import { state } from 'cerebral';
+
+/**
+ * runs through the props.errors and sets the state.alertError based on which fields failed validation which is used for
+ * displaying a list of bullet point alerts in a red error alert at the top of the page.
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.props the cerebral props object used for getting the props.errors
+ * @param {object} providers.store the cerebral store used for setting state.alertError
+ * @returns {undefined} doesn't return anything
+ */
+export const setFileDocumentValidationAlertErrorsAction = ({
+  props,
+  store,
+}) => {
+  let errorKeys = Object.keys(props.errors);
+  if (props.errorDisplayOrder) {
+    errorKeys = props.errorDisplayOrder.filter(
+      key => props.errors[key] !== undefined,
+    );
+  }
+  const alertError = {
+    messages: flattenDeep(
+      errorKeys.map(key => {
+        const error = props.errors[key];
+        if (Array.isArray(error)) {
+          return error.map(subError => {
+            let subErrorKeys = Object.keys(subError).filter(
+              key => key !== 'index',
+            );
+            if (props.errorDisplayOrder) {
+              subErrorKeys = props.errorDisplayOrder.filter(
+                key => subError[key] !== undefined,
+              );
+            }
+            let displayKey = key;
+            if (props.errorDisplayMap) {
+              displayKey = props.errorDisplayMap[key];
+            }
+            return subErrorKeys.map(subErrorKey => {
+              return `${displayKey} #${subError.index + 1} - ${
+                subError[subErrorKey]
+              }`;
+            });
+          });
+        } else if (typeof error === 'object') {
+          return Object.keys(error).map(k => error[k]);
+        } else {
+          return error;
+        }
+      }),
+    ),
+    title: 'Please correct the following errors on the page:',
+  };
+  store.set(state.alertError, alertError);
+};

--- a/web-client/src/presenter/actions/FileDocument/setFileDocumentValidationAlertErrorsAction.test.js
+++ b/web-client/src/presenter/actions/FileDocument/setFileDocumentValidationAlertErrorsAction.test.js
@@ -1,0 +1,54 @@
+import { presenter } from '../../presenter';
+import { runAction } from 'cerebral/test';
+import { setFileDocumentValidationAlertErrorsAction } from './setFileDocumentValidationAlertErrorsAction';
+
+describe('setFileDocumentValidationAlertErrors', () => {
+  it('creates messages for errors with nested objects in correct order with correct display text', async () => {
+    const { state } = await runAction(
+      setFileDocumentValidationAlertErrorsAction,
+      {
+        modules: {
+          presenter,
+        },
+        props: {
+          errorDisplayMap: {
+            supportingDocuments: 'Supporting Document',
+          },
+          errorDisplayOrder: [
+            'supportingDocument',
+            'supportingDocumentFreeText',
+            'primaryDocumentFile',
+            'certificateOfServiceDate',
+            'supportingDocuments',
+          ],
+          errors: {
+            certificateOfServiceDate: 'Enter a Certificate of Service Date.',
+            primaryDocumentFile: 'A file was not selected.',
+            supportingDocuments: [
+              {
+                index: 0,
+                supportingDocument: 'Enter selection for Supporting Document.',
+              },
+              {
+                certificateOfServiceDate:
+                  'Enter a Certificate of Service Date.',
+                index: 2,
+                supportingDocumentFreeText: 'Please provide a value.',
+              },
+            ],
+          },
+        },
+        state: {},
+      },
+    );
+    expect(state.alertError).toMatchObject({
+      messages: [
+        'A file was not selected.',
+        'Enter a Certificate of Service Date.',
+        'Supporting Document #1 - Enter selection for Supporting Document.',
+        'Supporting Document #3 - Please provide a value.',
+        'Supporting Document #3 - Enter a Certificate of Service Date.',
+      ],
+    });
+  });
+});

--- a/web-client/src/presenter/actions/FileDocument/validateExternalDocumentInformationAction.js
+++ b/web-client/src/presenter/actions/FileDocument/validateExternalDocumentInformationAction.js
@@ -28,6 +28,9 @@ export const validateExternalDocumentInformationAction = ({
     return path.success();
   } else {
     const errorDisplayOrder = [
+      'supportingDocument',
+      'supportingDocumentFreeText',
+      'supportingDocumentFile',
       'primaryDocumentFile',
       'certificateOfService',
       'certificateOfServiceDate',
@@ -43,10 +46,16 @@ export const validateExternalDocumentInformationAction = ({
       'partyRespondent',
     ];
 
+    const errorDisplayMap = {
+      secondarySupportingDocuments: 'Secondary Supporting Document',
+      supportingDocuments: 'Supporting Document',
+    };
+
     return path.error({
       alertError: {
         title: 'Errors were found. Please correct your form and resubmit.',
       },
+      errorDisplayMap,
       errorDisplayOrder,
       errors,
     });

--- a/web-client/src/presenter/sequences/reviewExternalDocumentInformationSequence.js
+++ b/web-client/src/presenter/sequences/reviewExternalDocumentInformationSequence.js
@@ -4,8 +4,8 @@ import { generateTitleAction } from '../actions/FileDocument/generateTitleAction
 import { navigateToReviewFileADocumentAction } from '../actions/FileDocument/navigateToReviewFileADocumentAction';
 import { set } from 'cerebral/factories';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
+import { setFileDocumentValidationAlertErrorsAction } from '../actions/FileDocument/setFileDocumentValidationAlertErrorsAction';
 import { setSupportingDocumentScenarioAction } from '../actions/FileDocument/setSupportingDocumentScenarioAction';
-import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { state } from 'cerebral';
 import { validateExternalDocumentInformationAction } from '../actions/FileDocument/validateExternalDocumentInformationAction';
@@ -19,7 +19,7 @@ export const reviewExternalDocumentInformationSequence = [
     error: [
       setAlertErrorAction,
       setValidationErrorsAction,
-      setValidationAlertErrorsAction,
+      setFileDocumentValidationAlertErrorsAction,
     ],
     success: [
       setSupportingDocumentScenarioAction,

--- a/web-client/src/views/FileDocument/SecondarySupportingDocumentForm.jsx
+++ b/web-client/src/views/FileDocument/SecondarySupportingDocumentForm.jsx
@@ -36,6 +36,7 @@ export const SecondarySupportingDocumentForm = connect(
           <div
             className={`usa-form-group ${
               validationErrors.secondarySupportingDocuments &&
+              validationErrors.secondarySupportingDocuments[index] &&
               validationErrors.secondarySupportingDocuments[index]
                 .supportingDocument
                 ? 'usa-form-group--error'
@@ -57,6 +58,7 @@ export const SecondarySupportingDocumentForm = connect(
               aria-describedby={`secondary-supporting-document-${index}-label`}
               className={`usa-select ${
                 validationErrors.secondarySupportingDocuments &&
+                validationErrors.secondarySupportingDocuments[index] &&
                 validationErrors.secondarySupportingDocuments[index]
                   .supportingDocument
                   ? 'usa-select--error'
@@ -108,6 +110,7 @@ export const SecondarySupportingDocumentForm = connect(
             <div
               className={`usa-form-group ${
                 validationErrors.secondarySupportingDocuments &&
+                validationErrors.secondarySupportingDocuments[index] &&
                 validationErrors.secondarySupportingDocuments[index]
                   .supportingDocumentFreeText
                   ? 'usa-form-group--error'
@@ -159,6 +162,7 @@ export const SecondarySupportingDocumentForm = connect(
               <div
                 className={`usa-form-group ${
                   validationErrors.secondarySupportingDocuments &&
+                  validationErrors.secondarySupportingDocuments[index] &&
                   validationErrors.secondarySupportingDocuments[index]
                     .supportingDocumentFile
                     ? 'usa-form-group--error'

--- a/web-client/src/views/FileDocument/SupportingDocumentForm.jsx
+++ b/web-client/src/views/FileDocument/SupportingDocumentForm.jsx
@@ -34,6 +34,7 @@ export const SupportingDocumentForm = connect(
           <div
             className={`usa-form-group ${
               validationErrors.supportingDocuments &&
+              validationErrors.supportingDocuments[index] &&
               validationErrors.supportingDocuments[index].supportingDocument
                 ? 'usa-form-group--error '
                 : ''
@@ -54,6 +55,7 @@ export const SupportingDocumentForm = connect(
               aria-describedby={`supporting-document-${index}-label`}
               className={`usa-select ${
                 validationErrors.supportingDocuments &&
+                validationErrors.supportingDocuments[index] &&
                 validationErrors.supportingDocuments[index].supportingDocument
                   ? 'usa-select--error'
                   : ''
@@ -101,6 +103,7 @@ export const SupportingDocumentForm = connect(
             <div
               className={`usa-form-group ${
                 validationErrors.supportingDocuments &&
+                validationErrors.supportingDocuments[index] &&
                 validationErrors.supportingDocuments[index]
                   .supportingDocumentFreeText
                   ? 'usa-form-group--error'
@@ -152,6 +155,7 @@ export const SupportingDocumentForm = connect(
               <div
                 className={`usa-form-group ${
                   validationErrors.supportingDocuments &&
+                  validationErrors.supportingDocuments[index] &&
                   validationErrors.supportingDocuments[index]
                     .supportingDocumentFile
                     ? 'usa-form-group--error'
@@ -194,7 +198,7 @@ export const SupportingDocumentForm = connect(
               <SupportingDocumentInclusionsForm
                 bind={`form.supportingDocuments.${index}`}
                 type={`supportingDocuments.${index}`}
-                validationBind={`validationErrors.supportingDocument${index}`}
+                validationBind={`validationErrors.supportingDocuments.${index}`}
               />
             </>
           )}


### PR DESCRIPTION
The error message formatting is still pending UX approval. 
`setFileDocumentValidationAlertErrorsAction.js` might be able to be combined with `setValidationAlertErrorsAction.js`, but that will change the validation errors throughout the app. I'm not sure if we are using nested validation errors anywhere else yet, or if we want to commit to this formatting everywhere. 
<img width="652" alt="Screen Shot 2019-07-19 at 7 16 41 AM" src="https://user-images.githubusercontent.com/43251054/61535990-31dc9000-a9f9-11e9-8ada-e812518be552.png">
