### PR TITLE
Refactor journey tests to only check validation messages when necessary

### DIFF
--- a/web-client/integration-tests/journey/docketClerkAddsDocketEntries.js
+++ b/web-client/integration-tests/journey/docketClerkAddsDocketEntries.js
@@ -20,13 +20,13 @@ export default (test, fakeFile) => {
       docketNumber: test.docketNumber,
     });
 
-    expect(test.getState('validationErrors')).toEqual({
-      dateReceived: 'Enter date received.',
-      documentType: 'Select a Document Type.',
-      eventCode: 'Select a document type.',
-      partyPrimary: 'Select a filing party.',
-      primaryDocumentFile: 'A file was not selected.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'dateReceived',
+      'documentType',
+      'eventCode',
+      'partyPrimary',
+      'primaryDocumentFile',
+    ]);
 
     //primary document
     await test.runSequence('updateDocketEntryFormValueSequence', {
@@ -70,11 +70,11 @@ export default (test, fakeFile) => {
       docketNumber: test.docketNumber,
     });
 
-    expect(test.getState('validationErrors')).toEqual({
-      objections: 'Enter selection for Objections.',
-      secondaryDocument: 'Select a document.',
-      secondaryDocumentFile: 'A file was not selected.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'objections',
+      'secondaryDocument',
+      'secondaryDocumentFile',
+    ]);
 
     await test.runSequence('updateDocketEntryFormValueSequence', {
       key: 'objections',

--- a/web-client/integration-tests/journey/docketClerkCreatesATrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkCreatesATrialSession.js
@@ -6,14 +6,14 @@ export default (test, overrides = {}) => {
 
     await test.runSequence('submitTrialSessionSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      maxCases: 'Enter the maximum number of cases allowed for this session.',
-      sessionType: 'Session type is required.',
-      startDate: 'Date must be in correct format.',
-      term: 'Term session is not valid.',
-      termYear: 'Term year is required.',
-      trialLocation: 'Trial Location is required.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'maxCases',
+      'sessionType',
+      'startDate',
+      'term',
+      'termYear',
+      'trialLocation',
+    ]);
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
       key: 'maxCases',
@@ -47,11 +47,17 @@ export default (test, overrides = {}) => {
 
     await test.runSequence('validateTrialSessionSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      startDate: 'Term session is not valid.',
-      term: 'Term session is not valid.',
-      trialLocation: 'Trial Location is required.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'startDate',
+      'term',
+      'trialLocation',
+    ]);
+    expect(test.getState('validationErrors').startDate).toEqual(
+      'Term session is not valid.',
+    );
+    expect(test.getState('validationErrors').term).toEqual(
+      'Term session is not valid.',
+    );
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
       key: 'month',

--- a/web-client/integration-tests/journey/docketClerkForwardWorkItem.js
+++ b/web-client/integration-tests/journey/docketClerkForwardWorkItem.js
@@ -24,7 +24,7 @@ export default test => {
 
     expect(
       test.getState(`validationErrors.${test.workItemId}.assigneeId`),
-    ).toEqual('Recipient is required.');
+    ).toBeDefined();
 
     await test.runSequence('updateForwardFormValueSequence', {
       form: `form.${test.workItemId}`,

--- a/web-client/integration-tests/journey/docketClerkStartsNewMessageThreadOnAnswer.js
+++ b/web-client/integration-tests/journey/docketClerkStartsNewMessageThreadOnAnswer.js
@@ -9,11 +9,11 @@ export default test => {
 
     await test.runSequence('createWorkItemSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      assigneeId: 'Recipient is required.',
-      message: 'Message is required.',
-      section: 'Section is required.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'assigneeId',
+      'message',
+      'section',
+    ]);
 
     await test.runSequence('updateFormValueSequence', {
       key: 'section',

--- a/web-client/integration-tests/journey/docketClerkStartsNewMessageThreadOnStipulatedDecisionToSeniorAttorney.js
+++ b/web-client/integration-tests/journey/docketClerkStartsNewMessageThreadOnStipulatedDecisionToSeniorAttorney.js
@@ -9,11 +9,11 @@ export default test => {
 
     await test.runSequence('createWorkItemSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      assigneeId: 'Recipient is required.',
-      message: 'Message is required.',
-      section: 'Section is required.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'assigneeId',
+      'message',
+      'section',
+    ]);
 
     await test.runSequence('updateFormValueSequence', {
       key: 'section',

--- a/web-client/integration-tests/journey/petitionsClerkAddsOrderToCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkAddsOrderToCase.js
@@ -4,11 +4,11 @@ export default test => {
 
     await test.runSequence('submitCreateOrderModalSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      documentTitle: 'Order title is required.',
-      documentType: 'Order type is required.',
-      eventCode: 'Order type is required.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'documentTitle',
+      'documentType',
+      'eventCode',
+    ]);
 
     await test.runSequence('updateCreateOrderModalFormValueSequence', {
       key: 'eventCode',

--- a/web-client/integration-tests/journey/petitionsClerkCreatesACaseDeadline.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesACaseDeadline.js
@@ -11,10 +11,10 @@ export default (test, overrides = {}) => {
 
     await test.runSequence('createCaseDeadlineSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      deadlineDate: 'Please enter a valid deadline date.',
-      description: 'Please enter a description.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'deadlineDate',
+      'description',
+    ]);
 
     await test.runSequence('updateFormValueSequence', {
       key: 'description',

--- a/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
@@ -7,17 +7,14 @@ export default (test, fakeFile) => {
       'Please correct the following errors on the page:',
     );
 
-    expect(test.getState('validationErrors.caseCaption')).toEqual(
-      'Case Caption is required.',
-    );
-
-    expect(test.getState('validationErrors.receivedAt')).toEqual(
-      'Please enter a valid Date Received.',
-    );
-
-    expect(test.getState('validationErrors.petitionFile')).toEqual(
-      'The Petition file was not selected.',
-    );
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'caseCaption',
+      'caseType',
+      'partyType',
+      'petitionFile',
+      'procedureType',
+      'receivedAt',
+    ]);
 
     await test.runSequence('updateFormValueSequence', {
       key: 'month',

--- a/web-client/integration-tests/journey/petitionsClerkDeletesCaseDeadline.js
+++ b/web-client/integration-tests/journey/petitionsClerkDeletesCaseDeadline.js
@@ -1,7 +1,7 @@
 import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
 
-export default (test, overrides = {}) => {
+export default test => {
   return it('Petitions clerk deletes a case deadline', async () => {
     test.setState('caseDetail', {});
     await test.runSequence('gotoCaseDetailSequence', {

--- a/web-client/integration-tests/journey/practitionerRequestsAccessToCase.js
+++ b/web-client/integration-tests/journey/practitionerRequestsAccessToCase.js
@@ -6,15 +6,15 @@ export default (test, fakeFile) => {
 
     await test.runSequence('reviewRequestAccessInformationSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      documentTitleTemplate: 'Select a document.',
-      documentType: 'Select a document.',
-      eventCode: 'Select a document.',
-      primaryDocumentFile: 'A file was not selected.',
-      representingPrimary: 'Select a party.',
-      scenario: 'Select a document.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+      'documentTitleTemplate',
+      'documentType',
+      'eventCode',
+      'primaryDocumentFile',
+      'representingPrimary',
+      'scenario',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'documentType',
@@ -34,11 +34,11 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      primaryDocumentFile: 'A file was not selected.',
-      representingPrimary: 'Select a party.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+      'primaryDocumentFile',
+      'representingPrimary',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'primaryDocumentFile',
@@ -46,10 +46,10 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      representingPrimary: 'Select a party.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+      'representingPrimary',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'certificateOfService',
@@ -57,10 +57,13 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfServiceDate: 'Enter a Certificate of Service Date.',
-      representingPrimary: 'Select a party.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfServiceDate',
+      'representingPrimary',
+    ]);
+    expect(test.getState('validationErrors.certificateOfServiceDate')).toEqual(
+      'Enter a Certificate of Service Date.',
+    );
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'certificateOfServiceMonth',
@@ -76,11 +79,13 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfServiceDate:
-        'Certificate of Service date is in the future. Please enter a valid date.',
-      representingPrimary: 'Select a party.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfServiceDate',
+      'representingPrimary',
+    ]);
+    expect(test.getState('validationErrors.certificateOfServiceDate')).toEqual(
+      'Certificate of Service date is in the future. Please enter a valid date.',
+    );
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'certificateOfServiceYear',
@@ -88,9 +93,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      representingPrimary: 'Select a party.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'representingPrimary',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'representingSecondary',

--- a/web-client/integration-tests/journey/practitionerRequestsPendingAccessToCase.js
+++ b/web-client/integration-tests/journey/practitionerRequestsPendingAccessToCase.js
@@ -6,15 +6,15 @@ export default (test, fakeFile) => {
 
     await test.runSequence('reviewRequestAccessInformationSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      documentTitleTemplate: 'Select a document.',
-      documentType: 'Select a document.',
-      eventCode: 'Select a document.',
-      primaryDocumentFile: 'A file was not selected.',
-      representingPrimary: 'Select a party.',
-      scenario: 'Select a document.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+      'documentTitleTemplate',
+      'documentType',
+      'eventCode',
+      'primaryDocumentFile',
+      'representingPrimary',
+      'scenario',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'documentType',
@@ -34,15 +34,15 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      attachments: 'Enter selection for Attachments.',
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      exhibits: 'Enter selection for Exhibits.',
-      hasSupportingDocuments: 'Enter selection for Supporting Documents.',
-      objections: 'Enter selection for Objections.',
-      primaryDocumentFile: 'A file was not selected.',
-      representingPrimary: 'Select a party.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'attachments',
+      'certificateOfService',
+      'exhibits',
+      'hasSupportingDocuments',
+      'objections',
+      'primaryDocumentFile',
+      'representingPrimary',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'certificateOfService',
@@ -80,9 +80,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      supportingDocument: 'Enter selection for Supporting Document.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'supportingDocument',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'supportingDocument',
@@ -100,10 +100,10 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      supportingDocumentFile: 'A file was not selected.',
-      supportingDocumentFreeText: 'Please provide a value.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'supportingDocumentFile',
+      'supportingDocumentFreeText',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'supportingDocumentFreeText',

--- a/web-client/integration-tests/journey/respondentAddsAnswer.js
+++ b/web-client/integration-tests/journey/respondentAddsAnswer.js
@@ -6,10 +6,10 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      category: 'Select a Category.',
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'category',
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'category',
@@ -17,9 +17,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateSelectDocumentTypeSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'documentType',

--- a/web-client/integration-tests/journey/respondentAddsMotion.js
+++ b/web-client/integration-tests/journey/respondentAddsMotion.js
@@ -6,10 +6,10 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      category: 'Select a Category.',
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'category',
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'category',
@@ -17,9 +17,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateSelectDocumentTypeSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'documentType',
@@ -85,15 +85,16 @@ export default (test, fakeFile) => {
 
     await test.runSequence('reviewExternalDocumentInformationSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      objections: 'Enter selection for Objections.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocumentFile: 'Upload a document.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'objections',
+      'supportingDocuments',
+    ]);
+    expect(test.getState('validationErrors.supportingDocuments')).toEqual([
+      {
+        index: 0,
+        supportingDocumentFile: 'Upload a document.',
+      },
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'objections',

--- a/web-client/integration-tests/journey/respondentAddsStipulatedDecision.js
+++ b/web-client/integration-tests/journey/respondentAddsStipulatedDecision.js
@@ -6,10 +6,10 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      category: 'Select a Category.',
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'category',
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'category',
@@ -17,9 +17,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateSelectDocumentTypeSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'documentType',

--- a/web-client/integration-tests/journey/respondentRequestsAccessToCase.js
+++ b/web-client/integration-tests/journey/respondentRequestsAccessToCase.js
@@ -6,14 +6,14 @@ export default (test, fakeFile) => {
 
     await test.runSequence('reviewRequestAccessInformationSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      documentTitleTemplate: 'Select a document.',
-      documentType: 'Select a document.',
-      eventCode: 'Select a document.',
-      primaryDocumentFile: 'A file was not selected.',
-      scenario: 'Select a document.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+      'documentTitleTemplate',
+      'documentType',
+      'eventCode',
+      'primaryDocumentFile',
+      'scenario',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'documentType',
@@ -33,10 +33,10 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-      primaryDocumentFile: 'A file was not selected.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+      'primaryDocumentFile',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'primaryDocumentFile',
@@ -44,9 +44,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateCaseAssociationRequestSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfService: 'Enter selection for Certificate of Service.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfService',
+    ]);
 
     await test.runSequence('updateCaseAssociationFormValueSequence', {
       key: 'certificateOfService',

--- a/web-client/integration-tests/journey/taxpayerFilesDocumentForCase.js
+++ b/web-client/integration-tests/journey/taxpayerFilesDocumentForCase.js
@@ -10,10 +10,10 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      category: 'Select a Category.',
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'category',
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'category',
@@ -21,9 +21,9 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateSelectDocumentTypeSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'documentType',
@@ -51,9 +51,9 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      documentType: 'Select a Document Type.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'documentType',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'documentType',
@@ -66,12 +66,12 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      secondaryDocument: {
-        category: 'Select a Category.',
-        documentType: 'Select a Document Type.',
-      },
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'secondaryDocument',
+    ]);
+    expect(
+      Object.keys(test.getState('validationErrors.secondaryDocument')).sort(),
+    ).toEqual(['category', 'documentType']);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'secondaryDocument.category',
@@ -89,11 +89,12 @@ export default (test, fakeFile) => {
 
     await test.runSequence('selectDocumentSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      secondaryDocument: {
-        freeText: 'Provide an answer.',
-      },
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'secondaryDocument',
+    ]);
+    expect(
+      Object.keys(test.getState('validationErrors.secondaryDocument')).sort(),
+    ).toEqual(['freeText']);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'secondaryDocument.freeText',
@@ -112,11 +113,11 @@ export default (test, fakeFile) => {
 
     await test.runSequence('reviewExternalDocumentInformationSequence');
 
-    expect(test.getState('validationErrors')).toEqual({
-      objections: 'Enter selection for Objections.',
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'objections',
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'certificateOfService',
@@ -128,18 +129,19 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfServiceDate: 'Enter date for Certificate of Service.',
-      objections: 'Enter selection for Objections.',
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocument: 'Select a Document Type.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfServiceDate',
+      'objections',
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+      'supportingDocuments',
+    ]);
+    expect(test.getState('validationErrors.supportingDocuments')).toEqual([
+      {
+        index: 0,
+        supportingDocument: 'Select a Document Type.',
+      },
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'objections',
@@ -147,17 +149,23 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfServiceDate: 'Enter date for Certificate of Service.',
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocument: 'Select a Document Type.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfServiceDate',
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+      'supportingDocuments',
+    ]);
+    expect(test.getState('validationErrors.certificateOfServiceDate')).toEqual(
+      'Enter date for Certificate of Service.',
+    );
+    expect(
+      Object.keys(
+        test.getState('validationErrors.supportingDocuments.0'),
+      ).sort(),
+    ).toEqual(['index', 'supportingDocument']);
+    expect(
+      test.getState('validationErrors.supportingDocuments.0.index'),
+    ).toEqual(0);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'certificateOfServiceMonth',
@@ -173,18 +181,15 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      certificateOfServiceDate:
-        'Certificate of Service date is in the future. Please enter a valid date.',
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocument: 'Select a Document Type.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'certificateOfServiceDate',
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+      'supportingDocuments',
+    ]);
+    expect(test.getState('validationErrors.certificateOfServiceDate')).toEqual(
+      'Certificate of Service date is in the future. Please enter a valid date.',
+    );
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'certificateOfServiceYear',
@@ -192,16 +197,11 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocument: 'Select a Document Type.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+      'supportingDocuments',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'supportingDocuments.0.supportingDocument',
@@ -209,17 +209,20 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocumentFile: 'Upload a document.',
-          supportingDocumentFreeText: 'Enter name.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+      'supportingDocuments',
+    ]);
+    expect(
+      Object.keys(
+        test.getState('validationErrors.supportingDocuments.0'),
+      ).sort(),
+    ).toEqual([
+      'index',
+      'supportingDocumentFile',
+      'supportingDocumentFreeText',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'supportingDocuments.0.supportingDocumentFreeText',
@@ -227,16 +230,19 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      primaryDocumentFile: 'Upload a document.',
-      secondaryDocumentFile: 'Upload a document.',
-      supportingDocuments: [
-        {
-          index: 0,
-          supportingDocumentFile: 'Upload a document.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'primaryDocumentFile',
+      'secondaryDocumentFile',
+      'supportingDocuments',
+    ]);
+    expect(
+      Object.keys(
+        test.getState('validationErrors.supportingDocuments.0'),
+      ).sort(),
+    ).toEqual(['index', 'supportingDocumentFile']);
+    expect(
+      test.getState('validationErrors.supportingDocuments.0.index'),
+    ).toEqual(0);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'primaryDocumentFile',
@@ -259,14 +265,14 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      secondarySupportingDocuments: [
-        {
-          index: 0,
-          supportingDocument: 'Select a Document Type.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'secondarySupportingDocuments',
+    ]);
+    expect(
+      Object.keys(
+        test.getState('validationErrors.secondarySupportingDocuments.0'),
+      ).sort(),
+    ).toEqual(['index', 'supportingDocument']);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'secondarySupportingDocuments.0.supportingDocument',
@@ -274,15 +280,18 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('validateExternalDocumentInformationSequence');
-    expect(test.getState('validationErrors')).toEqual({
-      secondarySupportingDocuments: [
-        {
-          index: 0,
-          supportingDocumentFile: 'Upload a document.',
-          supportingDocumentFreeText: 'Enter name.',
-        },
-      ],
-    });
+    expect(Object.keys(test.getState('validationErrors')).sort()).toEqual([
+      'secondarySupportingDocuments',
+    ]);
+    expect(
+      Object.keys(
+        test.getState('validationErrors.secondarySupportingDocuments.0'),
+      ).sort(),
+    ).toEqual([
+      'index',
+      'supportingDocumentFile',
+      'supportingDocumentFreeText',
+    ]);
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'secondarySupportingDocuments.0.supportingDocumentFile',


### PR DESCRIPTION
Open to other opinions on whether testing the actual validation messages is useful on the journey tests. I'm trying to reduce the amount of code changes required to simply update a display message.