### PR TITLE
1508: more UX fixes

### DIFF
--- a/web-client/src/presenter/computeds/fileDocumentHelper.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.js
@@ -71,6 +71,9 @@ export const fileDocumentHelper = (get, applicationContext) => {
   const showAddSupportingDocuments =
     !form.supportingDocumentCount || form.supportingDocumentCount < 5;
 
+  const showAddSupportingDocumentsLimitReached =
+    form.supportingDocumentCount && form.supportingDocumentCount >= 5;
+
   const showSecondaryDocumentInclusionsForm =
     form.documentType !== 'Motion for Leave to File' ||
     !!form.secondaryDocumentFile;
@@ -80,6 +83,10 @@ export const fileDocumentHelper = (get, applicationContext) => {
       form.secondarySupportingDocumentCount < 5) &&
     (form.documentType !== 'Motion for Leave to File' ||
       !!form.secondaryDocumentFile);
+
+  const showAddSecondarySupportingDocumentsLimitReached =
+    form.secondarySupportingDocumentCount &&
+    form.secondarySupportingDocumentCount >= 5;
 
   let exported = {
     certificateOfServiceDateFormatted,
@@ -96,7 +103,9 @@ export const fileDocumentHelper = (get, applicationContext) => {
         objectionDocumentTypes.includes(form.secondaryDocument.documentType),
     },
     showAddSecondarySupportingDocuments,
+    showAddSecondarySupportingDocumentsLimitReached,
     showAddSupportingDocuments,
+    showAddSupportingDocumentsLimitReached,
     showFilingIncludes,
     showPractitionerParty,
     showPrimaryDocumentValid: !!form.primaryDocumentFile,

--- a/web-client/src/presenter/computeds/fileDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.test.js
@@ -220,20 +220,20 @@ describe('fileDocumentHelper', () => {
       state.form.hasSecondarySupportingDocuments = true;
     });
 
-    it('shows Add Supporting Document button and not limit reached message when supportingDocumentCount is undefined', async () => {
+    it('shows Add Supporting Document button and not limit reached message when supportingDocumentCount is undefined', () => {
       const result = runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeTruthy();
       expect(result.showAddSupportingDocumentsLimitReached).toBeFalsy();
     });
 
-    it('shows Add Supporting Document button and not limit reached message when supportingDocumentCount is less than 5', async () => {
+    it('shows Add Supporting Document button and not limit reached message when supportingDocumentCount is less than 5', () => {
       state.form.supportingDocumentCount = 4;
       const result = runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeTruthy();
       expect(result.showAddSupportingDocumentsLimitReached).toBeFalsy();
     });
 
-    it('does not show Add Supporting Document button and shows limit reached message when supportingDocumentCount is 5 or greater', async () => {
+    it('does not show Add Supporting Document button and shows limit reached message when supportingDocumentCount is 5 or greater', () => {
       state.form.supportingDocumentCount = 5;
       let result = runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeFalsy();
@@ -302,7 +302,7 @@ describe('fileDocumentHelper', () => {
     });
 
     describe('for secondary supporting document', () => {
-      it('shows Add Secondary Supporting Document button and not limit reached message when secondarySupportingDocumentCount is undefined', async () => {
+      it('shows Add Secondary Supporting Document button and not limit reached message when secondarySupportingDocumentCount is undefined', () => {
         const result = runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeTruthy();
         expect(
@@ -310,7 +310,7 @@ describe('fileDocumentHelper', () => {
         ).toBeFalsy();
       });
 
-      it('does not show Add Secondary Supporting Document button or limit reached message when primary document type is Motion for Leave to File and secondary file is not selected', async () => {
+      it('does not show Add Secondary Supporting Document button or limit reached message when primary document type is Motion for Leave to File and secondary file is not selected', () => {
         state.form.documentType = 'Motion for Leave to File';
         const result = runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeFalsy();
@@ -319,7 +319,7 @@ describe('fileDocumentHelper', () => {
         ).toBeFalsy();
       });
 
-      it('shows Add Secondary Supporting Document button and not limit reached message when secondarySupportingDocumentCount is less than 5', async () => {
+      it('shows Add Secondary Supporting Document button and not limit reached message when secondarySupportingDocumentCount is less than 5', () => {
         state.form.secondarySupportingDocumentCount = 4;
         const result = runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeTruthy();
@@ -328,7 +328,7 @@ describe('fileDocumentHelper', () => {
         ).toBeFalsy();
       });
 
-      it('does not show Add Secondary Supporting Document button and shows limit reached message when secondarySupportingDocumentCount is 5 or greater', async () => {
+      it('does not show Add Secondary Supporting Document button and shows limit reached message when secondarySupportingDocumentCount is 5 or greater', () => {
         state.form.secondarySupportingDocumentCount = 5;
         let result = runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeFalsy();

--- a/web-client/src/presenter/computeds/fileDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.test.js
@@ -220,24 +220,28 @@ describe('fileDocumentHelper', () => {
       state.form.hasSecondarySupportingDocuments = true;
     });
 
-    it('shows Add Supporting Document button when supportingDocumentCount is undefined', async () => {
+    it('shows Add Supporting Document button and not limit reached message when supportingDocumentCount is undefined', async () => {
       const result = await runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeTruthy();
+      expect(result.showAddSupportingDocumentsLimitReached).toBeFalsy();
     });
 
-    it('shows Add Supporting Document button when supportingDocumentCount is less than 5', async () => {
+    it('shows Add Supporting Document button and not limit reached message when supportingDocumentCount is less than 5', async () => {
       state.form.supportingDocumentCount = 4;
       const result = await runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeTruthy();
+      expect(result.showAddSupportingDocumentsLimitReached).toBeFalsy();
     });
 
-    it('does not show Add Supporting Document button when supportingDocumentCount is 5 or greater', async () => {
+    it('does not show Add Supporting Document button and shows limit reached message when supportingDocumentCount is 5 or greater', async () => {
       state.form.supportingDocumentCount = 5;
       let result = await runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeFalsy();
+      expect(result.showAddSupportingDocumentsLimitReached).toBeTruthy();
       state.form.supportingDocumentCount = 6;
       result = await runCompute(fileDocumentHelper, { state });
       expect(result.showAddSupportingDocuments).toBeFalsy();
+      expect(result.showAddSupportingDocumentsLimitReached).toBeTruthy();
     });
 
     it('upload and free text not shown if no type selected', async () => {
@@ -298,30 +302,45 @@ describe('fileDocumentHelper', () => {
     });
 
     describe('for secondary supporting document', () => {
-      it('shows Add Secondary Supporting Document button when secondarySupportingDocumentCount is undefined', async () => {
+      it('shows Add Secondary Supporting Document button and not limit reached message when secondarySupportingDocumentCount is undefined', async () => {
         const result = await runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeTruthy();
+        expect(
+          result.showAddSecondarySupportingDocumentsLimitReached,
+        ).toBeFalsy();
       });
 
-      it('does not show Add Secondary Supporting Document button when primary document type is Motion for Leave to File and secondary file is not selected', async () => {
+      it('does not show Add Secondary Supporting Document button or limit reached message when primary document type is Motion for Leave to File and secondary file is not selected', async () => {
         state.form.documentType = 'Motion for Leave to File';
         const result = await runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeFalsy();
+        expect(
+          result.showAddSecondarySupportingDocumentsLimitReached,
+        ).toBeFalsy();
       });
 
-      it('shows Add Secondary Supporting Document button when secondarySupportingDocumentCount is less than 5', async () => {
+      it('shows Add Secondary Supporting Document button and not limit reached message when secondarySupportingDocumentCount is less than 5', async () => {
         state.form.secondarySupportingDocumentCount = 4;
         const result = await runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeTruthy();
+        expect(
+          result.showAddSecondarySupportingDocumentsLimitReached,
+        ).toBeFalsy();
       });
 
-      it('does not show Add Secondary Supporting Document button when secondarySupportingDocumentCount is 5 or greater', async () => {
+      it('does not show Add Secondary Supporting Document button and shows limit reached message when secondarySupportingDocumentCount is 5 or greater', async () => {
         state.form.secondarySupportingDocumentCount = 5;
         let result = await runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeFalsy();
+        expect(
+          result.showAddSecondarySupportingDocumentsLimitReached,
+        ).toBeTruthy();
         state.form.secondarySupportingDocumentCount = 6;
         result = await runCompute(fileDocumentHelper, { state });
         expect(result.showAddSecondarySupportingDocuments).toBeFalsy();
+        expect(
+          result.showAddSecondarySupportingDocumentsLimitReached,
+        ).toBeTruthy();
       });
 
       it('upload and free text not shown if no type selected', async () => {

--- a/web-client/src/styles/buttons.scss
+++ b/web-client/src/styles/buttons.scss
@@ -40,6 +40,10 @@
     padding: 0.75rem 1.25rem;
     text-align: center;
   }
+
+  &.ustc-button--mobile-inline {
+    width: auto;
+  }
 }
 
 .button-switch-box {
@@ -83,7 +87,5 @@
 }
 
 #init-file-petition {
-  //float: left;
-  //text-align: left;
   margin-right: 0;
 }

--- a/web-client/src/views/FileDocument/FileDocumentReviewRedesign.jsx
+++ b/web-client/src/views/FileDocument/FileDocumentReviewRedesign.jsx
@@ -325,14 +325,16 @@ export const FileDocumentReviewRedesign = connect(
                         Filing Parties
                       </label>
                       <ul className="ustc-unstyled-list without-margins">
-                        {form.partyPractitioner && (
-                          <li>Myself as Petitioner’s Counsel</li>
-                        )}
                         {form.partyPrimary && (
-                          <li>{caseDetail.contactPrimary.name}</li>
+                          <li>{caseDetail.contactPrimary.name}, Petitioner</li>
                         )}
                         {form.partySecondary && (
-                          <li>{caseDetail.contactSecondary.name}</li>
+                          <li>
+                            {caseDetail.contactSecondary.name}, Petitioner
+                          </li>
+                        )}
+                        {form.partyPractitioner && (
+                          <li>{caseDetail.practitioners[0].name}, Counsel</li>
                         )}
                         {form.partyRespondent && <li>Respondent</li>}
                       </ul>

--- a/web-client/src/views/FileDocument/SecondarySupportingDocuments.jsx
+++ b/web-client/src/views/FileDocument/SecondarySupportingDocuments.jsx
@@ -34,6 +34,13 @@ export const SecondarySupportingDocuments = connect(
             Add Secondary Supporting Document
           </button>
         )}
+
+        {fileDocumentHelper.showAddSecondarySupportingDocumentsLimitReached && (
+          <p>
+            You can only add 5 supporting documents at a time. You may file
+            another supporting document in a separate filing.
+          </p>
+        )}
       </>
     );
   },

--- a/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
+++ b/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
@@ -59,7 +59,7 @@ export const StateDrivenFileInput = connect(
           <div>
             <span className="mr-1">{form[name].name}</span>
             <button
-              className="usa-button usa-button--unstyled margin-left-1"
+              className="usa-button usa-button--unstyled ustc-button--mobile-inline margin-left-1"
               onClick={() => {
                 updateFormValueSequence({
                   key: name,

--- a/web-client/src/views/FileDocument/SupportingDocuments.jsx
+++ b/web-client/src/views/FileDocument/SupportingDocuments.jsx
@@ -34,6 +34,13 @@ export const SupportingDocuments = connect(
             Add Supporting Document
           </button>
         )}
+
+        {fileDocumentHelper.showAddSupportingDocumentsLimitReached && (
+          <p>
+            You can only add 5 supporting documents at a time. You may file
+            another supporting document in a separate filing.
+          </p>
+        )}
       </>
     );
   },


### PR DESCRIPTION
* change document button next to uploaded files on doc form needs to be inline on mobile
* add text to replace button if they add 5 supporting docs - "You can only add 5 supporting documents at a time. You may file another supporting document in a separate filing."
* add , Petitioner to parties on review page (display the same as on File a Doc form page for all parties)
  * note that this is only working for a single practitioner right now - will modify functionality for multiple practitioners as a separate task