### PR TITLE
Bug: case caption shows twice on Order header if it is missing postfix

### DIFF
--- a/web-client/src/presenter/actions/CourtIssuedOrder/createOrderAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/createOrderAction.js
@@ -22,9 +22,12 @@ export const createOrderAction = ({ applicationContext, get }) => {
     '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
   );
   const caseCaption = get(state.caseDetail.caseCaption) || '';
-  const caseCaptionNames =
-    applicationContext.getCaseCaptionNames(caseCaption) + ', ';
-  const caseCaptionPostfix = caseCaption.replace(caseCaptionNames, '');
+  let caseCaptionNames = applicationContext.getCaseCaptionNames(caseCaption);
+  let caseCaptionPostfix = '';
+  if (caseCaptionNames !== caseCaption) {
+    caseCaptionNames += ', ';
+    caseCaptionPostfix = caseCaption.replace(caseCaptionNames, '');
+  }
   const docketNumberWithSuffix = get(
     state.formattedCaseDetail.docketNumberWithSuffix,
   );


### PR DESCRIPTION
![Screen Shot 2019-07-29 at 3 22 16 PM](https://user-images.githubusercontent.com/43251054/62079645-c5416c80-b214-11e9-9f47-71b9872cf7df.png)
