### PR TITLE
49 print css

### DIFF
--- a/web-client/integration-tests/journey/petitionsClerkDeletesCaseDeadline.js
+++ b/web-client/integration-tests/journey/petitionsClerkDeletesCaseDeadline.js
@@ -1,5 +1,8 @@
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default (test, overrides = {}) => {
   return it('Petitions clerk deletes a case deadline', async () => {

--- a/web-client/integration-tests/journey/petitionsClerkEditsCaseDeadline.js
+++ b/web-client/integration-tests/journey/petitionsClerkEditsCaseDeadline.js
@@ -1,5 +1,8 @@
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default (test, overrides = {}) => {
   return it('Petitions clerk edits a case deadline', async () => {

--- a/web-client/integration-tests/journey/petitionsClerkIrsHoldingQueue.js
+++ b/web-client/integration-tests/journey/petitionsClerkIrsHoldingQueue.js
@@ -1,10 +1,12 @@
 import { runCompute } from 'cerebral/test';
 
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { documentDetailHelper as documentDetailHelperComputed } from '../../src/presenter/computeds/documentDetailHelper';
 
 import { waitForRouter } from '../helpers';
 import { withAppContextDecorator } from '../../src/withAppContext';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 const documentDetailHelper = withAppContextDecorator(
   documentDetailHelperComputed,

--- a/web-client/integration-tests/journey/petitionsClerkUpdatesCaseDetail.js
+++ b/web-client/integration-tests/journey/petitionsClerkUpdatesCaseDetail.js
@@ -1,8 +1,10 @@
 import { runCompute } from 'cerebral/test';
 
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
 import { withAppContextDecorator } from '../../src/withAppContext';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default test => {
   return it('Petitions clerk updates case detail', async () => {

--- a/web-client/integration-tests/journey/petitionsClerkViewCaseDeadline.js
+++ b/web-client/integration-tests/journey/petitionsClerkViewCaseDeadline.js
@@ -1,5 +1,8 @@
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default test => {
   return it('Petitions clerk views case deadlines', async () => {

--- a/web-client/integration-tests/journey/petitionsClerkViewsCaseDetail.js
+++ b/web-client/integration-tests/journey/petitionsClerkViewsCaseDetail.js
@@ -1,6 +1,8 @@
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
 
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default test => {
   return it('Petitions clerk views case detail', async () => {

--- a/web-client/integration-tests/journey/petitionsClerkViewsCaseWithNoDeadlines.js
+++ b/web-client/integration-tests/journey/petitionsClerkViewsCaseWithNoDeadlines.js
@@ -1,6 +1,8 @@
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
 
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default test => {
   return it('Petitions clerk views case detail', async () => {

--- a/web-client/integration-tests/journey/respondentViewsCaseDetailOfBatchedCase.js
+++ b/web-client/integration-tests/journey/respondentViewsCaseDetailOfBatchedCase.js
@@ -1,5 +1,8 @@
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 export default test => {
   return it('Respondent views case detail', async () => {

--- a/web-client/integration-tests/journey/taxpayerViewsCaseDetail.js
+++ b/web-client/integration-tests/journey/taxpayerViewsCaseDetail.js
@@ -1,4 +1,4 @@
-import { caseDetailHelper } from '../../src/presenter/computeds/caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from '../../src/presenter/computeds/caseDetailHelper';
 import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../src/withAppContext';
@@ -18,6 +18,8 @@ export default (test, overrides = {}) => {
         state: test.getState(),
       },
     );
+    const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
+
     expect(test.getState('currentPage')).toEqual('CaseDetail');
     expect(caseDetail.docketNumber).toEqual(test.docketNumber);
     expect(caseDetail.docketNumberSuffix).toEqual(docketNumberSuffix);

--- a/web-client/src/index.scss
+++ b/web-client/src/index.scss
@@ -12,3 +12,6 @@
 @import './styles/tables.scss';
 @import './styles/tabs.scss';
 @import './styles/typography.scss';
+
+// overriding all other styles for print-only
+@import './styles/print.scss';

--- a/web-client/src/presenter/actions/printViewAction.js
+++ b/web-client/src/presenter/actions/printViewAction.js
@@ -1,0 +1,21 @@
+import { state } from 'cerebral';
+/**
+ * Initiates a print session for the named view
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.props the cerebral props object
+ * @param {object} providers.store the cerebral store object
+ */
+export const printViewAction = ({ get, props, store }) => {
+  const { printView } = props;
+  const referringView = get(state.currentPage);
+
+  store.set(state.currentPage, printView);
+
+  // Remove from the current event loop
+  setTimeout(() => {
+    window.print();
+    // return to referring view
+    store.set(state.currentPage, referringView);
+  });
+};

--- a/web-client/src/presenter/actions/printViewAction.test.js
+++ b/web-client/src/presenter/actions/printViewAction.test.js
@@ -1,0 +1,56 @@
+import { printViewAction } from './printViewAction';
+import { runAction } from 'cerebral/test';
+
+const mockPrint = jest.fn();
+
+describe('printViewAction', () => {
+  it('should change state.currentPage to the specified printView', async () => {
+    global.window = {
+      print: mockPrint,
+    };
+    const result = await runAction(printViewAction, {
+      props: {
+        printView: 'testViewPrint',
+      },
+      state: {
+        currentPage: 'testView',
+      },
+    });
+
+    expect(result.state.currentPage).toEqual('testViewPrint');
+  });
+  it('should change the view back to the referred view', async () => {
+    global.window = {
+      print: mockPrint,
+    };
+    const result = await runAction(printViewAction, {
+      props: {
+        printView: 'testViewPrint',
+      },
+      state: {
+        currentPage: 'testView',
+      },
+    });
+
+    setTimeout(() => {
+      expect(result.state.currentPage).toEqual('testView');
+    });
+  });
+  it('should call window.print()', async () => {
+    global.window = {
+      print: mockPrint,
+    };
+    await runAction(printViewAction, {
+      props: {
+        printView: 'testViewPrint',
+      },
+      state: {
+        currentPage: 'testView',
+      },
+    });
+
+    setTimeout(() => {
+      expect(mockPrint).toHaveBeenCalled();
+    });
+  });
+});

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -1,4 +1,4 @@
-import { Case } from '../../../../shared/src/business/entities/cases/Case'
+import { Case } from '../../../../shared/src/business/entities/cases/Case';
 import { state } from 'cerebral';
 
 export const caseDetailHelper = get => {

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -1,7 +1,7 @@
-import { Case } from '../../../../shared/src/business/entities/cases/Case';
 import { state } from 'cerebral';
 
-export const caseDetailHelper = get => {
+export const caseDetailHelper = (get, applicationContext) => {
+  const { Case } = applicationContext.getEntityConstructors();
   const caseDetail = get(state.caseDetail);
   const caseDeadlines = get(state.caseDeadlines) || [];
   const caseHasRespondent =

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -1,3 +1,4 @@
+import { Case } from '../../../../shared/src/business/entities/cases/Case'
 import { state } from 'cerebral';
 
 export const caseDetailHelper = get => {
@@ -66,6 +67,7 @@ export const caseDetailHelper = get => {
   }
 
   return {
+    caseCaptionPostfix: Case.CASE_CAPTION_POSTFIX,
     caseDeadlines,
     documentDetailTab,
     hidePublicCaseInformation: !isExternalUser,

--- a/web-client/src/presenter/computeds/caseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.test.js
@@ -1,6 +1,9 @@
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../withAppContext';
 
-import { caseDetailHelper } from './caseDetailHelper';
+import { caseDetailHelper as caseDetailHelperComputed } from './caseDetailHelper';
+
+const caseDetailHelper = withAppContextDecorator(caseDetailHelperComputed);
 
 describe('case detail computed', () => {
   it('should set showFileDocumentButton to true if current page is CaseDetail, user role is practitioner, and case is owned by user', () => {

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -81,6 +81,7 @@ import { openPdfPreviewModalSequence } from './sequences/openPdfPreviewModalSequ
 import { openSelectDocumentWizardOverlaySequence } from './sequences/openSelectDocumentWizardOverlaySequence';
 import { openServeConfirmModalDialogSequence } from './sequences/openServeConfirmModalDialogSequence';
 import { openSetCalendarModalSequence } from './sequences/openSetCalendarModalSequence';
+import { printViewSequence } from './sequences/printViewSequence';
 import { redirectToLoginSequence } from './sequences/redirectToLoginSequence';
 import { refreshCaseSequence } from './sequences/refreshCaseSequence';
 import { removeYearAmountSequence } from './sequences/removeYearAmountSequence';
@@ -279,6 +280,7 @@ export const presenter = {
     openSelectDocumentWizardOverlaySequence,
     openServeConfirmModalDialogSequence,
     openSetCalendarModalSequence,
+    printViewSequence,
     redirectToLoginSequence,
     refreshCaseSequence,
     removeYearAmountSequence,

--- a/web-client/src/presenter/sequences/printViewSequence.js
+++ b/web-client/src/presenter/sequences/printViewSequence.js
@@ -1,0 +1,3 @@
+import { printViewAction } from '../actions/printViewAction';
+
+export const printViewSequence = [printViewAction];

--- a/web-client/src/styles/cards.scss
+++ b/web-client/src/styles/cards.scss
@@ -99,6 +99,21 @@
 
 .party-information {
   font-size: 17px;
+
+  @media only screen and (max-width: $medium-screen) {
+    .card {
+      box-shadow: none;
+      border: none;
+
+      .content-wrapper {
+        padding: 0px;
+
+        .underlined {
+          border-bottom: none;
+        }
+      }
+    }
+  }
 }
 
 .frequently-used-docs {

--- a/web-client/src/styles/cards.scss
+++ b/web-client/src/styles/cards.scss
@@ -102,8 +102,8 @@
 
   @media only screen and (max-width: $medium-screen) {
     .card {
-      box-shadow: none;
       border: none;
+      box-shadow: none;
 
       .content-wrapper {
         padding: 0px;

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -15,6 +15,18 @@ hr {
   margin: 20px 0;
 }
 
+.text-align-left {
+  text-align: left;
+}
+
+.text-align-center {
+  text-align: center;
+}
+
+.text-align-right {
+  text-align: right;
+}
+
 #dwtcontrolContainer {
   display: none;
 }

--- a/web-client/src/styles/print.scss
+++ b/web-client/src/styles/print.scss
@@ -1,0 +1,79 @@
+.print-only {
+  @media screen {
+    display: none;
+  }
+  @media print {
+    display: block;
+  }
+}
+.print-view {
+  * {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
+
+  .only-large-screens {
+    display: block;
+  }
+
+  .only-small-screens {
+    display: none;
+  }
+
+  .hide-on-mobile {
+    display: block !important;
+  }
+
+  .responsive-table thead {
+    display: table-header-group;
+  }
+
+
+  // view-specific overrides
+  .party-information {
+    [class*='grid-col'] {
+      width: auto !important;
+    }
+  }
+
+  .docket-record-header {
+    display: none;
+  }
+}
+
+@media print {
+  .hide-print {
+    display: none !important;
+  }
+
+  .beta {
+    display: none;
+  }
+
+  .big-blue-header {
+    display: none;
+  }
+
+  header {
+    display: none !important;
+  }
+
+  button {
+    display: none;
+  }
+
+  .title {
+    display: none;
+  }
+
+  .print-header {
+    text-align: center;
+
+    .usa-logo {
+      width: 100px;
+      height: auto;
+    }
+  }
+
+  // view-specific overrides
+}

--- a/web-client/src/styles/print.scss
+++ b/web-client/src/styles/print.scss
@@ -24,6 +24,19 @@
     display: block !important;
   }
 
+  table td, table th {
+    padding: 8px;
+    &.hide-on-mobile {
+      display: table-cell !important;
+    }
+  }
+
+  a {
+    color: #000;
+    font-weight: $font-bold;
+    text-decoration: none;
+  }
+
   .responsive-table thead {
     display: table-header-group;
   }

--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -4,6 +4,7 @@ import { BeforeStartingCase } from './BeforeStartingCase';
 import { BeforeYouFileADocument } from './FileDocument/BeforeYouFileADocument';
 import { CaseDetail } from './CaseDetail';
 import { CaseDetailInternal } from './CaseDetailInternal';
+import { CaseDetailInternalPrint } from './CaseDetailInternalPrint';
 import { CreateOrder } from './CreateOrder/CreateOrder';
 import { DashboardDocketClerk } from './DashboardDocketClerk';
 import { DashboardPetitioner } from './DashboardPetitioner';
@@ -42,6 +43,7 @@ const pages = {
   BeforeYouFileADocument,
   CaseDetail,
   CaseDetailInternal,
+  CaseDetailInternalPrint,
   CreateOrder,
   DashboardDocketClerk,
   DashboardPetitioner,

--- a/web-client/src/views/CaseDetail/PartyInformation.jsx
+++ b/web-client/src/views/CaseDetail/PartyInformation.jsx
@@ -1,6 +1,5 @@
 import { EditSecondaryContactModal } from '../EditSecondaryContactModal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Mobile, NonMobile } from '../../ustc-ui/Responsive/Responsive';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -16,7 +15,7 @@ export const PartyInformation = connect(
     const mainPartyInformation = () => (
       <div className="grid-container padding-x-0">
         <div className="grid-row">
-          <div className="tablet:grid-col-2">
+          <div className="tablet:grid-col-2 hide-print">
             <p className="label">Party Type</p>
             <p>{caseDetail.partyType || 'My Party Type'}</p>
           </div>
@@ -154,18 +153,18 @@ export const PartyInformation = connect(
     };
     return (
       <div className="subsection party-information">
-        <NonMobile>
+        <div className="only-large-screens">
           <div className="card">
             <div className="content-wrapper">
               <h3 className="underlined">Party Information</h3>
               {mainPartyInformation()}
             </div>
           </div>
-        </NonMobile>
-        <Mobile>
+        </div>
+        <div className="only-small-screens">
           <h3>Party Information</h3>
           {mainPartyInformation()}
-        </Mobile>
+        </div>
 
         {caseHelper.showEditSecondaryContactModal && (
           <EditSecondaryContactModal />

--- a/web-client/src/views/CaseDetail/PartyInformation.jsx
+++ b/web-client/src/views/CaseDetail/PartyInformation.jsx
@@ -153,17 +153,11 @@ export const PartyInformation = connect(
     };
     return (
       <div className="subsection party-information">
-        <div className="only-large-screens">
-          <div className="card">
-            <div className="content-wrapper">
-              <h3 className="underlined">Party Information</h3>
-              {mainPartyInformation()}
-            </div>
+        <div className="card">
+          <div className="content-wrapper">
+            <h3 className="underlined">Party Information</h3>
+            {mainPartyInformation()}
           </div>
-        </div>
-        <div className="only-small-screens">
-          <h3>Party Information</h3>
-          {mainPartyInformation()}
         </div>
 
         {caseHelper.showEditSecondaryContactModal && (

--- a/web-client/src/views/CaseDetailHeader.jsx
+++ b/web-client/src/views/CaseDetailHeader.jsx
@@ -23,7 +23,7 @@ export const CaseDetailHeader = connect(
   }) => {
     return (
       <div className="big-blue-header">
-        <div className="grid-container foo-bar">
+        <div className="grid-container">
           <div className="grid-row">
             <div className="tablet:grid-col-8">
               <div className="margin-bottom-1">

--- a/web-client/src/views/CaseDetailInternalPrint.jsx
+++ b/web-client/src/views/CaseDetailInternalPrint.jsx
@@ -1,0 +1,63 @@
+import { DocketRecord } from './DocketRecord/DocketRecord';
+import { PartyInformation } from './CaseDetail/PartyInformation';
+import { connect } from '@cerebral/react';
+import { state } from 'cerebral';
+import React from 'react';
+import seal from '../images/ustc_seal.svg';
+
+export const CaseDetailInternalPrint = connect(
+  {
+    caseDetail: state.formattedCaseDetail,
+    caseHelper: state.caseDetailHelper,
+  },
+  ({ caseDetail, caseHelper }) => {
+    return (
+      <>
+        <div className="print-view">
+          <section className="print-header margin-bottom-3">
+            <div className="grid-container">
+              <div className="grid-row margin-top-3 margin-bottom-3">
+                <div className="grid-col-2">
+                  <div className="usa-logo">
+                    <img alt="USTC Seal" src={seal} />
+                  </div>
+                </div>
+                <div className="grid-col-8">
+                  <h1 className="margin-bottom-0 text-align-center margin-top-3">
+                    United States Tax Court
+                  </h1>
+                  <h2 className="margin-top-0 text-align-center">
+                    Docket Record
+                  </h2>
+                </div>
+                <div className="grid-col-2" />
+              </div>
+              <div className="grid-row margin-top-3 margin-bottom-3">
+                <div className="grid-col-4 text-align-left">
+                  {caseDetail.caseCaption}
+                </div>
+                <div className="grid-col-4" />
+                <div className="grid-col-4" />
+              </div>
+              <div className="grid-row">
+                <div className="grid-col-6 text-align-left">
+                  {caseHelper.caseCaptionPostfix}
+                </div>
+                <div className="grid-col-6 text-align-right">
+                  Docket Number: {caseDetail.docketNumberWithSuffix}
+                </div>
+              </div>
+              <div className="grid-row text-align-left margin-top-4">
+                <div className="grid-col-12">
+                  <PartyInformation />
+                  <DocketRecord />
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+        <iframe name="print-view"></iframe>
+      </>
+    );
+  },
+);

--- a/web-client/src/views/CaseDetailInternalPrint.jsx
+++ b/web-client/src/views/CaseDetailInternalPrint.jsx
@@ -23,10 +23,10 @@ export const CaseDetailInternalPrint = connect(
                   </div>
                 </div>
                 <div className="grid-col-8">
-                  <h1 className="margin-bottom-0 text-align-center margin-top-3">
+                  <h1 className="margin-bottom-0 text-align-center margin-top-1">
                     United States Tax Court
                   </h1>
-                  <h2 className="margin-top-0 text-align-center">
+                  <h2 className="margin-top-neg-3 text-align-center">
                     Docket Record
                   </h2>
                 </div>
@@ -56,7 +56,6 @@ export const CaseDetailInternalPrint = connect(
             </div>
           </section>
         </div>
-        <iframe name="print-view"></iframe>
       </>
     );
   },

--- a/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
@@ -7,20 +7,22 @@ export const DocketRecordHeader = connect(
   {
     caseDetail: state.formattedCaseDetail,
     helper: state.caseDetailHelper,
+    printView: sequences.printViewSequence,
     toggleMobileDocketSortSequence: sequences.toggleMobileDocketSortSequence,
     updateSessionMetadataSequence: sequences.updateSessionMetadataSequence,
   },
   ({
     caseDetail,
     helper,
+    printView,
     toggleMobileDocketSortSequence,
     updateSessionMetadataSequence,
   }) => {
     return (
       <React.Fragment>
-        <div className="grid-container padding-0">
+        <div className="grid-container padding-0 docket-record-header">
           <div className="grid-row">
-            <div className="tablet:grid-col-8">
+            <div className="tablet:grid-col-9">
               {helper.showAddDocketEntryButton && (
                 <a
                   className="usa-button"
@@ -41,7 +43,24 @@ export const DocketRecordHeader = connect(
                 </a>
               )}
             </div>
-            <div className="tablet:grid-offset-2 tablet:grid-col-2">
+            <div className="tablet:grid-col-1 text-align-right">
+              <button
+                className="usa-button usa-button--unstyled margin-top-1 margin-right-1"
+                onClick={() => {
+                  updateSessionMetadataSequence({
+                    key: `docketRecordSort.${caseDetail.caseId}`,
+                    value: 'byDate',
+                  });
+                  printView({
+                    printView: 'CaseDetailInternalPrint',
+                  });
+                }}
+              >
+                <FontAwesomeIcon icon="print" size="sm" />
+                Print
+              </button>
+            </div>
+            <div className="tablet:grid-col-2">
               <div className="only-large-screens">
                 <select
                   aria-label="docket record"

--- a/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
@@ -22,7 +22,7 @@ export const DocketRecordHeader = connect(
       <React.Fragment>
         <div className="grid-container padding-0 docket-record-header">
           <div className="grid-row">
-            <div className="tablet:grid-col-9">
+            <div className="tablet:grid-col-8">
               {helper.showAddDocketEntryButton && (
                 <a
                   className="usa-button"
@@ -43,7 +43,7 @@ export const DocketRecordHeader = connect(
                 </a>
               )}
             </div>
-            <div className="tablet:grid-col-1 text-align-right">
+            <div className="tablet:grid-col-2 text-align-right">
               <button
                 className="usa-button usa-button--unstyled margin-top-1 margin-right-1"
                 onClick={() => {


### PR DESCRIPTION
Adds Docket Record print view.

Couple of notes:

- There is some odd behavior from the mobile styles when the print preview is captured, catching some contents in transition, making them invisible, so things like removing <Mobile> were necessary to try and prevent this.
- The print view is a composed view, but some components still need some things hidden, which spreads that logic out. In order to clean this up better, we may need to rebuild the view from scratch without including those components. I'm concerned that modifying these components will introduce side-effects in the printed view if they aren't explicitly tested.
- Redirecting to the print view and then back to the referring view is not ideal. I tried modifying the current view, but I couldn't get the control over the styles to eliminate the odd behavior mentioned above. I also tried using an overlay to put the printed view above the current view. This may still be an option, but I was having some with this in the print preview, as elements below would spill out under. Perhaps hiding that content, along with the overlay is a solution to consider.