### PR TITLE
1448: create start case wizard

### DIFF
--- a/web-client/src/presenter/actions/StartCase/navigateToStartCaseWizardNextStepAction.js
+++ b/web-client/src/presenter/actions/StartCase/navigateToStartCaseWizardNextStepAction.js
@@ -1,0 +1,18 @@
+import { state } from 'cerebral';
+
+/**
+ * changes the route to view the file-a-document of the docketNUmber
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.router the riot.router object that is used for changing the route
+ * @param {object} providers.props the cerebral props that contain the props.caseId
+ */
+export const navigateToStartCaseWizardNextStepAction = ({
+  props,
+  router,
+  store,
+}) => {
+  const { nextStep } = props;
+  store.set(state.wizardStep, `StartCaseStep${nextStep}`);
+  router.route(`/start-a-case-wizard/step-${nextStep}`);
+};

--- a/web-client/src/presenter/actions/StartCase/navigateToStartCaseWizardNextStepAction.js
+++ b/web-client/src/presenter/actions/StartCase/navigateToStartCaseWizardNextStepAction.js
@@ -1,11 +1,13 @@
 import { state } from 'cerebral';
 
 /**
- * changes the route to view the file-a-document of the docketNUmber
+ * changes the route to the next step (the step passed in via props.nextStep)
+ * for the start case wizard
  *
  * @param {object} providers the providers object
  * @param {object} providers.router the riot.router object that is used for changing the route
- * @param {object} providers.props the cerebral props that contain the props.caseId
+ * @param {object} providers.props the cerebral props that contain the props.nextStep
+ * @param {object} providers.store the cerebral store function to store state.wizardStep
  */
 export const navigateToStartCaseWizardNextStepAction = ({
   props,

--- a/web-client/src/presenter/actions/StartCase/validateStartCaseWizardAction.js
+++ b/web-client/src/presenter/actions/StartCase/validateStartCaseWizardAction.js
@@ -1,0 +1,37 @@
+/**
+ * validates the petition.
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext the application context needed for getting the validatePetition use case
+ * @param {object} providers.path the cerebral path which contains the next path in the sequence (path of success or error)
+ * @param {object} providers.get the cerebral get function used for getting state.form
+ * @returns {object} the next path based on if validation was successful or error
+ */
+export const validateStartCaseWizardAction = ({ path }) => {
+  /*const petition = get(state.petition);
+
+  const form = omit(
+    {
+      ...get(state.form),
+    },
+    ['year', 'month', 'day', 'trialCities'],
+  );
+
+  const errors = applicationContext.getUseCases().validatePetitionInteractor({
+    applicationContext,
+    petition: { ...petition, ...form },
+  });*/
+
+  const errors = null;
+
+  if (!errors) {
+    return path.success();
+  } else {
+    return path.error({
+      alertError: {
+        title: 'Errors were found. Please correct your form and resubmit.',
+      },
+      errors,
+    });
+  }
+};

--- a/web-client/src/presenter/actions/StartCase/validateStartCaseWizardAction.js
+++ b/web-client/src/presenter/actions/StartCase/validateStartCaseWizardAction.js
@@ -1,5 +1,5 @@
 /**
- * validates the petition.
+ * validates the petition based on the current wizard step.
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context needed for getting the validatePetition use case
@@ -8,6 +8,7 @@
  * @returns {object} the next path based on if validation was successful or error
  */
 export const validateStartCaseWizardAction = ({ path }) => {
+  //TODO
   /*const petition = get(state.petition);
 
   const form = omit(

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -28,6 +28,7 @@ import { closeModalAndReturnToTrialSessionsSequence } from './sequences/closeMod
 import { completeDocumentSelectSequence } from './sequences/completeDocumentSelectSequence';
 import { completeDocumentSigningSequence } from './sequences/completeDocumentSigningSequence';
 import { completeScanSequence } from './sequences/completeScanSequence';
+import { completeStartCaseWizardStepSequence } from './sequences/completeStartCaseWizardStepSequence';
 import { confirmStayLoggedInSequence } from './sequences/confirmStayLoggedInSequence';
 import { convertHtml2PdfSequence } from './sequences/convertHtml2PdfSequence';
 import { countryTypeChangeSequence } from './sequences/countryTypeChangeSequence';
@@ -59,6 +60,7 @@ import { gotoRequestAccessSequence } from './sequences/gotoRequestAccessSequence
 import { gotoSelectDocumentTypeSequence } from './sequences/gotoSelectDocumentTypeSequence';
 import { gotoSignPDFDocumentSequence } from './sequences/gotoSignPDFDocumentSequence';
 import { gotoStartCaseSequence } from './sequences/gotoStartCaseSequence';
+import { gotoStartCaseWizardSequence } from './sequences/gotoStartCaseWizardSequence';
 import { gotoStyleGuideSequence } from './sequences/gotoStyleGuideSequence';
 import { gotoTrialSessionDetailSequence } from './sequences/gotoTrialSessionDetailSequence';
 import { gotoTrialSessionsSequence } from './sequences/gotoTrialSessionsSequence';
@@ -226,6 +228,7 @@ export const presenter = {
     completeDocumentSelectSequence,
     completeDocumentSigningSequence,
     completeScanSequence,
+    completeStartCaseWizardStepSequence,
     confirmStayLoggedInSequence,
     convertHtml2PdfSequence,
     countryTypeChangeSequence,
@@ -257,6 +260,7 @@ export const presenter = {
     gotoSelectDocumentTypeSequence,
     gotoSignPDFDocumentSequence,
     gotoStartCaseSequence,
+    gotoStartCaseWizardSequence,
     gotoStyleGuideSequence,
     gotoTrialSessionDetailSequence,
     gotoTrialSessionsSequence,

--- a/web-client/src/presenter/sequences/completeStartCaseWizardStepSequence.js
+++ b/web-client/src/presenter/sequences/completeStartCaseWizardStepSequence.js
@@ -1,0 +1,20 @@
+import { clearAlertsAction } from '../actions/clearAlertsAction';
+import { navigateToStartCaseWizardNextStepAction } from '../actions/StartCase/navigateToStartCaseWizardNextStepAction';
+import { set } from 'cerebral/factories';
+import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
+import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
+import { state } from 'cerebral';
+import { validateStartCaseWizardAction } from '../actions/StartCase/validateStartCaseWizardAction';
+
+export const completeStartCaseWizardStepSequence = [
+  set(state.showValidation, true),
+  validateStartCaseWizardAction,
+  {
+    error: [setValidationErrorsAction, setValidationAlertErrorsAction],
+    success: [
+      clearAlertsAction,
+      set(state.showValidation, false),
+      navigateToStartCaseWizardNextStepAction,
+    ],
+  },
+];

--- a/web-client/src/presenter/sequences/gotoStartCaseWizardSequence.js
+++ b/web-client/src/presenter/sequences/gotoStartCaseWizardSequence.js
@@ -1,0 +1,45 @@
+import { clearAlertsAction } from '../actions/clearAlertsAction';
+import { clearFormAction } from '../actions/clearFormAction';
+import { clearPetitionAction } from '../actions/clearPetitionAction';
+import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
+import { getCaseTypesAction } from '../actions/getCaseTypesAction';
+import { getFilingTypesAction } from '../actions/getFilingTypesAction';
+import { getProcedureTypesAction } from '../actions/getProcedureTypesAction';
+import { getUserRoleAction } from '../actions/getUserRoleAction';
+import { prepareFormAction } from '../actions/prepareFormAction';
+import { set } from 'cerebral/factories';
+import { setCaseTypesAction } from '../actions/setCaseTypesAction';
+import { setCurrentPageAction } from '../actions/setCurrentPageAction';
+import { setFilingTypesAction } from '../actions/setFilingTypesAction';
+import { setProcedureTypesAction } from '../actions/setProcedureTypesAction';
+import { state } from 'cerebral';
+
+export const gotoStartCaseWizardSequence = [
+  clearAlertsAction,
+  clearPetitionAction,
+  clearFormAction,
+  clearScreenMetadataAction,
+  prepareFormAction,
+  set(state.showValidation, false),
+  getCaseTypesAction,
+  setCaseTypesAction,
+  getProcedureTypesAction,
+  setProcedureTypesAction,
+  getUserRoleAction,
+  {
+    docketclerk: [setCurrentPageAction('StartCaseInternal')],
+    petitioner: [
+      getFilingTypesAction,
+      setFilingTypesAction,
+      set(state.wizardStep, 'StartCaseStep1'),
+      setCurrentPageAction('StartCaseWizard'),
+    ],
+    petitionsclerk: [setCurrentPageAction('StartCaseInternal')],
+    practitioner: [
+      getFilingTypesAction,
+      setFilingTypesAction,
+      set(state.wizardStep, 'StartCaseStep1'),
+      setCurrentPageAction('StartCaseWizard'),
+    ],
+  },
+];

--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -276,6 +276,58 @@ const router = {
         app.getSequence('gotoStartCaseSequence')();
       }),
     );
+    route(
+      '/start-a-case-wizard/step-1',
+      checkLoggedIn(() => {
+        document.title = `Start a case ${pageTitleSuffix}`;
+        app.getSequence('gotoStartCaseWizardSequence')();
+      }),
+    );
+    route(
+      '/start-a-case-wizard/step-2',
+      checkLoggedIn(() => {
+        document.title = `Start a case ${pageTitleSuffix}`;
+        if (app.getState('currentPage') === 'StartCaseWizard') {
+          app.getSequence('chooseWizardStepSequence')({
+            value: 'StartCaseStep2',
+          });
+        } else {
+          app.getSequence('navigateToPathSequence')({
+            path: '/start-a-case-wizard/step-1',
+          });
+        }
+      }),
+    );
+    route(
+      '/start-a-case-wizard/step-3',
+      checkLoggedIn(() => {
+        document.title = `Start a case ${pageTitleSuffix}`;
+        if (app.getState('currentPage') === 'StartCaseWizard') {
+          app.getSequence('chooseWizardStepSequence')({
+            value: 'StartCaseStep3',
+          });
+        } else {
+          app.getSequence('navigateToPathSequence')({
+            path: '/start-a-case-wizard/step-1',
+          });
+        }
+      }),
+    );
+    route(
+      '/start-a-case-wizard/step-4',
+      checkLoggedIn(() => {
+        document.title = `Start a case ${pageTitleSuffix}`;
+        if (app.getState('currentPage') === 'StartCaseWizard') {
+          app.getSequence('chooseWizardStepSequence')({
+            value: 'StartCaseStep4',
+          });
+        } else {
+          app.getSequence('navigateToPathSequence')({
+            path: '/start-a-case-wizard/step-1',
+          });
+        }
+      }),
+    );
 
     route(
       '/add-a-trial-session',

--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -277,54 +277,23 @@ const router = {
       }),
     );
     route(
-      '/start-a-case-wizard/step-1',
-      checkLoggedIn(() => {
+      '/start-a-case-wizard/step-*',
+      checkLoggedIn(step => {
         document.title = `Start a case ${pageTitleSuffix}`;
-        app.getSequence('gotoStartCaseWizardSequence')();
-      }),
-    );
-    route(
-      '/start-a-case-wizard/step-2',
-      checkLoggedIn(() => {
-        document.title = `Start a case ${pageTitleSuffix}`;
-        if (app.getState('currentPage') === 'StartCaseWizard') {
-          app.getSequence('chooseWizardStepSequence')({
-            value: 'StartCaseStep2',
-          });
-        } else {
-          app.getSequence('navigateToPathSequence')({
-            path: '/start-a-case-wizard/step-1',
-          });
-        }
-      }),
-    );
-    route(
-      '/start-a-case-wizard/step-3',
-      checkLoggedIn(() => {
-        document.title = `Start a case ${pageTitleSuffix}`;
-        if (app.getState('currentPage') === 'StartCaseWizard') {
-          app.getSequence('chooseWizardStepSequence')({
-            value: 'StartCaseStep3',
-          });
-        } else {
-          app.getSequence('navigateToPathSequence')({
-            path: '/start-a-case-wizard/step-1',
-          });
-        }
-      }),
-    );
-    route(
-      '/start-a-case-wizard/step-4',
-      checkLoggedIn(() => {
-        document.title = `Start a case ${pageTitleSuffix}`;
-        if (app.getState('currentPage') === 'StartCaseWizard') {
-          app.getSequence('chooseWizardStepSequence')({
-            value: 'StartCaseStep4',
-          });
-        } else {
-          app.getSequence('navigateToPathSequence')({
-            path: '/start-a-case-wizard/step-1',
-          });
+        switch (step) {
+          case '1':
+            app.getSequence('gotoStartCaseWizardSequence')();
+            break;
+          default:
+            if (app.getState('currentPage') === 'StartCaseWizard') {
+              app.getSequence('chooseWizardStepSequence')({
+                value: `StartCaseStep${step}`,
+              });
+            } else {
+              app.getSequence('navigateToPathSequence')({
+                path: '/start-a-case-wizard/step-1',
+              });
+            }
         }
       }),
     );

--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -26,6 +26,7 @@ import { RequestAccessWizard } from './RequestAccess/RequestAccessWizard';
 import { SelectDocumentType } from './FileDocument/SelectDocumentType';
 import { StartCase } from './StartCase';
 import { StartCaseInternal } from './StartCaseInternal';
+import { StartCaseWizard } from './StartCase/StartCaseWizard';
 import { StyleGuide } from './StyleGuide/StyleGuide';
 import { TrialSessionDetail } from './TrialSessionDetail/TrialSessionDetail';
 import { TrialSessions } from './TrialSessions/TrialSessions';
@@ -62,6 +63,7 @@ const pages = {
   SelectDocumentType,
   StartCase,
   StartCaseInternal,
+  StartCaseWizard,
   StyleGuide,
   TrialSessionDetail,
   TrialSessions,

--- a/web-client/src/views/BeforeStartingCase.jsx
+++ b/web-client/src/views/BeforeStartingCase.jsx
@@ -203,6 +203,12 @@ export const BeforeStartingCase = () => (
         <a className="usa-button margin-right-205" href="/start-a-case">
           Got It, Letʼs Start My Case
         </a>
+        <a
+          className="usa-button margin-right-205"
+          href="/start-a-case-wizard/step-1"
+        >
+          Got It, Letʼs Start My Case (New Wizard)
+        </a>
         <a className="usa-button usa-button--outline" href="/">
           Cancel
         </a>

--- a/web-client/src/views/StartCase/StartCaseStep1.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep1.jsx
@@ -1,0 +1,140 @@
+import { FileUploadErrorModal } from '../FileUploadErrorModal';
+import { FileUploadStatusModal } from '../FileUploadStatusModal';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { FormCancelModalDialog } from '../FormCancelModalDialog';
+import { Hint } from '../../ustc-ui/Hint/Hint';
+import { Text } from '../../ustc-ui/Text/Text';
+import { connect } from '@cerebral/react';
+import { limitFileSize } from '../limitFileSize';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+export const StartCaseStep1 = connect(
+  {
+    completeStartCaseWizardStepSequence:
+      sequences.completeStartCaseWizardStepSequence,
+    constants: state.constants,
+    formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
+    showModal: state.showModal,
+    startCaseHelper: state.startCaseHelper,
+    submitFilePetitionSequence: sequences.submitFilePetitionSequence,
+    updatePetitionValueSequence: sequences.updatePetitionValueSequence,
+    updateStartCaseFormValueSequence:
+      sequences.updateStartCaseFormValueSequence,
+    validationErrors: state.validationErrors,
+  },
+  ({
+    completeStartCaseWizardStepSequence,
+    constants,
+    formCancelToggleCancelSequence,
+    showModal,
+    startCaseHelper,
+    submitFilePetitionSequence,
+    updatePetitionValueSequence,
+    validateStartCaseSequence,
+    validationErrors,
+  }) => {
+    return (
+      <>
+        {showModal === 'FormCancelModalDialog' && (
+          <FormCancelModalDialog onCancelSequence="closeModalAndReturnToDashboardSequence" />
+        )}
+        <h1 className="margin-bottom-2" id="start-case-header" tabIndex="-1">
+          1. Provide Your Statement of Identity
+        </h1>
+        <p className="required-statement margin-top-05 margin-bottom-2">
+          All fields required unless otherwise noted
+        </p>
+        <Hint>
+          The Statement of Taxpayer Identification is the only document that
+          should include personal information (such as Social Security Numbers,
+          Taxpayer Identification Numbers, or Employer Identification Numbers).
+          It’s sent to the IRS to help identify you, but is never viewed by the
+          Court or stored as part of the public record.
+        </Hint>
+        <h2>Upload Your Statement of Taxpayer Identification</h2>
+        <div className="blue-container">
+          <div
+            className={`usa-form-group ${
+              validationErrors.stinFile ? 'usa-form-group--error' : ''
+            }`}
+          >
+            <label
+              className={
+                'usa-label ustc-upload-stin with-hint ' +
+                (startCaseHelper.showStinFileValid ? 'validated' : '')
+              }
+              htmlFor="stin-file"
+            >
+              Upload Your Statement of Taxpayer Identification
+              <span className="success-message">
+                <FontAwesomeIcon icon="check-circle" size="1x" />
+              </span>
+            </label>
+            <span className="usa-hint">
+              File must be in PDF format (.pdf). Max file size{' '}
+              {constants.MAX_FILE_SIZE_MB}MB.
+            </span>
+            <input
+              accept=".pdf"
+              className="usa-input"
+              id="stin-file"
+              name="stinFile"
+              type="file"
+              onChange={e => {
+                limitFileSize(e, constants.MAX_FILE_SIZE_MB, () => {
+                  updatePetitionValueSequence({
+                    key: e.target.name,
+                    value: e.target.files[0],
+                  });
+                  updatePetitionValueSequence({
+                    key: `${e.target.name}Size`,
+                    value: e.target.files[0].size,
+                  });
+                  validateStartCaseSequence();
+                });
+              }}
+            />
+            <Text
+              bind="validationErrors.stinFile"
+              className="usa-error-message"
+            />
+            <Text
+              bind="validationErrors.stinFileSize"
+              className="usa-error-message"
+            />
+          </div>
+        </div>
+
+        <div className="button-box-container">
+          <button
+            className="usa-button margin-right-205"
+            id="submit-case"
+            type="button"
+            onClick={() => {
+              completeStartCaseWizardStepSequence({ nextStep: 2 });
+            }}
+          >
+            Continue to Step 2 of 5
+          </button>
+          <button className="usa-button usa-button--outline" type="button">
+            Back
+          </button>
+          <button
+            className="usa-button usa-button--unstyled ustc-button--unstyled"
+            type="button"
+            onClick={() => {
+              formCancelToggleCancelSequence();
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+        {showModal === 'FileUploadStatusModal' && <FileUploadStatusModal />}
+        {showModal === 'FileUploadErrorModal' && (
+          <FileUploadErrorModal confirmSequence={submitFilePetitionSequence} />
+        )}
+      </>
+    );
+  },
+);

--- a/web-client/src/views/StartCase/StartCaseStep1.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep1.jsx
@@ -1,7 +1,6 @@
 import { FileUploadErrorModal } from '../FileUploadErrorModal';
 import { FileUploadStatusModal } from '../FileUploadStatusModal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { FormCancelModalDialog } from '../FormCancelModalDialog';
 import { Hint } from '../../ustc-ui/Hint/Hint';
 import { Text } from '../../ustc-ui/Text/Text';
 import { connect } from '@cerebral/react';
@@ -36,15 +35,9 @@ export const StartCaseStep1 = connect(
   }) => {
     return (
       <>
-        {showModal === 'FormCancelModalDialog' && (
-          <FormCancelModalDialog onCancelSequence="closeModalAndReturnToDashboardSequence" />
-        )}
         <h1 className="margin-bottom-2" id="start-case-header" tabIndex="-1">
-          1. Provide Your Statement of Identity
+          1. Provide Statement of Identity
         </h1>
-        <p className="required-statement margin-top-05 margin-bottom-2">
-          All fields required unless otherwise noted
-        </p>
         <Hint>
           The Statement of Taxpayer Identification is the only document that
           should include personal information (such as Social Security Numbers,
@@ -52,7 +45,6 @@ export const StartCaseStep1 = connect(
           It’s sent to the IRS to help identify you, but is never viewed by the
           Court or stored as part of the public record.
         </Hint>
-        <h2>Upload Your Statement of Taxpayer Identification</h2>
         <div className="blue-container">
           <div
             className={`usa-form-group ${
@@ -66,7 +58,7 @@ export const StartCaseStep1 = connect(
               }
               htmlFor="stin-file"
             >
-              Upload Your Statement of Taxpayer Identification
+              Upload Your Statement of Taxpayer Identification{' '}
               <span className="success-message">
                 <FontAwesomeIcon icon="check-circle" size="1x" />
               </span>
@@ -108,7 +100,7 @@ export const StartCaseStep1 = connect(
 
         <div className="button-box-container">
           <button
-            className="usa-button margin-right-205"
+            className="usa-button margin-right-205 margin-bottom-4"
             id="submit-case"
             type="button"
             onClick={() => {
@@ -117,7 +109,11 @@ export const StartCaseStep1 = connect(
           >
             Continue to Step 2 of 5
           </button>
-          <button className="usa-button usa-button--outline" type="button">
+          <button
+            className="usa-button usa-button--outline margin-bottom-1"
+            type="button"
+            onClick={() => history.back()}
+          >
             Back
           </button>
           <button

--- a/web-client/src/views/StartCase/StartCaseStep2.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.jsx
@@ -277,7 +277,7 @@ export const StartCaseStep2 = connect(
 
         <div className="button-box-container">
           <button
-            className="usa-button margin-right-205"
+            className="usa-button margin-right-205 margin-bottom-4"
             id="submit-case"
             type="button"
             onClick={() => {
@@ -286,7 +286,11 @@ export const StartCaseStep2 = connect(
           >
             Continue to Step 3 of 5
           </button>
-          <button className="usa-button usa-button--outline" type="button">
+          <button
+            className="usa-button usa-button--outline margin-bottom-1"
+            type="button"
+            onClick={() => history.back()}
+          >
             Back
           </button>
           <button

--- a/web-client/src/views/StartCase/StartCaseStep2.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.jsx
@@ -1,0 +1,305 @@
+import { CaseTypeSelect } from './CaseTypeSelect';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Hint } from '../../ustc-ui/Hint/Hint';
+import { Text } from '../../ustc-ui/Text/Text';
+import { connect } from '@cerebral/react';
+import { limitFileSize } from '../limitFileSize';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+export const StartCaseStep2 = connect(
+  {
+    caseTypeDescriptionHelper: state.caseTypeDescriptionHelper,
+    completeStartCaseWizardStepSequence:
+      sequences.completeStartCaseWizardStepSequence,
+    constants: state.constants,
+    formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
+    startCaseHelper: state.startCaseHelper,
+    updateFormValueSequence: sequences.updateFormValueSequence,
+    updateHasIrsNoticeFormValueSequence:
+      sequences.updateHasIrsNoticeFormValueSequence,
+    updatePetitionValueSequence: sequences.updatePetitionValueSequence,
+    updateStartCaseFormValueSequence:
+      sequences.updateStartCaseFormValueSequence,
+    validationErrors: state.validationErrors,
+  },
+  ({
+    caseTypeDescriptionHelper,
+    completeStartCaseWizardStepSequence,
+    constants,
+    formCancelToggleCancelSequence,
+    startCaseHelper,
+    updateFormValueSequence,
+    updateHasIrsNoticeFormValueSequence,
+    updatePetitionValueSequence,
+    validateStartCaseSequence,
+    validationErrors,
+  }) => {
+    return (
+      <>
+        <h1 className="margin-top-5"> 2. Tell Us About Your Petition </h1>
+        <p className="required-statement margin-top-05 margin-bottom-2">
+          All fields required unless otherwise noted
+        </p>
+        <h2 className="margin-top-4">
+          Upload Your Petition to Start Your Case
+        </h2>
+        <Hint>
+          Your Petition upload should include your Petition form and any IRS
+          notices. Don’t forget to remove or redact your personal information on
+          all of your documents, including any IRS notice(s).
+        </Hint>
+        <div className="blue-container grid-container padding-x-0">
+          <div className="grid-row grid-gap">
+            <div className="mobile-lg:grid-col-5">
+              <div
+                className={`usa-form-group ${
+                  validationErrors.petitionFile ? 'usa-form-group--error' : ''
+                }`}
+              >
+                <label
+                  className={
+                    'usa-label ustc-upload-petition with-hint ' +
+                    (startCaseHelper.showPetitionFileValid ? 'validated' : '')
+                  }
+                  htmlFor="petition-file"
+                >
+                  Upload Your Petition{' '}
+                  <span className="success-message">
+                    <FontAwesomeIcon icon="check-circle" size="1x" />
+                  </span>
+                </label>
+                <span className="usa-hint">
+                  File must be in PDF format (.pdf). Max file size{' '}
+                  {constants.MAX_FILE_SIZE_MB}MB.
+                </span>
+                <input
+                  accept=".pdf"
+                  aria-describedby="petition-hint"
+                  className="usa-input"
+                  id="petition-file"
+                  name="petitionFile"
+                  type="file"
+                  onChange={e => {
+                    limitFileSize(e, constants.MAX_FILE_SIZE_MB, () => {
+                      updatePetitionValueSequence({
+                        key: e.target.name,
+                        value: e.target.files[0],
+                      });
+                      updatePetitionValueSequence({
+                        key: `${e.target.name}Size`,
+                        value: e.target.files[0].size,
+                      });
+                      validateStartCaseSequence();
+                    });
+                  }}
+                />
+                <Text
+                  bind="validationErrors.petitionFile"
+                  className="usa-error-message"
+                />
+                <Text
+                  bind="validationErrors.petitionFileSize"
+                  className="usa-error-message"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <h2 className="margin-top-4">Why are you filing this petition?</h2>
+        <div className="blue-container">
+          <div className="usa-form-group">
+            <fieldset
+              className={
+                'usa-fieldset ' +
+                (validationErrors.hasIrsNotice ? 'usa-form-group--error' : '')
+              }
+              id="irs-notice-radios"
+            >
+              <legend className="usa-legend">
+                {startCaseHelper.noticeLegend}
+              </legend>
+              <div className="usa-form-group">
+                {['Yes', 'No'].map((hasIrsNotice, idx) => (
+                  <div
+                    className="usa-radio usa-radio__inline"
+                    key={hasIrsNotice}
+                  >
+                    <input
+                      className="usa-radio__input"
+                      id={`hasIrsNotice-${hasIrsNotice}`}
+                      name="hasIrsNotice"
+                      type="radio"
+                      value={hasIrsNotice === 'Yes'}
+                      onChange={e => {
+                        updateHasIrsNoticeFormValueSequence({
+                          key: e.target.name,
+                          value: e.target.value === 'true',
+                        });
+                        validateStartCaseSequence();
+                      }}
+                    />
+                    <label
+                      className="usa-radio__label"
+                      htmlFor={`hasIrsNotice-${hasIrsNotice}`}
+                      id={`hasIrsNotice-${idx}`}
+                    >
+                      {hasIrsNotice}
+                    </label>
+                  </div>
+                ))}
+                <Text
+                  bind="validationErrors.hasIrsNotice"
+                  className="usa-error-message"
+                />
+              </div>
+            </fieldset>
+
+            {startCaseHelper.showHasIrsNoticeOptions && (
+              <React.Fragment>
+                <CaseTypeSelect
+                  allowDefaultOption={true}
+                  caseTypes={caseTypeDescriptionHelper.caseTypes}
+                  legend="Type of Notice / Case"
+                  validation="validateStartCaseSequence"
+                  onChange="updateFormValueSequence"
+                />
+                <div
+                  className={
+                    'usa-form-group' +
+                    (validationErrors.irsNoticeDate
+                      ? ' usa-form-group--error'
+                      : '')
+                  }
+                >
+                  <fieldset className="usa-fieldset">
+                    <legend className="usa-legend" id="date-of-notice-legend">
+                      Date of Notice
+                    </legend>
+                    <div className="usa-memorable-date">
+                      <div className="usa-form-group usa-form-group--month">
+                        <label
+                          aria-hidden="true"
+                          htmlFor="date-of-notice-month"
+                        >
+                          MM
+                        </label>
+                        <input
+                          aria-describedby="date-of-notice-legend"
+                          aria-label="month, two digits"
+                          className="usa-input usa-input--inline"
+                          id="date-of-notice-month"
+                          max="12"
+                          min="1"
+                          name="month"
+                          type="number"
+                          onBlur={() => {
+                            validateStartCaseSequence();
+                          }}
+                          onChange={e => {
+                            updateFormValueSequence({
+                              key: e.target.name,
+                              value: e.target.value,
+                            });
+                          }}
+                        />
+                      </div>
+                      <div className="usa-form-group usa-form-group--day">
+                        <label aria-hidden="true" htmlFor="date-of-notice-day">
+                          DD
+                        </label>
+                        <input
+                          aria-describedby="date-of-notice-legend"
+                          aria-label="day, two digits"
+                          className="usa-input usa-input--inline"
+                          id="date-of-notice-day"
+                          max="31"
+                          min="1"
+                          name="day"
+                          type="number"
+                          onBlur={() => {
+                            validateStartCaseSequence();
+                          }}
+                          onChange={e => {
+                            updateFormValueSequence({
+                              key: e.target.name,
+                              value: e.target.value,
+                            });
+                          }}
+                        />
+                      </div>
+                      <div className="usa-form-group usa-form-group--year">
+                        <label aria-hidden="true" htmlFor="date-of-notice-year">
+                          YYYY
+                        </label>
+                        <input
+                          aria-describedby="date-of-notice-legend"
+                          aria-label="year, four digits"
+                          className="usa-input usa-input--inline"
+                          id="date-of-notice-year"
+                          max="2100"
+                          min="1900"
+                          name="year"
+                          type="number"
+                          onBlur={() => {
+                            validateStartCaseSequence();
+                          }}
+                          onChange={e => {
+                            updateFormValueSequence({
+                              key: e.target.name,
+                              value: e.target.value,
+                            });
+                          }}
+                        />
+                      </div>
+                      <Text
+                        bind="validationErrors.irsNoticeDate"
+                        className="usa-error-message"
+                      />
+                    </div>
+                  </fieldset>
+                </div>
+              </React.Fragment>
+            )}
+            {startCaseHelper.showNotHasIrsNoticeOptions && (
+              <CaseTypeSelect
+                allowDefaultOption={true}
+                caseTypes={caseTypeDescriptionHelper.caseTypes}
+                legend="Which topic most closely matches your complaint with the
+                IRS?"
+                validation="validateStartCaseSequence"
+                onChange="updateFormValueSequence"
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="button-box-container">
+          <button
+            className="usa-button margin-right-205"
+            id="submit-case"
+            type="button"
+            onClick={() => {
+              completeStartCaseWizardStepSequence({ nextStep: 3 });
+            }}
+          >
+            Continue to Step 3 of 5
+          </button>
+          <button className="usa-button usa-button--outline" type="button">
+            Back
+          </button>
+          <button
+            className="usa-button usa-button--unstyled ustc-button--unstyled"
+            type="button"
+            onClick={() => {
+              formCancelToggleCancelSequence();
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </>
+    );
+  },
+);

--- a/web-client/src/views/StartCase/StartCaseStep3.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep3.jsx
@@ -1,6 +1,8 @@
 import { Contacts } from './Contacts';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Text } from '../../ustc-ui/Text/Text';
 import { connect } from '@cerebral/react';
+import { limitFileSize } from '../limitFileSize';
 import { sequences, state } from 'cerebral';
 import React from 'react';
 
@@ -12,6 +14,7 @@ export const StartCaseStep3 = connect(
     filingTypes: state.filingTypes,
     formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
     startCaseHelper: state.startCaseHelper,
+    updatePetitionValueSequence: sequences.updatePetitionValueSequence,
     updateStartCaseFormValueSequence:
       sequences.updateStartCaseFormValueSequence,
     validateStartCaseSequence: sequences.validateStartCaseSequence,
@@ -23,6 +26,7 @@ export const StartCaseStep3 = connect(
     filingTypes,
     formCancelToggleCancelSequence,
     startCaseHelper,
+    updatePetitionValueSequence,
     updateStartCaseFormValueSequence,
     validateStartCaseSequence,
     validationErrors,
@@ -327,6 +331,74 @@ export const StartCaseStep3 = connect(
           onBlur="validateStartCaseSequence"
           onChange="updateFormValueSequence"
         />
+
+        {startCaseHelper.showOwnershipDisclosure && (
+          <>
+            <h2 className="margin-top-4">Ownership Disclosure Statement</h2>
+            <p>
+              Tax Court Rules of Practice and Procedure (Rule 60) requires a
+              corporation, partnership, or limited liability company, filing a
+              Petition with the Court to also file an Ownership Disclosure
+              Statement (ODS). Complete your{' '}
+              <a
+                href="https://www.ustaxcourt.gov/forms/Ownership_Disclosure_Statement_Form_6.pdf"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Ownership Disclosure Statement Form 6
+              </a>
+              .
+            </p>
+            <div className="blue-container">
+              <label
+                className={
+                  'ustc-upload-ods usa-label with-hint ' +
+                  (startCaseHelper.showOwnershipDisclosureValid
+                    ? 'validated'
+                    : '')
+                }
+                htmlFor="ownership-disclosure-file"
+              >
+                Upload your Ownership Disclosure Statement
+                <span className="success-message">
+                  <FontAwesomeIcon icon="check-circle" size="1x" />
+                </span>
+              </label>
+              <span className="usa-hint">
+                File must be in PDF format (.pdf). Max file size{' '}
+                {constants.MAX_FILE_SIZE_MB}MB.
+              </span>
+              <input
+                accept=".pdf"
+                className="usa-input"
+                id="ownership-disclosure-file"
+                name="ownershipDisclosureFile"
+                type="file"
+                onChange={e => {
+                  limitFileSize(e, constants.MAX_FILE_SIZE_MB, () => {
+                    updatePetitionValueSequence({
+                      key: e.target.name,
+                      value: e.target.files[0],
+                    });
+                    updatePetitionValueSequence({
+                      key: `${e.target.name}Size`,
+                      value: e.target.files[0].size,
+                    });
+                    validateStartCaseSequence();
+                  });
+                }}
+              />
+              <Text
+                bind="validationErrors.ownershipDisclosureFile"
+                className="usa-error-message"
+              />
+              <Text
+                bind="validationErrors.ownershipDisclosureFileSize"
+                className="usa-error-message"
+              />
+            </div>
+          </>
+        )}
 
         <div className="button-box-container">
           <button

--- a/web-client/src/views/StartCase/StartCaseStep3.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep3.jsx
@@ -1,0 +1,358 @@
+import { Contacts } from './Contacts';
+import { Text } from '../../ustc-ui/Text/Text';
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+export const StartCaseStep3 = connect(
+  {
+    completeStartCaseWizardStepSequence:
+      sequences.completeStartCaseWizardStepSequence,
+    constants: state.constants,
+    filingTypes: state.filingTypes,
+    formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
+    startCaseHelper: state.startCaseHelper,
+    updateStartCaseFormValueSequence:
+      sequences.updateStartCaseFormValueSequence,
+    validateStartCaseSequence: sequences.validateStartCaseSequence,
+    validationErrors: state.validationErrors,
+  },
+  ({
+    completeStartCaseWizardStepSequence,
+    constants,
+    filingTypes,
+    formCancelToggleCancelSequence,
+    startCaseHelper,
+    updateStartCaseFormValueSequence,
+    validateStartCaseSequence,
+    validationErrors,
+  }) => {
+    return (
+      <>
+        <h1 className="margin-top-5">
+          3. Who are you filing this petition for?
+        </h1>
+        <p className="required-statement margin-top-05 margin-bottom-2">
+          All fields required unless otherwise noted
+        </p>
+        <div className="blue-container grid-container padding-x-0">
+          <div className="grid-row grid-gap">
+            <div className="mobile-lg:grid-col-5">
+              <div
+                className={
+                  validationErrors.filingType ? 'usa-form-group--error' : ''
+                }
+              >
+                <fieldset
+                  className="usa-fieldset usa-sans"
+                  id="filing-type-radios"
+                >
+                  <legend htmlFor="filing-type-radios">
+                    I am filing this petition on behalf of …
+                  </legend>
+                  {filingTypes.map((filingType, idx) => (
+                    <div className="usa-radio" key={filingType}>
+                      <input
+                        className="usa-radio__input"
+                        data-type={filingType}
+                        id={filingType}
+                        name="filingType"
+                        type="radio"
+                        value={filingType}
+                        onChange={e => {
+                          updateStartCaseFormValueSequence({
+                            key: e.target.name,
+                            value: e.target.value,
+                          });
+                          validateStartCaseSequence();
+                        }}
+                      />
+                      <label
+                        className="usa-radio__label"
+                        htmlFor={filingType}
+                        id={`filing-type-${idx}`}
+                      >
+                        {filingType}
+                      </label>
+                    </div>
+                  ))}
+                  <Text
+                    bind="validationErrors.partyType"
+                    className="usa-error-message"
+                  />
+                </fieldset>
+              </div>
+            </div>
+          </div>
+
+          {startCaseHelper.showPetitionerDeceasedSpouseForm && (
+            <div
+              className={
+                'ustc-secondary-question ' +
+                (validationErrors.partyType ? 'usa-form-group--error' : '')
+              }
+            >
+              <fieldset
+                className="usa-fieldset usa-sans"
+                id="deceased-spouse-radios"
+              >
+                <legend htmlFor="deceased-spouse-radios">
+                  {startCaseHelper.deceasedSpouseLegend}
+                </legend>
+                {['Yes', 'No'].map((isSpouseDeceased, idx) => (
+                  <div
+                    className="usa-radio usa-radio__inline"
+                    key={isSpouseDeceased}
+                  >
+                    <input
+                      className="usa-radio__input"
+                      id={`isSpouseDeceased-${isSpouseDeceased}`}
+                      name="isSpouseDeceased"
+                      type="radio"
+                      value={isSpouseDeceased}
+                      onChange={e => {
+                        updateStartCaseFormValueSequence({
+                          key: e.target.name,
+                          value: e.target.value,
+                        });
+                        validateStartCaseSequence();
+                      }}
+                    />
+                    <label
+                      className="usa-radio__label"
+                      htmlFor={`isSpouseDeceased-${isSpouseDeceased}`}
+                      id={`is-spouse-deceased-${idx}`}
+                    >
+                      {isSpouseDeceased}
+                    </label>
+                  </div>
+                ))}
+              </fieldset>
+            </div>
+          )}
+          {startCaseHelper.showBusinessFilingTypeOptions && (
+            <div
+              className={
+                'ustc-secondary-question ' +
+                (validationErrors.partyType ? 'usa-form-group--error' : '')
+              }
+            >
+              <fieldset className="usa-fieldset" id="business-type-radios">
+                <legend htmlFor="business-type-radios">
+                  What type of business are you filing for?
+                </legend>
+                {[
+                  constants.BUSINESS_TYPES.corporation,
+                  constants.BUSINESS_TYPES.partnershipAsTaxMattersPartner,
+                  constants.BUSINESS_TYPES.partnershipOtherThanTaxMatters,
+                  constants.BUSINESS_TYPES.partnershipBBA,
+                ].map((businessType, idx) => (
+                  <div className="usa-radio" key={businessType}>
+                    <input
+                      className="usa-radio__input"
+                      id={`businessType-${businessType}`}
+                      name="businessType"
+                      type="radio"
+                      value={businessType}
+                      onChange={e => {
+                        updateStartCaseFormValueSequence({
+                          key: e.target.name,
+                          value: e.target.value,
+                        });
+                        validateStartCaseSequence();
+                      }}
+                    />
+                    <label
+                      className="usa-radio__label"
+                      htmlFor={`businessType-${businessType}`}
+                      id={`is-business-type-${idx}`}
+                    >
+                      {businessType}
+                    </label>
+                  </div>
+                ))}
+              </fieldset>
+            </div>
+          )}
+          {startCaseHelper.showOtherFilingTypeOptions && (
+            <div
+              className={
+                'ustc-secondary-question ' +
+                (validationErrors.partyType ? 'usa-form-group--error' : '')
+              }
+            >
+              <fieldset className="usa-fieldset" id="other-type-radios">
+                <legend htmlFor="other-type-radios">
+                  What other type of taxpayer are you filing for?
+                </legend>
+                {[
+                  'An estate or trust',
+                  'A minor or legally incompetent person',
+                  'Donor',
+                  'Transferee',
+                  'Deceased Spouse',
+                ].map((otherType, idx) => (
+                  <div className="usa-radio" key={otherType}>
+                    <input
+                      className="usa-radio__input"
+                      id={`otherType-${otherType}`}
+                      name="otherType"
+                      type="radio"
+                      value={otherType}
+                      onChange={e => {
+                        updateStartCaseFormValueSequence({
+                          key: e.target.name,
+                          value: e.target.value,
+                        });
+                        validateStartCaseSequence();
+                      }}
+                    />
+                    <label
+                      className="usa-radio__label"
+                      htmlFor={`otherType-${otherType}`}
+                      id={`is-other-type-${idx}`}
+                    >
+                      {otherType}
+                    </label>
+                  </div>
+                ))}
+              </fieldset>
+            </div>
+          )}
+          {startCaseHelper.showOtherFilingTypeOptions &&
+            startCaseHelper.showEstateFilingOptions && (
+              <div
+                className={
+                  'ustc-secondary-question ' +
+                  (validationErrors.partyType ? 'usa-form-group--error' : '')
+                }
+              >
+                <fieldset
+                  className="usa-fieldset usa-sans"
+                  id="estate-type-radios"
+                >
+                  <legend htmlFor="estate-type-radios">
+                    What type of estate or trust are you filing for?
+                  </legend>
+                  {[
+                    constants.ESTATE_TYPES.estate,
+                    constants.ESTATE_TYPES.estateWithoutExecutor,
+                    constants.ESTATE_TYPES.trust,
+                  ].map((estateType, idx) => (
+                    <div className="usa-radio" key={estateType}>
+                      <input
+                        className="usa-radio__input"
+                        id={`estateType-${estateType}`}
+                        name="estateType"
+                        type="radio"
+                        value={estateType}
+                        onChange={e => {
+                          updateStartCaseFormValueSequence({
+                            key: e.target.name,
+                            value: e.target.value,
+                          });
+                          validateStartCaseSequence();
+                        }}
+                      />
+                      <label
+                        className="usa-radio__label"
+                        htmlFor={`estateType-${estateType}`}
+                        id={`is-estate-type-${idx}`}
+                      >
+                        {estateType}
+                      </label>
+                    </div>
+                  ))}
+                </fieldset>
+              </div>
+            )}
+          {startCaseHelper.showOtherFilingTypeOptions &&
+            startCaseHelper.showMinorIncompetentFilingOptions && (
+              <div
+                className={
+                  'ustc-secondary-question ' +
+                  (validationErrors.partyType ? 'usa-form-group--error' : '')
+                }
+              >
+                <fieldset
+                  className="usa-fieldset"
+                  id="minorIncompetent-type-radios"
+                >
+                  <legend htmlFor="minorIncompetent-type-radios">
+                    {startCaseHelper.minorIncompetentLegend}
+                  </legend>
+                  {[
+                    constants.OTHER_TYPES.conservator,
+                    constants.OTHER_TYPES.guardian,
+                    constants.OTHER_TYPES.custodian,
+                    constants.OTHER_TYPES.nextFriendForMinor,
+                    constants.OTHER_TYPES.nextFriendForIncompetentPerson,
+                  ].map((minorIncompetentType, idx) => (
+                    <div className="usa-radio" key={minorIncompetentType}>
+                      <input
+                        className="usa-radio__input"
+                        id={`minorIncompetentType-${minorIncompetentType}`}
+                        name="minorIncompetentType"
+                        type="radio"
+                        value={minorIncompetentType}
+                        onChange={e => {
+                          updateStartCaseFormValueSequence({
+                            key: e.target.name,
+                            value: e.target.value,
+                          });
+                          validateStartCaseSequence();
+                        }}
+                      />
+                      <label
+                        className="usa-radio__label"
+                        htmlFor={`minorIncompetentType-${minorIncompetentType}`}
+                        id={`is-minorIncompetent-type-${idx}`}
+                      >
+                        {minorIncompetentType}
+                      </label>
+                    </div>
+                  ))}
+                </fieldset>
+              </div>
+            )}
+        </div>
+
+        <Contacts
+          bind="form"
+          contactsHelper="contactsHelper"
+          emailBind="user"
+          parentView="StartCase"
+          showPrimaryContact={startCaseHelper.showPrimaryContact}
+          showSecondaryContact={startCaseHelper.showSecondaryContact}
+          onBlur="validateStartCaseSequence"
+          onChange="updateFormValueSequence"
+        />
+
+        <div className="button-box-container">
+          <button
+            className="usa-button margin-right-205"
+            id="submit-case"
+            type="button"
+            onClick={() => {
+              completeStartCaseWizardStepSequence({ nextStep: 4 });
+            }}
+          >
+            Continue to Step 4 of 5
+          </button>
+          <button className="usa-button usa-button--outline" type="button">
+            Back
+          </button>
+          <button
+            className="usa-button usa-button--unstyled ustc-button--unstyled"
+            type="button"
+            onClick={() => {
+              formCancelToggleCancelSequence();
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </>
+    );
+  },
+);

--- a/web-client/src/views/StartCase/StartCaseStep3.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep3.jsx
@@ -402,7 +402,7 @@ export const StartCaseStep3 = connect(
 
         <div className="button-box-container">
           <button
-            className="usa-button margin-right-205"
+            className="usa-button margin-right-205 margin-bottom-4"
             id="submit-case"
             type="button"
             onClick={() => {
@@ -411,7 +411,11 @@ export const StartCaseStep3 = connect(
           >
             Continue to Step 4 of 5
           </button>
-          <button className="usa-button usa-button--outline" type="button">
+          <button
+            className="usa-button usa-button--outline margin-bottom-1"
+            type="button"
+            onClick={() => history.back()}
+          >
             Back
           </button>
           <button

--- a/web-client/src/views/StartCase/StartCaseStep4.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep4.jsx
@@ -121,7 +121,7 @@ export const StartCaseStep4 = connect(
 
         <div className="button-box-container">
           <button
-            className="usa-button margin-right-205"
+            className="usa-button margin-right-205 margin-bottom-4"
             id="submit-case"
             type="button"
             onClick={() => {
@@ -130,7 +130,11 @@ export const StartCaseStep4 = connect(
           >
             Continue to Step 5 of 5
           </button>
-          <button className="usa-button usa-button--outline" type="button">
+          <button
+            className="usa-button usa-button--outline margin-bottom-1"
+            type="button"
+            onClick={() => history.back()}
+          >
             Back
           </button>
           <button

--- a/web-client/src/views/StartCase/StartCaseStep4.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep4.jsx
@@ -1,0 +1,149 @@
+import { CaseDifferenceExplained } from '../CaseDifferenceExplained';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ProcedureType } from './ProcedureType';
+import { Text } from '../../ustc-ui/Text/Text';
+import { TrialCity } from './TrialCity';
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+export const StartCaseStep4 = connect(
+  {
+    clearPreferredTrialCitySequence: sequences.clearPreferredTrialCitySequence,
+    completeStartCaseWizardStepSequence:
+      sequences.completeStartCaseWizardStepSequence,
+    form: state.form,
+    formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
+    screenMetadata: state.screenMetadata,
+    startCaseHelper: state.startCaseHelper,
+    toggleCaseDifferenceSequence: sequences.toggleCaseDifferenceSequence,
+    trialCitiesHelper: state.trialCitiesHelper,
+    updateFormValueSequence: sequences.updateFormValueSequence,
+    validateStartCaseSequence: sequences.validateStartCaseSequence,
+    validationErrors: state.validationErrors,
+  },
+  ({
+    clearPreferredTrialCitySequence,
+    completeStartCaseWizardStepSequence,
+    form,
+    formCancelToggleCancelSequence,
+    screenMetadata,
+    startCaseHelper,
+    toggleCaseDifferenceSequence,
+    trialCitiesHelper,
+    updateFormValueSequence,
+    validateStartCaseSequence,
+    validationErrors,
+  }) => {
+    return (
+      <>
+        <h1 className="margin-top-4">4. How do you want this case handled?</h1>
+        <p className="required-statement margin-top-05 margin-bottom-2">
+          All fields required unless otherwise noted
+        </p>
+        <p>
+          Tax laws allow you to file your case as a “small case,” which means
+          it’s handled a bit differently than a regular case. If you choose to
+          have your case processed as a small case, the Tax Court must approve
+          your choice. Generally, the Tax Court will agree with your request if
+          you qualify.
+        </p>
+        <div className="usa-accordion start-a-case">
+          <button
+            aria-controls="case-difference-container"
+            aria-expanded={!!screenMetadata.showCaseDifference}
+            className="usa-accordion__button case-difference"
+            type="button"
+            onClick={() => toggleCaseDifferenceSequence()}
+          >
+            <span className="usa-accordion__heading usa-banner__button-text">
+              <FontAwesomeIcon icon="question-circle" size="lg" />
+              Which case procedure should I choose?
+              {screenMetadata.showCaseDifference ? (
+                <FontAwesomeIcon icon="caret-up" />
+              ) : (
+                <FontAwesomeIcon icon="caret-down" />
+              )}
+            </span>
+          </button>
+          <div
+            aria-hidden={!screenMetadata.showCaseDifference}
+            className="usa-accordion__content"
+            id="case-difference-container"
+          >
+            <CaseDifferenceExplained />
+          </div>
+        </div>
+        <div className="blue-container">
+          <ProcedureType
+            legend="Select Case Procedure"
+            value={form.procedureType}
+            onChange={e => {
+              updateFormValueSequence({
+                key: 'procedureType',
+                value: e.target.value,
+              });
+              clearPreferredTrialCitySequence();
+              validateStartCaseSequence();
+            }}
+          />
+          {startCaseHelper.showSelectTrial && (
+            <TrialCity
+              label="Select a Trial Location"
+              showDefaultOption={true}
+              showHint={true}
+              showRegularTrialCitiesHint={
+                startCaseHelper.showRegularTrialCitiesHint
+              }
+              showSmallTrialCitiesHint={
+                startCaseHelper.showSmallTrialCitiesHint
+              }
+              trialCitiesByState={
+                trialCitiesHelper(form.procedureType).trialCitiesByState
+              }
+              value={form.preferredTrialCity}
+              onChange={e => {
+                updateFormValueSequence({
+                  key: e.target.name,
+                  value: e.target.value || null,
+                });
+                validateStartCaseSequence();
+              }}
+            />
+          )}
+          {!validationErrors.procedureType && (
+            <Text
+              bind="validationErrors.preferredTrialCity"
+              className="usa-error-message"
+            />
+          )}
+        </div>
+
+        <div className="button-box-container">
+          <button
+            className="usa-button margin-right-205"
+            id="submit-case"
+            type="button"
+            onClick={() => {
+              completeStartCaseWizardStepSequence({ nextStep: 5 });
+            }}
+          >
+            Continue to Step 5 of 5
+          </button>
+          <button className="usa-button usa-button--outline" type="button">
+            Back
+          </button>
+          <button
+            className="usa-button usa-button--unstyled ustc-button--unstyled"
+            type="button"
+            onClick={() => {
+              formCancelToggleCancelSequence();
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </>
+    );
+  },
+);

--- a/web-client/src/views/StartCase/StartCaseWizard.jsx
+++ b/web-client/src/views/StartCase/StartCaseWizard.jsx
@@ -1,0 +1,51 @@
+import { BigHeader } from '../BigHeader';
+import { ErrorNotification } from '../ErrorNotification';
+import { FormCancelModalDialog } from '../FormCancelModalDialog';
+import { StartCaseStep1 } from './StartCaseStep1';
+import { StartCaseStep2 } from './StartCaseStep2';
+import { StartCaseStep3 } from './StartCaseStep3';
+import { StartCaseStep4 } from './StartCaseStep4';
+import { SuccessNotification } from '../SuccessNotification';
+import { Tab, Tabs } from '../../ustc-ui/Tabs/Tabs';
+import { connect } from '@cerebral/react';
+import { state } from 'cerebral';
+import React from 'react';
+
+export const StartCaseWizard = connect(
+  {
+    showModal: state.showModal,
+  },
+  ({ showModal }) => {
+    return (
+      <>
+        <BigHeader text="File a Petition" />
+        <section
+          className="usa-section grid-container"
+          id="ustc-start-a-case-form"
+        >
+          <div className="grid-container">
+            {showModal == 'FormCancelModalDialog' && (
+              <FormCancelModalDialog onCancelSequence="closeModalAndReturnToDashboardSequence" />
+            )}
+            <SuccessNotification />
+            <ErrorNotification />
+          </div>
+          <Tabs asSwitch bind="wizardStep" defaultActiveTab="StartCaseStep1">
+            <Tab tabName="StartCaseStep1">
+              <StartCaseStep1 />
+            </Tab>
+            <Tab tabName="StartCaseStep2">
+              <StartCaseStep2 />
+            </Tab>
+            <Tab tabName="StartCaseStep3">
+              <StartCaseStep3 />
+            </Tab>
+            <Tab tabName="StartCaseStep4">
+              <StartCaseStep4 />
+            </Tab>
+          </Tabs>
+        </section>
+      </>
+    );
+  },
+);


### PR DESCRIPTION
This is messy right now, but it lays the groundwork for building out each of the steps. Basically what I've done at this point is create a start case wizard and split the form up into separate components for each step.

Note that I did **not** remove the old form or route so the flow isn't broken while we're working through these updates.

<img width="771" alt="Screen Shot 2019-07-24 at 1 12 18 PM" src="https://user-images.githubusercontent.com/43251054/61818582-c0e11200-ae16-11e9-9ca2-411e96d238c0.png">
