### PR TITLE
1272: add judge messages to seed data

### DIFF
--- a/cypress/integration/create-a-work-item.spec.js
+++ b/cypress/integration/create-a-work-item.spec.js
@@ -45,14 +45,14 @@ describe('Create a work item ', () => {
   it('creates a sent message in the petitionsclerk sent queue with yolo', () => {
     navigateToDashboard('petitionsclerk');
     viewMyOutbox();
-    getTableRows().should('have.length', 1);
+    getTableRows().should('have.length', 2);
     getWorkItemContaining('104-19').click();
     getWorkItemContaining('yolo').should('exist');
   });
 
   it('creates a section sent message in the petitions section', () => {
     viewSectionOutbox();
-    getTableRows().should('have.length', 1);
+    getTableRows().should('have.length', 2);
     getWorkItemContaining('104-19').click();
     getWorkItemContaining('yolo').should('exist');
   });

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "cypress:open": "CYPRESS=true cypress open --config watchForFileChanges=true",
     "cypress": "cypress run",
     "dynamo:admin": "DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin",
-    "dynamo:export": "AWS_ACCESS_KEY_ID=noop AWS_SECRET_ACCESS_KEY=noop SLS_DEPLOYMENT_BUCKET=noop node dynamo-export.js > ./storage/fixtures/efcms.json",
+    "dynamo:export": "AWS_ACCESS_KEY_ID=noop AWS_SECRET_ACCESS_KEY=noop SLS_DEPLOYMENT_BUCKET=noop node web-api/dynamo-export.js > ./web-api/storage/fixtures/efcms.json",
     "lint:swagger": "swagger-cli validate web-api/swagger.json",
     "lint:css:fix": "npm run lint:css -- --fix",
     "lint:css": "stylelint web-client/src/**/*.scss",

--- a/web-api/storage/fixtures/seed/101-19.json
+++ b/web-api/storage/fixtures/seed/101-19.json
@@ -1,197 +1,13 @@
 [
   {
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "document": {
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "documentType": "Petition",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
-    },
-    "section": "armensChambers",
-    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk",
-    "sentBySection": "petitions",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:36:56.870Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "sk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:36:56.870Z",
-        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
-        "from": "Test Petitionsclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "docketNumber": "101-19",
-    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:36:56.870Z"
-  },
-  {
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "document": {
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "documentType": "Petition",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
-    },
-    "section": "armensChambers",
-    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk",
-    "sentBySection": "petitions",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:36:56.870Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "sk": "2019-08-08T13:36:56.870Z",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:36:56.870Z",
-        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
-        "from": "Test Petitionsclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "section-outbox-petitions",
-    "docketNumber": "101-19",
-    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:36:56.870Z"
-  },
-  {
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "document": {
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "documentType": "Petition",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
-    },
-    "section": "armensChambers",
-    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk",
-    "sentBySection": "petitions",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:36:56.870Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "sk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:36:56.870Z",
-        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
-        "from": "Test Petitionsclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
-    "docketNumber": "101-19",
-    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:36:56.870Z"
-  },
-  {
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "document": {
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "documentType": "Petition",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
-    },
-    "section": "armensChambers",
-    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk",
-    "sentBySection": "petitions",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:36:56.870Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "sk": "2019-08-08T13:36:56.870Z",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:36:56.870Z",
-        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
-        "from": "Test Petitionsclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "user-outbox-3805d1ab-18d0-43ec-bafb-654e83405416",
-    "docketNumber": "101-19",
-    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:36:56.870Z"
-  },
-  {
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "document": {
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "documentType": "Petition",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
-    },
-    "section": "armensChambers",
-    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk",
-    "sentBySection": "petitions",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:36:56.870Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "sk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:36:56.870Z",
-        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
-        "from": "Test Petitionsclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "section-armensChambers",
-    "docketNumber": "101-19",
-    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:36:56.870Z"
-  },
-  {
-    "sk": "a5925a2e-101e-4c94-a1c0-53776453552c",
-    "pk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02|workItem"
-  },
-  {
     "procedureType": "Regular",
-    "initialTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "docketNumberSuffix": "W",
     "documents": [
       {
         "createdAt": "2019-03-01T21:40:46.415Z",
-        "processingStatus": "complete",
         "documentType": "Petition",
         "filedBy": "Test Petitioner",
+        "processingStatus": "complete",
         "workItems": [
           {
             "docketNumberSuffix": "W",
@@ -206,10 +22,10 @@
             },
             "section": "petitions",
             "workItemId": "2611344f-f7bf-4f47-8ba0-60c70cb25446",
+            "isInternal": false,
             "isInitializeCase": true,
             "assigneeId": null,
             "sentBy": "taxpayer",
-            "isInternal": false,
             "createdAt": "2019-03-01T21:40:46.415Z",
             "assigneeName": null,
             "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
@@ -217,67 +33,33 @@
               {
                 "createdAt": "2019-03-01T21:40:46.415Z",
                 "messageId": "1aafec9c-b7b9-45e8-8850-893cca973ce7",
-                "from": "Test Petitioner",
                 "message": "Petition filed by Brett Osborne is ready for review.",
+                "from": "Test Petitioner",
                 "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
               }
             ],
             "docketNumber": "101-19",
             "updatedAt": "2019-03-01T21:40:46.415Z"
-          },
-          {
-            "docketNumberSuffix": "W",
-            "caseStatus": "New",
-            "document": {
-              "createdAt": "2019-03-01T21:40:46.415Z",
-              "documentType": "Petition",
-              "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
-            },
-            "section": "armensChambers",
-            "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
-            "isInitializeCase": false,
-            "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-            "sentBy": "Test Petitionsclerk",
-            "sentBySection": "petitions",
-            "isInternal": true,
-            "createdAt": "2019-08-08T13:36:56.870Z",
-            "assigneeName": "Judge Armen",
-            "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-            "messages": [
-              {
-                "createdAt": "2019-08-08T13:36:56.870Z",
-                "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-                "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
-                "from": "Test Petitionsclerk",
-                "to": "Judge Armen",
-                "message": "This is a test message for Judge Armen.",
-                "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-              }
-            ],
-            "docketNumber": "101-19",
-            "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
-            "updatedAt": "2019-08-08T13:36:56.870Z"
           }
         ],
         "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
         "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76",
-        "receivedAt": "2019-08-08T13:36:56.870Z",
         "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       },
       {
-        "createdAt": "2019-03-05T17:34:13.491Z",
         "processingStatus": "complete",
+        "createdAt": "2019-03-05T17:34:13.491Z",
         "documentType": "Statement of Taxpayer Identification",
         "filedBy": "Test Petitioner",
         "workItems": [],
         "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8",
-        "receivedAt": "2019-08-08T13:36:56.870Z",
-        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8"
       }
     ],
-    "orderForFilingFee": false,
     "partyType": "Petitioner",
+    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "currentVersion": "0",
     "caseType": "Whistleblower",
     "yearAmounts": [],
     "contactPrimary": {
@@ -292,41 +74,124 @@
       "countryType": "domestic",
       "email": "taxpayer"
     },
-    "createdAt": "2019-03-01T21:40:46.415Z",
-    "noticeOfAttachments": false,
-    "caseCaption": "Brett Osborne, Petitioner",
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "sk": "1",
-    "filingType": "Myself",
-    "orderForOds": false,
-    "orderForRatification": false,
-    "hasIrsNotice": false,
-    "initialDocketNumberSuffix": "W",
-    "docketNumberSuffix": "W",
-    "caseTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
-    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "currentVersion": "1",
-    "orderForAmendedPetition": false,
-    "orderToShowCause": false,
     "preferredTrialCity": "Birmingham, Alabama",
-    "respondents": [],
-    "practitioners": [],
+    "createdAt": "2019-03-01T21:40:46.415Z",
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
     "docketRecord": [
       {
-        "description": "Petition",
-        "index": 1,
         "filingDate": "2019-03-01T21:40:46.415Z",
-        "filedBy": "Test Petitioner"
+        "description": "Petition",
+        "filedBy": "Test Petitioner",
+        "index": 1
       },
       {
-        "description": "Request for Place of Trial at Birmingham, Alabama",
         "filingDate": "2019-03-01T21:40:46.415Z",
+        "description": "Request for Place of Trial at Birmingham, Alabama",
         "index": 2
       }
     ],
-    "orderForAmendedPetitionAndFilingFee": false,
+    "sk": "0",
+    "caseCaption": "Brett Osborne, Petitioner",
+    "caseTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "initialTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "filingType": "Myself",
     "pk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "hasIrsNotice": false,
+    "petitioners": [
+      {
+        "role": "petitioner",
+        "name": "Test Petitioner",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+        "custom:role": "petitioner",
+        "iat": 1551476326,
+        "email": "taxpayer",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0YXhwYXllciIsInNlY3Rpb24iOiJwZXRpdGlvbmVyIiwibmFtZSI6IlRlc3QgUGV0aXRpb25lciIsImN1c3RvbTpyb2xlIjoicGV0aXRpb25lciIsInJvbGUiOiJwZXRpdGlvbmVyIiwiZW1haWwiOiJ0YXhwYXllciIsImlhdCI6MTU1MTQ3NjMyNn0.4oFS9lipN-OViu7SuWmkBrUeZMk8-i4o0XdbDLEkaaU"
+      }
+    ],
     "docketNumber": "101-19",
     "status": "New"
+  },
+  {
+    "sk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
+  },
+  {
+    "sk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "pk": "101-19|case"
+  },
+  {
+    "sk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
+    "pk": "section-petitions",
+    "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "document": {
+      "processingStatus": "complete",
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "receivedAt": "2019-03-01T21:40:46.415Z",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76",
+      "documentType": "Petition",
+      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+      "filedBy": "Test Petitioner",
+      "workItems": []
+    },
+    "section": "petitions",
+    "workItemId": "2611344f-f7bf-4f47-8ba0-60c70cb25446",
+    "isInternal": false,
+    "isInitializeCase": true,
+    "assigneeId": null,
+    "sentBy": "taxpayer",
+    "createdAt": "2019-03-01T21:40:46.415Z",
+    "assigneeName": null,
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "gsi1pk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
+
+    "messages": [
+      {
+        "createdAt": "2019-03-01T21:40:46.415Z",
+        "messageId": "1aafec9c-b7b9-45e8-8850-893cca973ce7",
+        "message": "Petition filed by Brett Osborne is ready for review.",
+        "from": "Test Petitioner",
+        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "docketNumber": "101-19",
+    "updatedAt": "2019-03-01T21:40:46.415Z"
+  },
+  {
+    "sk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
+    "pk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
+    "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "document": {
+      "processingStatus": "complete",
+      "receivedAt": "2019-03-01T21:40:46.415Z",
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76",
+      "documentType": "Petition",
+      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+      "filedBy": "Test Petitioner",
+      "workItems": []
+    },
+    "section": "petitions",
+    "workItemId": "2611344f-f7bf-4f47-8ba0-60c70cb25446",
+    "isInternal": false,
+    "isInitializeCase": true,
+    "assigneeId": null,
+    "sentBy": "taxpayer",
+    "createdAt": "2019-03-01T21:40:46.415Z",
+    "assigneeName": null,
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "gsi1pk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
+    "messages": [
+      {
+        "createdAt": "2019-03-01T21:40:46.415Z",
+        "messageId": "1aafec9c-b7b9-45e8-8850-893cca973ce7",
+        "message": "Petition filed by Brett Osborne is ready for review.",
+        "from": "Test Petitioner",
+        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "docketNumber": "101-19",
+    "updatedAt": "2019-03-01T21:40:46.415Z"
   }
 ]

--- a/web-api/storage/fixtures/seed/101-19.json
+++ b/web-api/storage/fixtures/seed/101-19.json
@@ -1,13 +1,197 @@
 [
   {
-    "procedureType": "Regular",
     "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "document": {
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "documentType": "Petition",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
+    },
+    "section": "armensChambers",
+    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:36:56.870Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "sk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:36:56.870Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "docketNumber": "101-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:36:56.870Z"
+  },
+  {
+    "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "document": {
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "documentType": "Petition",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
+    },
+    "section": "armensChambers",
+    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:36:56.870Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "sk": "2019-08-08T13:36:56.870Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:36:56.870Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-outbox-petitions",
+    "docketNumber": "101-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:36:56.870Z"
+  },
+  {
+    "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "document": {
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "documentType": "Petition",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
+    },
+    "section": "armensChambers",
+    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:36:56.870Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "sk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:36:56.870Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "101-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:36:56.870Z"
+  },
+  {
+    "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "document": {
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "documentType": "Petition",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
+    },
+    "section": "armensChambers",
+    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:36:56.870Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "sk": "2019-08-08T13:36:56.870Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:36:56.870Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-outbox-3805d1ab-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "101-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:36:56.870Z"
+  },
+  {
+    "docketNumberSuffix": "W",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "document": {
+      "createdAt": "2019-03-01T21:40:46.415Z",
+      "documentType": "Petition",
+      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
+    },
+    "section": "armensChambers",
+    "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:36:56.870Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "sk": "workitem-a5925a2e-101e-4c94-a1c0-53776453552c",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:36:56.870Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-armensChambers",
+    "docketNumber": "101-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:36:56.870Z"
+  },
+  {
+    "sk": "a5925a2e-101e-4c94-a1c0-53776453552c",
+    "pk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02|workItem"
+  },
+  {
+    "procedureType": "Regular",
+    "initialTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
     "documents": [
       {
         "createdAt": "2019-03-01T21:40:46.415Z",
+        "processingStatus": "complete",
         "documentType": "Petition",
         "filedBy": "Test Petitioner",
-        "processingStatus": "complete",
         "workItems": [
           {
             "docketNumberSuffix": "W",
@@ -22,10 +206,10 @@
             },
             "section": "petitions",
             "workItemId": "2611344f-f7bf-4f47-8ba0-60c70cb25446",
-            "isInternal": false,
             "isInitializeCase": true,
             "assigneeId": null,
             "sentBy": "taxpayer",
+            "isInternal": false,
             "createdAt": "2019-03-01T21:40:46.415Z",
             "assigneeName": null,
             "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
@@ -33,33 +217,67 @@
               {
                 "createdAt": "2019-03-01T21:40:46.415Z",
                 "messageId": "1aafec9c-b7b9-45e8-8850-893cca973ce7",
-                "message": "Petition filed by Brett Osborne is ready for review.",
                 "from": "Test Petitioner",
+                "message": "Petition filed by Brett Osborne is ready for review.",
                 "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
               }
             ],
             "docketNumber": "101-19",
             "updatedAt": "2019-03-01T21:40:46.415Z"
+          },
+          {
+            "docketNumberSuffix": "W",
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-03-01T21:40:46.415Z",
+              "documentType": "Petition",
+              "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76"
+            },
+            "section": "armensChambers",
+            "workItemId": "a5925a2e-101e-4c94-a1c0-53776453552c",
+            "isInitializeCase": false,
+            "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+            "sentBy": "Test Petitionsclerk",
+            "sentBySection": "petitions",
+            "isInternal": true,
+            "createdAt": "2019-08-08T13:36:56.870Z",
+            "assigneeName": "Judge Armen",
+            "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+            "messages": [
+              {
+                "createdAt": "2019-08-08T13:36:56.870Z",
+                "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+                "messageId": "1a61f88d-321a-423e-8e6e-dce79616a76e",
+                "from": "Test Petitionsclerk",
+                "to": "Judge Armen",
+                "message": "This is a test message for Judge Armen.",
+                "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "101-19",
+            "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+            "updatedAt": "2019-08-08T13:36:56.870Z"
           }
         ],
         "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
         "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76",
+        "receivedAt": "2019-08-08T13:36:56.870Z",
         "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       },
       {
-        "processingStatus": "complete",
         "createdAt": "2019-03-05T17:34:13.491Z",
+        "processingStatus": "complete",
         "documentType": "Statement of Taxpayer Identification",
         "filedBy": "Test Petitioner",
         "workItems": [],
         "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8"
+        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8",
+        "receivedAt": "2019-08-08T13:36:56.870Z",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       }
     ],
+    "orderForFilingFee": false,
     "partyType": "Petitioner",
-    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "currentVersion": "0",
     "caseType": "Whistleblower",
     "yearAmounts": [],
     "contactPrimary": {
@@ -74,124 +292,41 @@
       "countryType": "domestic",
       "email": "taxpayer"
     },
-    "preferredTrialCity": "Birmingham, Alabama",
     "createdAt": "2019-03-01T21:40:46.415Z",
+    "noticeOfAttachments": false,
+    "caseCaption": "Brett Osborne, Petitioner",
     "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
+    "sk": "1",
+    "filingType": "Myself",
+    "orderForOds": false,
+    "orderForRatification": false,
+    "hasIrsNotice": false,
+    "initialDocketNumberSuffix": "W",
+    "docketNumberSuffix": "W",
+    "caseTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "currentVersion": "1",
+    "orderForAmendedPetition": false,
+    "orderToShowCause": false,
+    "preferredTrialCity": "Birmingham, Alabama",
+    "respondents": [],
+    "practitioners": [],
     "docketRecord": [
       {
-        "filingDate": "2019-03-01T21:40:46.415Z",
         "description": "Petition",
-        "filedBy": "Test Petitioner",
-        "index": 1
+        "index": 1,
+        "filingDate": "2019-03-01T21:40:46.415Z",
+        "filedBy": "Test Petitioner"
       },
       {
-        "filingDate": "2019-03-01T21:40:46.415Z",
         "description": "Request for Place of Trial at Birmingham, Alabama",
+        "filingDate": "2019-03-01T21:40:46.415Z",
         "index": 2
       }
     ],
-    "sk": "0",
-    "caseCaption": "Brett Osborne, Petitioner",
-    "caseTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
-    "initialTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
-    "filingType": "Myself",
+    "orderForAmendedPetitionAndFilingFee": false,
     "pk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "hasIrsNotice": false,
-    "petitioners": [
-      {
-        "role": "petitioner",
-        "name": "Test Petitioner",
-        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-        "custom:role": "petitioner",
-        "iat": 1551476326,
-        "email": "taxpayer",
-        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0YXhwYXllciIsInNlY3Rpb24iOiJwZXRpdGlvbmVyIiwibmFtZSI6IlRlc3QgUGV0aXRpb25lciIsImN1c3RvbTpyb2xlIjoicGV0aXRpb25lciIsInJvbGUiOiJwZXRpdGlvbmVyIiwiZW1haWwiOiJ0YXhwYXllciIsImlhdCI6MTU1MTQ3NjMyNn0.4oFS9lipN-OViu7SuWmkBrUeZMk8-i4o0XdbDLEkaaU"
-      }
-    ],
     "docketNumber": "101-19",
     "status": "New"
-  },
-  {
-    "sk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
-  },
-  {
-    "sk": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "pk": "101-19|case"
-  },
-  {
-    "sk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
-    "pk": "section-petitions",
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "document": {
-      "processingStatus": "complete",
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "receivedAt": "2019-03-01T21:40:46.415Z",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76",
-      "documentType": "Petition",
-      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-      "filedBy": "Test Petitioner",
-      "workItems": []
-    },
-    "section": "petitions",
-    "workItemId": "2611344f-f7bf-4f47-8ba0-60c70cb25446",
-    "isInternal": false,
-    "isInitializeCase": true,
-    "assigneeId": null,
-    "sentBy": "taxpayer",
-    "createdAt": "2019-03-01T21:40:46.415Z",
-    "assigneeName": null,
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "gsi1pk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
-
-    "messages": [
-      {
-        "createdAt": "2019-03-01T21:40:46.415Z",
-        "messageId": "1aafec9c-b7b9-45e8-8850-893cca973ce7",
-        "message": "Petition filed by Brett Osborne is ready for review.",
-        "from": "Test Petitioner",
-        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "docketNumber": "101-19",
-    "updatedAt": "2019-03-01T21:40:46.415Z"
-  },
-  {
-    "sk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
-    "pk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
-    "docketNumberSuffix": "W",
-    "caseStatus": "New",
-    "document": {
-      "processingStatus": "complete",
-      "receivedAt": "2019-03-01T21:40:46.415Z",
-      "createdAt": "2019-03-01T21:40:46.415Z",
-      "documentId": "1f1aa3f7-e2e3-43e6-885d-4ce341588c76",
-      "documentType": "Petition",
-      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-      "filedBy": "Test Petitioner",
-      "workItems": []
-    },
-    "section": "petitions",
-    "workItemId": "2611344f-f7bf-4f47-8ba0-60c70cb25446",
-    "isInternal": false,
-    "isInitializeCase": true,
-    "assigneeId": null,
-    "sentBy": "taxpayer",
-    "createdAt": "2019-03-01T21:40:46.415Z",
-    "assigneeName": null,
-    "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
-    "gsi1pk": "workitem-2611344f-f7bf-4f47-8ba0-60c70cb25446",
-    "messages": [
-      {
-        "createdAt": "2019-03-01T21:40:46.415Z",
-        "messageId": "1aafec9c-b7b9-45e8-8850-893cca973ce7",
-        "message": "Petition filed by Brett Osborne is ready for review.",
-        "from": "Test Petitioner",
-        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "docketNumber": "101-19",
-    "updatedAt": "2019-03-01T21:40:46.415Z"
   }
 ]

--- a/web-api/storage/fixtures/seed/103-19.json
+++ b/web-api/storage/fixtures/seed/103-19.json
@@ -324,5 +324,396 @@
     ],
     "docketNumber": "103-19",
     "updatedAt": "2019-03-01T22:54:06.000Z"
+  },
+  {
+    "sk": "8686ddef-c74d-4d26-8748-6b22914c7687",
+    "pk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50|workItem"
+  },
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "8686ddef-c74d-4d26-8748-6b22914c7687",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:33:24.183Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:33:24.183Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "549d6fc7-786b-40da-b360-b1c73d51371e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-armensChambers",
+    "docketNumber": "103-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:33:24.183Z"
+  },
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "8686ddef-c74d-4d26-8748-6b22914c7687",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:33:24.183Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "2019-08-08T14:33:24.183Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:33:24.183Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "549d6fc7-786b-40da-b360-b1c73d51371e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-outbox-3805d1ab-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "103-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:33:24.183Z"
+  },
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "8686ddef-c74d-4d26-8748-6b22914c7687",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:33:24.183Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:33:24.183Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "549d6fc7-786b-40da-b360-b1c73d51371e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "103-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:33:24.183Z"
+  },
+
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "8686ddef-c74d-4d26-8748-6b22914c7687",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:33:24.183Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:33:24.183Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "549d6fc7-786b-40da-b360-b1c73d51371e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "docketNumber": "103-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:33:24.183Z"
+  },
+  {
+    "procedureType": "Small",
+    "initialTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "documents": [
+      {
+        "createdAt": "2019-03-01T22:53:50.098Z",
+        "processingStatus": "complete",
+        "documentType": "Petition",
+        "filedBy": "Test Petitioner",
+        "workItems": [
+          {
+            "docketNumberSuffix": "S",
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-03-01T22:53:50.098Z",
+              "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
+              "documentType": "Petition",
+              "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+              "filedBy": "Test Petitioner",
+              "workItems": []
+            },
+            "section": "petitions",
+            "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
+            "isInitializeCase": true,
+            "assigneeId": null,
+            "sentBy": "taxpayer",
+            "isInternal": false,
+            "createdAt": "2019-03-01T22:53:50.098Z",
+            "assigneeName": null,
+            "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+            "messages": [
+              {
+                "createdAt": "2019-03-01T22:53:50.098Z",
+                "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
+                "from": "Test Petitioner",
+                "message": "Petition filed by Samson Workman is ready for review.",
+                "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "103-19",
+            "updatedAt": "2019-03-01T22:53:50.098Z"
+          }
+        ],
+        "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+        "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
+        "receivedAt": "2019-08-08T14:33:24.183Z",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      },
+      {
+        "createdAt": "2019-03-05T17:34:13.491Z",
+        "processingStatus": "complete",
+        "documentType": "Statement of Taxpayer Identification",
+        "filedBy": "Test Petitioner",
+        "workItems": [],
+        "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8",
+        "receivedAt": "2019-08-08T14:33:24.183Z",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      },
+      {
+        "createdAt": "2019-03-01T22:54:05.993Z",
+        "processingStatus": "complete",
+        "documentType": "Answer",
+        "filedBy": "Test Respondent",
+        "workItems": [
+          {
+            "docketNumberSuffix": "S",
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-03-01T22:54:05.993Z",
+              "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
+              "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+              "documentType": "Answer",
+              "filedBy": "Test Respondent",
+              "workItems": []
+            },
+            "section": "docket",
+            "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+            "assigneeId": null,
+            "sentBy": "respondent",
+            "isInternal": false,
+            "createdAt": "2019-03-01T22:54:06.000Z",
+            "assigneeName": null,
+            "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+            "messages": [
+              {
+                "createdAt": "2019-03-01T22:54:06.000Z",
+                "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
+                "from": "Test Respondent",
+                "message": "Answer filed by Respondent is ready for review.",
+                "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "103-19",
+            "updatedAt": "2019-03-01T22:54:06.000Z"
+          },
+          {
+            "docketNumberSuffix": "S",
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-03-01T22:54:05.993Z",
+              "documentType": "Answer",
+              "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+            },
+            "section": "armensChambers",
+            "workItemId": "8686ddef-c74d-4d26-8748-6b22914c7687",
+            "isInitializeCase": false,
+            "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+            "sentBy": "Test Petitionsclerk",
+            "sentBySection": "petitions",
+            "isInternal": true,
+            "createdAt": "2019-08-08T14:33:24.183Z",
+            "assigneeName": "Judge Armen",
+            "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+            "messages": [
+              {
+                "createdAt": "2019-08-08T14:33:24.183Z",
+                "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+                "messageId": "549d6fc7-786b-40da-b360-b1c73d51371e",
+                "from": "Test Petitionsclerk",
+                "to": "Judge Armen",
+                "message": "This is a test message for Judge Armen.",
+                "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "103-19",
+            "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+            "updatedAt": "2019-08-08T14:33:24.183Z"
+          }
+        ],
+        "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+        "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
+        "receivedAt": "2019-08-08T14:33:24.183Z",
+        "userId": "respondent"
+      }
+    ],
+    "orderForFilingFee": false,
+    "partyType": "Petitioner",
+    "caseType": "Deficiency",
+    "yearAmounts": [],
+    "contactPrimary": {
+      "address3": "Officiis sit consect",
+      "address2": "Eiusmod officiis dol",
+      "city": "Laborum Expedita qu",
+      "phone": "+1 (523) 202-1718",
+      "address1": "40 East Cowley Boulevard",
+      "postalCode": "18152",
+      "name": "Samson Workman",
+      "state": "MA",
+      "countryType": "domestic",
+      "email": "taxpayer"
+    },
+    "createdAt": "2019-03-01T22:53:50.097Z",
+    "noticeOfAttachments": false,
+    "caseCaption": "Samson Workman, Petitioner",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "1",
+    "filingType": "Myself",
+    "orderForOds": false,
+    "orderForRatification": false,
+    "hasIrsNotice": false,
+    "initialDocketNumberSuffix": "S",
+    "docketNumberSuffix": "S",
+    "caseTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "currentVersion": "1",
+    "orderForAmendedPetition": false,
+    "orderToShowCause": false,
+    "preferredTrialCity": "Mobile, Alabama",
+    "respondents": [
+      {
+        "role": "respondent",
+        "name": "Test Respondent",
+        "custom:role": "respondent",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+        "iat": 1551480838,
+        "respondentId": "respondent",
+        "email": "respondent",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InJlc3BvbmRlbnQiLCJlbWFpbCI6InJlc3BvbmRlbnQiLCJuYW1lIjoiVGVzdCBSZXNwb25kZW50Iiwicm9sZSI6InJlc3BvbmRlbnQiLCJzZWN0aW9uIjoicGV0aXRpb25zIiwidXNlcklkIjoicmVzcG9uZGVudCIsImlhdCI6MTU1MTQ4MDgzOH0.U72pP7ZEwQkQIzlhpKvaEdMbcQhCjSLQbp0FP06LKao"
+      }
+    ],
+    "practitioners": [],
+    "docketRecord": [
+      {
+        "description": "Petition",
+        "index": 1,
+        "filingDate": "2019-03-01T22:53:50.098Z",
+        "filedBy": "Test Petitioner"
+      },
+      {
+        "description": "Request for Place of Trial at Mobile, Alabama",
+        "filingDate": "2019-03-01T22:53:50.097Z",
+        "index": 2
+      },
+      {
+        "description": "Answer",
+        "index": 3,
+        "filingDate": "2019-03-01T22:54:05.993Z",
+        "filedBy": "Test Respondent"
+      }
+    ],
+    "orderForAmendedPetitionAndFilingFee": false,
+    "pk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "docketNumber": "103-19",
+    "status": "New"
+  },
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-8686ddef-c74d-4d26-8748-6b22914c7687",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "8686ddef-c74d-4d26-8748-6b22914c7687",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk",
+    "sentBySection": "petitions",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:33:24.183Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "2019-08-08T14:33:24.183Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:33:24.183Z",
+        "fromUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "549d6fc7-786b-40da-b360-b1c73d51371e",
+        "from": "Test Petitionsclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-outbox-petitions",
+    "docketNumber": "103-19",
+    "sentByUserId": "3805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:33:24.183Z"
   }
 ]

--- a/web-api/storage/fixtures/seed/103-19.json
+++ b/web-api/storage/fixtures/seed/103-19.json
@@ -1,13 +1,49 @@
 [
   {
-    "procedureType": "Small",
     "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:12:56.627Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:12:56.626Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
+    "docketNumber": "103-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:12:56.627Z"
+  },
+  {
+    "procedureType": "Small",
+    "initialTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
     "documents": [
       {
         "createdAt": "2019-03-01T22:53:50.098Z",
+        "processingStatus": "complete",
         "documentType": "Petition",
         "filedBy": "Test Petitioner",
-        "processingStatus": "complete",
         "workItems": [
           {
             "docketNumberSuffix": "S",
@@ -22,10 +58,10 @@
             },
             "section": "petitions",
             "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
-            "isInternal": false,
             "isInitializeCase": true,
             "assigneeId": null,
             "sentBy": "taxpayer",
+            "isInternal": false,
             "createdAt": "2019-03-01T22:53:50.098Z",
             "assigneeName": null,
             "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
@@ -33,8 +69,8 @@
               {
                 "createdAt": "2019-03-01T22:53:50.098Z",
                 "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
-                "message": "Petition filed by Samson Workman is ready for review.",
                 "from": "Test Petitioner",
+                "message": "Petition filed by Samson Workman is ready for review.",
                 "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
               }
             ],
@@ -44,21 +80,23 @@
         ],
         "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
         "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
+        "receivedAt": "2019-08-08T13:12:56.626Z",
         "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       },
       {
-        "processingStatus": "complete",
         "createdAt": "2019-03-05T17:34:13.491Z",
+        "processingStatus": "complete",
         "documentType": "Statement of Taxpayer Identification",
         "filedBy": "Test Petitioner",
         "workItems": [],
         "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8"
+        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8",
+        "receivedAt": "2019-08-08T13:12:56.626Z",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       },
       {
-        "processingStatus": "complete",
         "createdAt": "2019-03-01T22:54:05.993Z",
+        "processingStatus": "complete",
         "documentType": "Answer",
         "filedBy": "Test Respondent",
         "workItems": [
@@ -75,9 +113,9 @@
             },
             "section": "docket",
             "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
-            "isInternal": false,
             "assigneeId": null,
             "sentBy": "respondent",
+            "isInternal": false,
             "createdAt": "2019-03-01T22:54:06.000Z",
             "assigneeName": null,
             "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
@@ -85,35 +123,56 @@
               {
                 "createdAt": "2019-03-01T22:54:06.000Z",
                 "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
-                "message": "Answer filed by Respondent is ready for review.",
                 "from": "Test Respondent",
+                "message": "Answer filed by Respondent is ready for review.",
                 "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
               }
             ],
             "docketNumber": "103-19",
             "updatedAt": "2019-03-01T22:54:06.000Z"
+          },
+          {
+            "docketNumberSuffix": "S",
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-03-01T22:54:05.993Z",
+              "documentType": "Answer",
+              "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+            },
+            "section": "armensChambers",
+            "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
+            "isInitializeCase": false,
+            "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+            "sentBy": "Test Docketclerk",
+            "sentBySection": "docket",
+            "isInternal": true,
+            "createdAt": "2019-08-08T13:12:56.627Z",
+            "assigneeName": "Judge Armen",
+            "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+            "messages": [
+              {
+                "createdAt": "2019-08-08T13:12:56.626Z",
+                "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+                "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
+                "from": "Test Docketclerk",
+                "to": "Judge Armen",
+                "message": "This is a test message for Judge Armen.",
+                "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "103-19",
+            "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+            "updatedAt": "2019-08-08T13:12:56.627Z"
           }
         ],
         "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
         "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
+        "receivedAt": "2019-08-08T13:12:56.626Z",
         "userId": "respondent"
       }
     ],
-    "respondents": [
-      {
-        "role": "respondent",
-        "name": "Test Respondent",
-        "custom:role": "respondent",
-        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
-        "iat": 1551480838,
-        "respondentId": "respondent",
-        "email": "respondent",
-        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InJlc3BvbmRlbnQiLCJlbWFpbCI6InJlc3BvbmRlbnQiLCJuYW1lIjoiVGVzdCBSZXNwb25kZW50Iiwicm9sZSI6InJlc3BvbmRlbnQiLCJzZWN0aW9uIjoicGV0aXRpb25zIiwidXNlcklkIjoicmVzcG9uZGVudCIsImlhdCI6MTU1MTQ4MDgzOH0.U72pP7ZEwQkQIzlhpKvaEdMbcQhCjSLQbp0FP06LKao"
-      }
-    ],
+    "orderForFilingFee": false,
     "partyType": "Petitioner",
-    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "currentVersion": "0",
     "caseType": "Deficiency",
     "yearAmounts": [],
     "contactPrimary": {
@@ -128,15 +187,42 @@
       "countryType": "domestic",
       "email": "taxpayer"
     },
-    "preferredTrialCity": "Mobile, Alabama",
     "createdAt": "2019-03-01T22:53:50.097Z",
+    "noticeOfAttachments": false,
+    "caseCaption": "Samson Workman, Petitioner",
     "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "1",
+    "filingType": "Myself",
+    "orderForOds": false,
+    "orderForRatification": false,
+    "hasIrsNotice": false,
+    "initialDocketNumberSuffix": "S",
+    "docketNumberSuffix": "S",
+    "caseTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "currentVersion": "1",
+    "orderForAmendedPetition": false,
+    "orderToShowCause": false,
+    "preferredTrialCity": "Mobile, Alabama",
+    "respondents": [
+      {
+        "role": "respondent",
+        "name": "Test Respondent",
+        "custom:role": "respondent",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+        "iat": 1551480838,
+        "respondentId": "respondent",
+        "email": "respondent",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InJlc3BvbmRlbnQiLCJlbWFpbCI6InJlc3BvbmRlbnQiLCJuYW1lIjoiVGVzdCBSZXNwb25kZW50Iiwicm9sZSI6InJlc3BvbmRlbnQiLCJzZWN0aW9uIjoicGV0aXRpb25zIiwidXNlcklkIjoicmVzcG9uZGVudCIsImlhdCI6MTU1MTQ4MDgzOH0.U72pP7ZEwQkQIzlhpKvaEdMbcQhCjSLQbp0FP06LKao"
+      }
+    ],
+    "practitioners": [],
     "docketRecord": [
       {
         "description": "Petition",
+        "index": 1,
         "filingDate": "2019-03-01T22:53:50.098Z",
-        "filedBy": "Test Petitioner",
-        "index": 1
+        "filedBy": "Test Petitioner"
       },
       {
         "description": "Request for Place of Trial at Mobile, Alabama",
@@ -145,184 +231,162 @@
       },
       {
         "description": "Answer",
+        "index": 3,
         "filingDate": "2019-03-01T22:54:05.993Z",
-        "filedBy": "Test Respondent",
-        "index": 3
+        "filedBy": "Test Respondent"
       }
     ],
-    "sk": "0",
-    "caseCaption": "Samson Workman, Petitioner",
-    "caseTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
-    "initialTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
-    "filingType": "Myself",
+    "orderForAmendedPetitionAndFilingFee": false,
     "pk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "hasIrsNotice": false,
-    "petitioners": [
-      {
-        "role": "petitioner",
-        "name": "Test Petitioner",
-        "custom:role": "petitioner",
-        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-        "iat": 1551480807,
-        "email": "taxpayer",
-        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InBldGl0aW9uZXIiLCJlbWFpbCI6InRheHBheWVyIiwibmFtZSI6IlRlc3QgUGV0aXRpb25lciIsInJvbGUiOiJwZXRpdGlvbmVyIiwic2VjdGlvbiI6InBldGl0aW9uZXIiLCJ1c2VySWQiOiJ0YXhwYXllciIsImlhdCI6MTU1MTQ4MDgwN30.sV0OKvwCmL1YUSmvC3-rCviw6iyIj4491Gr-GipsC60"
-      }
-    ],
     "docketNumber": "103-19",
     "status": "New"
   },
   {
-    "sk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
-  },
-  {
-    "sk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "pk": "103-19|case"
-  },
-  {
-    "sk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "pk": "5805d1ab-18d0-43ec-bafb-654e83405416|case"
-  },
-  {
-    "sk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
-    "pk": "section-petitions",
-    "gsi1pk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
     "docketNumberSuffix": "S",
     "caseStatus": "New",
-    "document": {
-      "receivedAt": "2019-03-01T21:40:46.415Z",
-      "createdAt": "2019-03-01T22:53:50.098Z",
-      "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
-      "documentType": "Petition",
-      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-      "filedBy": "Test Petitioner",
-      "workItems": []
-    },
-    "section": "petitions",
-    "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
-    "isInternal": false,
-    "isInitializeCase": true,
-    "assigneeId": null,
-    "sentBy": "taxpayer",
-    "createdAt": "2019-03-01T22:53:50.098Z",
-    "assigneeName": null,
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "messages": [
-      {
-        "createdAt": "2019-03-01T22:53:50.098Z",
-        "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
-        "message": "Petition filed by Samson Workman is ready for review.",
-        "from": "Test Petitioner",
-        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "docketNumber": "103-19",
-    "updatedAt": "2019-03-01T22:53:50.098Z"
-  },
-  {
-    "sk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
-    "pk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
-    "gsi1pk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
-    "docketNumberSuffix": "S",
-    "caseStatus": "New",
-    "document": {
-      "receivedAt": "2019-03-01T21:40:46.415Z",
-      "createdAt": "2019-03-01T22:53:50.098Z",
-      "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
-      "documentType": "Petition",
-      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-      "filedBy": "Test Petitioner",
-      "workItems": []
-    },
-    "section": "petitions",
-    "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
-    "isInternal": false,
-    "isInitializeCase": true,
-    "assigneeId": null,
-    "sentBy": "taxpayer",
-    "createdAt": "2019-03-01T22:53:50.098Z",
-    "assigneeName": null,
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "messages": [
-      {
-        "createdAt": "2019-03-01T22:53:50.098Z",
-        "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
-        "message": "Petition filed by Samson Workman is ready for review.",
-        "from": "Test Petitioner",
-        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "docketNumber": "103-19",
-    "updatedAt": "2019-03-01T22:53:50.098Z"
-  },
-  {
-    "sk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
-    "pk": "section-docket",
-    "gsi1pk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
-    "docketNumberSuffix": "S",
-    "caseStatus": "New",
+    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
     "document": {
       "createdAt": "2019-03-01T22:54:05.993Z",
-      "receivedAt": "2019-03-01T21:40:46.415Z",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
-      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
       "documentType": "Answer",
-      "filedBy": "Test Respondent",
-      "workItems": []
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
     },
-    "section": "docket",
-    "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
-    "isInternal": false,
-    "assigneeId": null,
-    "sentBy": "respondent",
-    "createdAt": "2019-03-01T22:54:06.000Z",
-    "assigneeName": null,
+    "section": "armensChambers",
+    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:12:56.627Z",
+    "assigneeName": "Judge Armen",
     "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "2019-08-08T13:12:56.627Z",
     "messages": [
       {
-        "createdAt": "2019-03-01T22:54:06.000Z",
-        "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
-        "message": "Answer filed by Respondent is ready for review.",
-        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
-        "from": "Test Respondent",
-        "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:12:56.626Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
+    "pk": "section-outbox-docket",
     "docketNumber": "103-19",
-    "updatedAt": "2019-03-01T22:54:06.000Z"
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:12:56.627Z"
   },
   {
-    "sk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
-    "pk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
     "docketNumberSuffix": "S",
     "caseStatus": "New",
+    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
     "document": {
       "createdAt": "2019-03-01T22:54:05.993Z",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
-      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
       "documentType": "Answer",
-      "filedBy": "Test Respondent",
-      "workItems": []
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
     },
-    "section": "docket",
-    "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
-    "isInternal": false,
-    "assigneeId": null,
-    "sentBy": "respondent",
-    "createdAt": "2019-03-01T22:54:06.000Z",
-    "assigneeName": null,
+    "section": "armensChambers",
+    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:12:56.627Z",
+    "assigneeName": "Judge Armen",
     "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
     "messages": [
       {
-        "createdAt": "2019-03-01T22:54:06.000Z",
-        "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
-        "message": "Answer filed by Respondent is ready for review.",
-        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
-        "from": "Test Respondent",
-        "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:12:56.626Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
+    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
     "docketNumber": "103-19",
-    "updatedAt": "2019-03-01T22:54:06.000Z"
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:12:56.627Z"
+  },
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:12:56.627Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "2019-08-08T13:12:56.627Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:12:56.626Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "103-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:12:56.627Z"
+  },
+  {
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentType": "Answer",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+    },
+    "section": "armensChambers",
+    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T13:12:56.627Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "sk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T13:12:56.626Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "This is a test message for Judge Armen.",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-armensChambers",
+    "docketNumber": "103-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:12:56.627Z"
+  },
+  {
+    "sk": "c219005b-8037-437a-9ad7-e2426d39862b",
+    "pk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50|workItem"
   }
 ]

--- a/web-api/storage/fixtures/seed/103-19.json
+++ b/web-api/storage/fixtures/seed/103-19.json
@@ -1,49 +1,13 @@
 [
   {
-    "docketNumberSuffix": "S",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "document": {
-      "createdAt": "2019-03-01T22:54:05.993Z",
-      "documentType": "Answer",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
-    },
-    "section": "armensChambers",
-    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:12:56.627Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "sk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:12:56.626Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
-        "from": "Test Docketclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "docketNumber": "103-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:12:56.627Z"
-  },
-  {
     "procedureType": "Small",
-    "initialTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "docketNumberSuffix": "S",
     "documents": [
       {
         "createdAt": "2019-03-01T22:53:50.098Z",
-        "processingStatus": "complete",
         "documentType": "Petition",
         "filedBy": "Test Petitioner",
+        "processingStatus": "complete",
         "workItems": [
           {
             "docketNumberSuffix": "S",
@@ -58,10 +22,10 @@
             },
             "section": "petitions",
             "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
+            "isInternal": false,
             "isInitializeCase": true,
             "assigneeId": null,
             "sentBy": "taxpayer",
-            "isInternal": false,
             "createdAt": "2019-03-01T22:53:50.098Z",
             "assigneeName": null,
             "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
@@ -69,8 +33,8 @@
               {
                 "createdAt": "2019-03-01T22:53:50.098Z",
                 "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
-                "from": "Test Petitioner",
                 "message": "Petition filed by Samson Workman is ready for review.",
+                "from": "Test Petitioner",
                 "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
               }
             ],
@@ -80,23 +44,21 @@
         ],
         "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
         "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
-        "receivedAt": "2019-08-08T13:12:56.626Z",
         "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       },
       {
-        "createdAt": "2019-03-05T17:34:13.491Z",
         "processingStatus": "complete",
+        "createdAt": "2019-03-05T17:34:13.491Z",
         "documentType": "Statement of Taxpayer Identification",
         "filedBy": "Test Petitioner",
         "workItems": [],
         "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8",
-        "receivedAt": "2019-08-08T13:12:56.626Z",
-        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+        "documentId": "b1aa4aa2-c214-424c-8870-d0049c5744d8"
       },
       {
-        "createdAt": "2019-03-01T22:54:05.993Z",
         "processingStatus": "complete",
+        "createdAt": "2019-03-01T22:54:05.993Z",
         "documentType": "Answer",
         "filedBy": "Test Respondent",
         "workItems": [
@@ -113,9 +75,9 @@
             },
             "section": "docket",
             "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+            "isInternal": false,
             "assigneeId": null,
             "sentBy": "respondent",
-            "isInternal": false,
             "createdAt": "2019-03-01T22:54:06.000Z",
             "assigneeName": null,
             "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
@@ -123,56 +85,35 @@
               {
                 "createdAt": "2019-03-01T22:54:06.000Z",
                 "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
-                "from": "Test Respondent",
                 "message": "Answer filed by Respondent is ready for review.",
+                "from": "Test Respondent",
                 "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
               }
             ],
             "docketNumber": "103-19",
             "updatedAt": "2019-03-01T22:54:06.000Z"
-          },
-          {
-            "docketNumberSuffix": "S",
-            "caseStatus": "New",
-            "document": {
-              "createdAt": "2019-03-01T22:54:05.993Z",
-              "documentType": "Answer",
-              "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
-            },
-            "section": "armensChambers",
-            "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
-            "isInitializeCase": false,
-            "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-            "sentBy": "Test Docketclerk",
-            "sentBySection": "docket",
-            "isInternal": true,
-            "createdAt": "2019-08-08T13:12:56.627Z",
-            "assigneeName": "Judge Armen",
-            "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-            "messages": [
-              {
-                "createdAt": "2019-08-08T13:12:56.626Z",
-                "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-                "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
-                "from": "Test Docketclerk",
-                "to": "Judge Armen",
-                "message": "This is a test message for Judge Armen.",
-                "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-              }
-            ],
-            "docketNumber": "103-19",
-            "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-            "updatedAt": "2019-08-08T13:12:56.627Z"
           }
         ],
         "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
         "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
-        "receivedAt": "2019-08-08T13:12:56.626Z",
         "userId": "respondent"
       }
     ],
-    "orderForFilingFee": false,
+    "respondents": [
+      {
+        "role": "respondent",
+        "name": "Test Respondent",
+        "custom:role": "respondent",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+        "iat": 1551480838,
+        "respondentId": "respondent",
+        "email": "respondent",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InJlc3BvbmRlbnQiLCJlbWFpbCI6InJlc3BvbmRlbnQiLCJuYW1lIjoiVGVzdCBSZXNwb25kZW50Iiwicm9sZSI6InJlc3BvbmRlbnQiLCJzZWN0aW9uIjoicGV0aXRpb25zIiwidXNlcklkIjoicmVzcG9uZGVudCIsImlhdCI6MTU1MTQ4MDgzOH0.U72pP7ZEwQkQIzlhpKvaEdMbcQhCjSLQbp0FP06LKao"
+      }
+    ],
     "partyType": "Petitioner",
+    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "currentVersion": "0",
     "caseType": "Deficiency",
     "yearAmounts": [],
     "contactPrimary": {
@@ -187,42 +128,15 @@
       "countryType": "domestic",
       "email": "taxpayer"
     },
-    "createdAt": "2019-03-01T22:53:50.097Z",
-    "noticeOfAttachments": false,
-    "caseCaption": "Samson Workman, Petitioner",
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "sk": "1",
-    "filingType": "Myself",
-    "orderForOds": false,
-    "orderForRatification": false,
-    "hasIrsNotice": false,
-    "initialDocketNumberSuffix": "S",
-    "docketNumberSuffix": "S",
-    "caseTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
-    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "currentVersion": "1",
-    "orderForAmendedPetition": false,
-    "orderToShowCause": false,
     "preferredTrialCity": "Mobile, Alabama",
-    "respondents": [
-      {
-        "role": "respondent",
-        "name": "Test Respondent",
-        "custom:role": "respondent",
-        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
-        "iat": 1551480838,
-        "respondentId": "respondent",
-        "email": "respondent",
-        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InJlc3BvbmRlbnQiLCJlbWFpbCI6InJlc3BvbmRlbnQiLCJuYW1lIjoiVGVzdCBSZXNwb25kZW50Iiwicm9sZSI6InJlc3BvbmRlbnQiLCJzZWN0aW9uIjoicGV0aXRpb25zIiwidXNlcklkIjoicmVzcG9uZGVudCIsImlhdCI6MTU1MTQ4MDgzOH0.U72pP7ZEwQkQIzlhpKvaEdMbcQhCjSLQbp0FP06LKao"
-      }
-    ],
-    "practitioners": [],
+    "createdAt": "2019-03-01T22:53:50.097Z",
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
     "docketRecord": [
       {
         "description": "Petition",
-        "index": 1,
         "filingDate": "2019-03-01T22:53:50.098Z",
-        "filedBy": "Test Petitioner"
+        "filedBy": "Test Petitioner",
+        "index": 1
       },
       {
         "description": "Request for Place of Trial at Mobile, Alabama",
@@ -231,162 +145,184 @@
       },
       {
         "description": "Answer",
-        "index": 3,
         "filingDate": "2019-03-01T22:54:05.993Z",
-        "filedBy": "Test Respondent"
+        "filedBy": "Test Respondent",
+        "index": 3
       }
     ],
-    "orderForAmendedPetitionAndFilingFee": false,
+    "sk": "0",
+    "caseCaption": "Samson Workman, Petitioner",
+    "caseTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "initialTitle": "Samson Workman, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "filingType": "Myself",
     "pk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "hasIrsNotice": false,
+    "petitioners": [
+      {
+        "role": "petitioner",
+        "name": "Test Petitioner",
+        "custom:role": "petitioner",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+        "iat": 1551480807,
+        "email": "taxpayer",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206cm9sZSI6InBldGl0aW9uZXIiLCJlbWFpbCI6InRheHBheWVyIiwibmFtZSI6IlRlc3QgUGV0aXRpb25lciIsInJvbGUiOiJwZXRpdGlvbmVyIiwic2VjdGlvbiI6InBldGl0aW9uZXIiLCJ1c2VySWQiOiJ0YXhwYXllciIsImlhdCI6MTU1MTQ4MDgwN30.sV0OKvwCmL1YUSmvC3-rCviw6iyIj4491Gr-GipsC60"
+      }
+    ],
     "docketNumber": "103-19",
     "status": "New"
   },
   {
-    "docketNumberSuffix": "S",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "document": {
-      "createdAt": "2019-03-01T22:54:05.993Z",
-      "documentType": "Answer",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
-    },
-    "section": "armensChambers",
-    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:12:56.627Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "sk": "2019-08-08T13:12:56.627Z",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:12:56.626Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
-        "from": "Test Docketclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "section-outbox-docket",
-    "docketNumber": "103-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:12:56.627Z"
+    "sk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
   },
   {
-    "docketNumberSuffix": "S",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "document": {
-      "createdAt": "2019-03-01T22:54:05.993Z",
-      "documentType": "Answer",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
-    },
-    "section": "armensChambers",
-    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:12:56.627Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "sk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:12:56.626Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
-        "from": "Test Docketclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
-    "docketNumber": "103-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:12:56.627Z"
+    "sk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "pk": "103-19|case"
   },
   {
-    "docketNumberSuffix": "S",
-    "caseStatus": "New",
-    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
-    "document": {
-      "createdAt": "2019-03-01T22:54:05.993Z",
-      "documentType": "Answer",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
-    },
-    "section": "armensChambers",
-    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:12:56.627Z",
-    "assigneeName": "Judge Armen",
-    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "sk": "2019-08-08T13:12:56.627Z",
-    "messages": [
-      {
-        "createdAt": "2019-08-08T13:12:56.626Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
-        "from": "Test Docketclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
-    "docketNumber": "103-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:12:56.627Z"
+    "sk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "pk": "5805d1ab-18d0-43ec-bafb-654e83405416|case"
   },
   {
+    "sk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
+    "pk": "section-petitions",
+    "gsi1pk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
     "docketNumberSuffix": "S",
     "caseStatus": "New",
-    "gsi1pk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
     "document": {
-      "createdAt": "2019-03-01T22:54:05.993Z",
-      "documentType": "Answer",
-      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7"
+      "receivedAt": "2019-03-01T21:40:46.415Z",
+      "createdAt": "2019-03-01T22:53:50.098Z",
+      "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
+      "documentType": "Petition",
+      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+      "filedBy": "Test Petitioner",
+      "workItems": []
     },
-    "section": "armensChambers",
-    "workItemId": "c219005b-8037-437a-9ad7-e2426d39862b",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:12:56.627Z",
-    "assigneeName": "Judge Armen",
+    "section": "petitions",
+    "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
+    "isInternal": false,
+    "isInitializeCase": true,
+    "assigneeId": null,
+    "sentBy": "taxpayer",
+    "createdAt": "2019-03-01T22:53:50.098Z",
+    "assigneeName": null,
     "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
-    "sk": "workitem-c219005b-8037-437a-9ad7-e2426d39862b",
     "messages": [
       {
-        "createdAt": "2019-08-08T13:12:56.626Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "37300ccc-4bae-497b-8c56-3fbf3b2ac652",
-        "from": "Test Docketclerk",
-        "to": "Judge Armen",
-        "message": "This is a test message for Judge Armen.",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-03-01T22:53:50.098Z",
+        "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
+        "message": "Petition filed by Samson Workman is ready for review.",
+        "from": "Test Petitioner",
+        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "section-armensChambers",
     "docketNumber": "103-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:12:56.627Z"
+    "updatedAt": "2019-03-01T22:53:50.098Z"
   },
   {
-    "sk": "c219005b-8037-437a-9ad7-e2426d39862b",
-    "pk": "491b05b4-483f-4b85-8dd7-2dd4c069eb50|workItem"
+    "sk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
+    "pk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
+    "gsi1pk": "workitem-9055257a-0a95-4b80-a728-5bb754c60e59",
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "document": {
+      "receivedAt": "2019-03-01T21:40:46.415Z",
+      "createdAt": "2019-03-01T22:53:50.098Z",
+      "documentId": "c611ee2e-a270-4dcd-a7bd-b8b9062db630",
+      "documentType": "Petition",
+      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+      "filedBy": "Test Petitioner",
+      "workItems": []
+    },
+    "section": "petitions",
+    "workItemId": "9055257a-0a95-4b80-a728-5bb754c60e59",
+    "isInternal": false,
+    "isInitializeCase": true,
+    "assigneeId": null,
+    "sentBy": "taxpayer",
+    "createdAt": "2019-03-01T22:53:50.098Z",
+    "assigneeName": null,
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "messages": [
+      {
+        "createdAt": "2019-03-01T22:53:50.098Z",
+        "messageId": "a53dc4c8-e550-4c19-8cff-223e92fab526",
+        "message": "Petition filed by Samson Workman is ready for review.",
+        "from": "Test Petitioner",
+        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "docketNumber": "103-19",
+    "updatedAt": "2019-03-01T22:53:50.098Z"
+  },
+  {
+    "sk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+    "pk": "section-docket",
+    "gsi1pk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "receivedAt": "2019-03-01T21:40:46.415Z",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
+      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+      "documentType": "Answer",
+      "filedBy": "Test Respondent",
+      "workItems": []
+    },
+    "section": "docket",
+    "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+    "isInternal": false,
+    "assigneeId": null,
+    "sentBy": "respondent",
+    "createdAt": "2019-03-01T22:54:06.000Z",
+    "assigneeName": null,
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "messages": [
+      {
+        "createdAt": "2019-03-01T22:54:06.000Z",
+        "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
+        "message": "Answer filed by Respondent is ready for review.",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+        "from": "Test Respondent",
+        "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "docketNumber": "103-19",
+    "updatedAt": "2019-03-01T22:54:06.000Z"
+  },
+  {
+    "sk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+    "pk": "workitem-337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+    "docketNumberSuffix": "S",
+    "caseStatus": "New",
+    "document": {
+      "createdAt": "2019-03-01T22:54:05.993Z",
+      "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
+      "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+      "documentType": "Answer",
+      "filedBy": "Test Respondent",
+      "workItems": []
+    },
+    "section": "docket",
+    "workItemId": "337f4e0d-cf5e-4c4f-b373-5256edbbbdf2",
+    "isInternal": false,
+    "assigneeId": null,
+    "sentBy": "respondent",
+    "createdAt": "2019-03-01T22:54:06.000Z",
+    "assigneeName": null,
+    "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "messages": [
+      {
+        "createdAt": "2019-03-01T22:54:06.000Z",
+        "messageId": "08e1cbed-d215-42d2-9216-25c9788dcf5b",
+        "message": "Answer filed by Respondent is ready for review.",
+        "userId": "5805d1ab-18d0-43ec-bafb-654e83405416",
+        "from": "Test Respondent",
+        "fromUserId": "5805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "docketNumber": "103-19",
+    "updatedAt": "2019-03-01T22:54:06.000Z"
   }
 ]

--- a/web-api/storage/fixtures/seed/106-19.json
+++ b/web-api/storage/fixtures/seed/106-19.json
@@ -1,188 +1,480 @@
 [
   {
-    "sk": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+    "document": {
+      "createdAt": "2019-07-12T17:09:41.026Z",
+      "processingStatus": "pending",
+      "documentType": "Petition",
+      "filedBy": "Denise Gould",
+      "workItems": [],
+      "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
+      "receivedAt": "2019-07-12T17:09:41.026Z",
+      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+    },
+    "section": "petitions",
+    "workItemId": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+    "isInitializeCase": true,
+    "assigneeId": null,
+    "sentBy": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "isInternal": false,
+    "createdAt": "2019-07-12T17:09:41.027Z",
+    "assigneeName": null,
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+    "messages": [
+      {
+        "createdAt": "2019-07-12T17:09:41.027Z",
+        "messageId": "818bb44d-1512-4a82-b524-a179ed5f7589",
+        "from": "Test Petitioner",
+        "message": "Petition filed by Denise Gould is ready for review.",
+        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+    "docketNumber": "106-19",
+    "updatedAt": "2019-07-12T17:09:41.027Z"
+  },
+  {
+    "sk": "case-d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "pk": "catalog"
+  },
+  {
+    "sk": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
+  },
+  {
+    "sk": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
+  },
+  {
+    "sk": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
     "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "armensChambers",
-    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "section": "seniorattorney",
+    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
     "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk1",
-    "sentBySection": "petitions",
+    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
     "isInternal": true,
-    "createdAt": "2019-08-08T13:16:27.710Z",
-    "assigneeName": "Judge Armen",
+    "createdAt": "2019-07-12T17:11:47.010Z",
+    "assigneeName": "Test Seniorattorney",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "sk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
     "messages": [
       {
-        "createdAt": "2019-08-08T13:16:27.710Z",
-        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
-        "from": "Test Petitionsclerk1",
-        "to": "Judge Armen",
-        "message": "What do you think, Judge Armen?",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-07-12T17:11:47.010Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
+        "from": "Test Docketclerk",
+        "to": "Test Seniorattorney",
+        "message": "sign this please",
+        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "pk": "user-6805d1ab-18d0-43ec-bafb-654e83405416",
     "docketNumber": "106-19",
-    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:16:27.710Z"
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-07-12T17:11:47.010Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "armensChambers",
-    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "section": "seniorattorney",
+    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
     "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk1",
-    "sentBySection": "petitions",
+    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
     "isInternal": true,
-    "createdAt": "2019-08-08T13:16:27.710Z",
-    "assigneeName": "Judge Armen",
+    "createdAt": "2019-07-12T17:11:47.010Z",
+    "assigneeName": "Test Seniorattorney",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "2019-08-08T13:16:27.710Z",
+    "sk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
     "messages": [
       {
-        "createdAt": "2019-08-08T13:16:27.710Z",
-        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
-        "from": "Test Petitionsclerk1",
-        "to": "Judge Armen",
-        "message": "What do you think, Judge Armen?",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-07-12T17:11:47.010Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
+        "from": "Test Docketclerk",
+        "to": "Test Seniorattorney",
+        "message": "sign this please",
+        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "user-outbox-4805d1ab-18d0-43ec-bafb-654e83405416",
+    "pk": "section-seniorattorney",
     "docketNumber": "106-19",
-    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:16:27.710Z"
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-07-12T17:11:47.010Z"
+  },
+  {
+    "completedAt": "2019-07-12T17:11:27.244Z",
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "completedMessage": "completed",
+    "gsi1pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "document": {
+      "isPaper": true,
+      "serviceDate": "undefined-undefined-undefined",
+      "documentType": "Proposed Stipulated Decision",
+      "practitioner": [],
+      "partyPrimary": true,
+      "workItems": [],
+      "receivedAt": "1990-10-10",
+      "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+      "eventCode": "PSDEC",
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "processingStatus": "pending",
+      "lodged": false,
+      "scenario": "Standard",
+      "filedBy": "Petr. Denise Gould",
+      "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
+      "category": "Decision",
+      "documentTitle": "Proposed Stipulated Decision",
+      "relationship": "primaryDocument",
+      "docketNumber": "106-19"
+    },
+    "section": "docket",
+    "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": false,
+    "createdAt": "2019-07-12T17:11:27.244Z",
+    "assigneeName": "Test Docketclerk",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "messages": [
+      {
+        "createdAt": "2019-07-12T17:11:27.244Z",
+        "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
+        "from": "Test Docketclerk",
+        "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "completedBy": "Test Docketclerk",
+    "updatedAt": "2019-07-12T17:11:27.244Z"
+  },
+  {
+    "completedAt": "2019-07-12T17:11:27.244Z",
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "completedMessage": "completed",
+    "gsi1pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "document": {
+      "isPaper": true,
+      "serviceDate": "undefined-undefined-undefined",
+      "documentType": "Proposed Stipulated Decision",
+      "practitioner": [],
+      "partyPrimary": true,
+      "workItems": [],
+      "receivedAt": "1990-10-10",
+      "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+      "eventCode": "PSDEC",
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "processingStatus": "pending",
+      "lodged": false,
+      "scenario": "Standard",
+      "filedBy": "Petr. Denise Gould",
+      "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
+      "category": "Decision",
+      "documentTitle": "Proposed Stipulated Decision",
+      "relationship": "primaryDocument",
+      "docketNumber": "106-19"
+    },
+    "section": "docket",
+    "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": false,
+    "createdAt": "2019-07-12T17:11:27.244Z",
+    "assigneeName": "Test Docketclerk",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "2019-07-12T17:11:27.244Z",
+    "messages": [
+      {
+        "createdAt": "2019-07-12T17:11:27.244Z",
+        "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
+        "from": "Test Docketclerk",
+        "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-outbox-docket",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "completedBy": "Test Docketclerk",
+    "updatedAt": "2019-07-12T17:11:27.244Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "armensChambers",
-    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "section": "seniorattorney",
+    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
     "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk1",
-    "sentBySection": "petitions",
+    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
     "isInternal": true,
-    "createdAt": "2019-08-08T13:16:27.710Z",
-    "assigneeName": "Judge Armen",
+    "createdAt": "2019-07-12T17:11:47.010Z",
+    "assigneeName": "Test Seniorattorney",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "2019-08-08T13:16:27.710Z",
+    "sk": "2019-07-12T17:11:47.010Z",
     "messages": [
       {
-        "createdAt": "2019-08-08T13:16:27.710Z",
-        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
-        "from": "Test Petitionsclerk1",
-        "to": "Judge Armen",
-        "message": "What do you think, Judge Armen?",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-07-12T17:11:47.010Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
+        "from": "Test Docketclerk",
+        "to": "Test Seniorattorney",
+        "message": "sign this please",
+        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "section-outbox-petitions",
+    "pk": "section-outbox-docket",
     "docketNumber": "106-19",
-    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:16:27.710Z"
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-07-12T17:11:47.010Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
+    "gsi1pk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
     "document": {
-      "createdAt": "2019-07-12T17:11:26.955Z",
-      "documentType": "Proposed Stipulated Decision",
-      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+      "createdAt": "2019-07-12T17:09:41.026Z",
+      "processingStatus": "pending",
+      "documentType": "Petition",
+      "filedBy": "Denise Gould",
+      "workItems": [],
+      "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
+      "receivedAt": "2019-07-12T17:09:41.026Z",
+      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
     },
-    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
-    "isRead": true,
-    "section": "armensChambers",
-    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
-    "isInitializeCase": false,
-    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk1",
-    "sentBySection": "petitions",
-    "isInternal": true,
-    "createdAt": "2019-08-08T13:16:27.710Z",
-    "assigneeName": "Judge Armen",
+    "section": "petitions",
+    "workItemId": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+    "isInitializeCase": true,
+    "assigneeId": null,
+    "sentBy": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "isInternal": false,
+    "createdAt": "2019-07-12T17:09:41.027Z",
+    "assigneeName": null,
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "sk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
     "messages": [
       {
-        "createdAt": "2019-08-08T13:16:27.710Z",
-        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
-        "from": "Test Petitionsclerk1",
-        "to": "Judge Armen",
-        "message": "What do you think, Judge Armen?",
-        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-07-12T17:09:41.027Z",
+        "messageId": "818bb44d-1512-4a82-b524-a179ed5f7589",
+        "from": "Test Petitioner",
+        "message": "Petition filed by Denise Gould is ready for review.",
+        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
+    "pk": "section-petitions",
     "docketNumber": "106-19",
-    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:16:27.710Z"
+    "updatedAt": "2019-07-12T17:09:41.027Z"
+  },
+  {
+    "completedAt": "2019-07-12T17:11:27.244Z",
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "completedMessage": "completed",
+    "gsi1pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "document": {
+      "isPaper": true,
+      "serviceDate": "undefined-undefined-undefined",
+      "documentType": "Proposed Stipulated Decision",
+      "practitioner": [],
+      "partyPrimary": true,
+      "workItems": [],
+      "receivedAt": "1990-10-10",
+      "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+      "eventCode": "PSDEC",
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "processingStatus": "pending",
+      "lodged": false,
+      "scenario": "Standard",
+      "filedBy": "Petr. Denise Gould",
+      "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
+      "category": "Decision",
+      "documentTitle": "Proposed Stipulated Decision",
+      "relationship": "primaryDocument",
+      "docketNumber": "106-19"
+    },
+    "section": "docket",
+    "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+    "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": false,
+    "createdAt": "2019-07-12T17:11:27.244Z",
+    "assigneeName": "Test Docketclerk",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "2019-07-12T17:11:27.244Z",
+    "messages": [
+      {
+        "createdAt": "2019-07-12T17:11:27.244Z",
+        "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
+        "from": "Test Docketclerk",
+        "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "completedBy": "Test Docketclerk",
+    "updatedAt": "2019-07-12T17:11:27.244Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "document": {
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "documentType": "Proposed Stipulated Decision",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+    },
+    "section": "seniorattorney",
+    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "isInitializeCase": false,
+    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-07-12T17:11:47.010Z",
+    "assigneeName": "Test Seniorattorney",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "2019-07-12T17:11:47.010Z",
+    "messages": [
+      {
+        "createdAt": "2019-07-12T17:11:47.010Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
+        "from": "Test Docketclerk",
+        "to": "Test Seniorattorney",
+        "message": "sign this please",
+        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-07-12T17:11:47.010Z"
+  },
+  {
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "document": {
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "documentType": "Proposed Stipulated Decision",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+    },
+    "section": "seniorattorney",
+    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "isInitializeCase": false,
+    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-07-12T17:11:47.010Z",
+    "assigneeName": "Test Seniorattorney",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "messages": [
+      {
+        "createdAt": "2019-07-12T17:11:47.010Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
+        "from": "Test Docketclerk",
+        "to": "Test Seniorattorney",
+        "message": "sign this please",
+        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-07-12T17:11:47.010Z"
+  },
+  {
+    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "pk": "106-19|case"
+  },
+  {
+    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
+  },
+  {
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
     "section": "armensChambers",
-    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "workItemId": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
     "isInitializeCase": false,
     "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Petitionsclerk1",
-    "sentBySection": "petitions",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
     "isInternal": true,
-    "createdAt": "2019-08-08T13:16:27.710Z",
+    "createdAt": "2019-08-08T14:23:51.565Z",
     "assigneeName": "Judge Armen",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "sk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
     "messages": [
       {
-        "createdAt": "2019-08-08T13:16:27.710Z",
-        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
-        "from": "Test Petitionsclerk1",
+        "createdAt": "2019-08-08T14:23:51.565Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "74d5d508-937f-4ddd-880d-e2ce369fa9e6",
+        "from": "Test Docketclerk",
         "to": "Judge Armen",
         "message": "What do you think, Judge Armen?",
         "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "section-armensChambers",
+    "pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
     "docketNumber": "106-19",
-    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-08-08T13:16:27.710Z"
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:23:51.565Z"
   },
   {
     "procedureType": "Regular",
@@ -347,29 +639,29 @@
               "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
             },
             "section": "armensChambers",
-            "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+            "workItemId": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
             "isInitializeCase": false,
             "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
-            "sentBy": "Test Petitionsclerk1",
-            "sentBySection": "petitions",
+            "sentBy": "Test Docketclerk",
+            "sentBySection": "docket",
             "isInternal": true,
-            "createdAt": "2019-08-08T13:16:27.710Z",
+            "createdAt": "2019-08-08T14:23:51.565Z",
             "assigneeName": "Judge Armen",
             "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
             "messages": [
               {
-                "createdAt": "2019-08-08T13:16:27.710Z",
-                "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-                "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
-                "from": "Test Petitionsclerk1",
+                "createdAt": "2019-08-08T14:23:51.565Z",
+                "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+                "messageId": "74d5d508-937f-4ddd-880d-e2ce369fa9e6",
+                "from": "Test Docketclerk",
                 "to": "Judge Armen",
                 "message": "What do you think, Judge Armen?",
                 "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
               }
             ],
             "docketNumber": "106-19",
-            "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
-            "updatedAt": "2019-08-08T13:16:27.710Z"
+            "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+            "updatedAt": "2019-08-08T14:23:51.565Z"
           }
         ],
         "receivedAt": "1990-10-10",
@@ -447,5 +739,153 @@
     "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
     "docketNumber": "106-19",
     "status": "New"
+  },
+  {
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "document": {
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "documentType": "Proposed Stipulated Decision",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+    },
+    "section": "armensChambers",
+    "workItemId": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:23:51.565Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:23:51.565Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "74d5d508-937f-4ddd-880d-e2ce369fa9e6",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-armensChambers",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:23:51.565Z"
+  },
+  {
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "document": {
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "documentType": "Proposed Stipulated Decision",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+    },
+    "section": "armensChambers",
+    "workItemId": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:23:51.565Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "2019-08-08T14:23:51.565Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:23:51.565Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "74d5d508-937f-4ddd-880d-e2ce369fa9e6",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:23:51.565Z"
+  },
+  {
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "document": {
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "documentType": "Proposed Stipulated Decision",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+    },
+    "section": "armensChambers",
+    "workItemId": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:23:51.565Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:23:51.565Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "74d5d508-937f-4ddd-880d-e2ce369fa9e6",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:23:51.565Z"
+  },
+  {
+    "sk": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
+  },
+  {
+    "docketNumberSuffix": null,
+    "caseStatus": "New",
+    "gsi1pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "document": {
+      "createdAt": "2019-07-12T17:11:26.955Z",
+      "documentType": "Proposed Stipulated Decision",
+      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+    },
+    "section": "armensChambers",
+    "workItemId": "368e5d9a-6a9d-4e27-bd88-8521741f0639",
+    "isInitializeCase": false,
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Docketclerk",
+    "sentBySection": "docket",
+    "isInternal": true,
+    "createdAt": "2019-08-08T14:23:51.565Z",
+    "assigneeName": "Judge Armen",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "2019-08-08T14:23:51.565Z",
+    "messages": [
+      {
+        "createdAt": "2019-08-08T14:23:51.565Z",
+        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "74d5d508-937f-4ddd-880d-e2ce369fa9e6",
+        "from": "Test Docketclerk",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+      }
+    ],
+    "pk": "section-outbox-docket",
+    "docketNumber": "106-19",
+    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T14:23:51.565Z"
   }
 ]

--- a/web-api/storage/fixtures/seed/106-19.json
+++ b/web-api/storage/fixtures/seed/106-19.json
@@ -1,436 +1,188 @@
 [
   {
-    "docketNumberSuffix": null,
-    "caseStatus": "New",
-    "gsi1pk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "document": {
-      "createdAt": "2019-07-12T17:09:41.026Z",
-      "processingStatus": "pending",
-      "documentType": "Petition",
-      "filedBy": "Denise Gould",
-      "workItems": [],
-      "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
-      "receivedAt": "2019-07-12T17:09:41.026Z",
-      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-    },
-    "section": "petitions",
-    "workItemId": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "isInitializeCase": true,
-    "assigneeId": null,
-    "sentBy": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "isInternal": false,
-    "createdAt": "2019-07-12T17:09:41.027Z",
-    "assigneeName": null,
-    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "messages": [
-      {
-        "createdAt": "2019-07-12T17:09:41.027Z",
-        "messageId": "818bb44d-1512-4a82-b524-a179ed5f7589",
-        "from": "Test Petitioner",
-        "message": "Petition filed by Denise Gould is ready for review.",
-        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "docketNumber": "106-19",
-    "updatedAt": "2019-07-12T17:09:41.027Z"
-  },
-  {
-    "sk": "case-d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "pk": "catalog"
-  },
-  {
-    "sk": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
-  },
-  {
-    "sk": "5059e127-1796-45aa-96bc-351cd5705c66",
-    "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
-  },
-  {
-    "sk": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+    "sk": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88|workItem"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "seniorattorney",
-    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "section": "armensChambers",
+    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "isInitializeCase": false,
-    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk1",
+    "sentBySection": "petitions",
     "isInternal": true,
-    "createdAt": "2019-07-12T17:11:47.010Z",
-    "assigneeName": "Test Seniorattorney",
+    "createdAt": "2019-08-08T13:16:27.710Z",
+    "assigneeName": "Judge Armen",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "sk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "messages": [
       {
-        "createdAt": "2019-07-12T17:11:47.010Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
-        "from": "Test Docketclerk",
-        "to": "Test Seniorattorney",
-        "message": "sign this please",
-        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:16:27.710Z",
+        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
+        "from": "Test Petitionsclerk1",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "user-6805d1ab-18d0-43ec-bafb-654e83405416",
+    "pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-07-12T17:11:47.010Z"
+    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:16:27.710Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "seniorattorney",
-    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "section": "armensChambers",
+    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "isInitializeCase": false,
-    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk1",
+    "sentBySection": "petitions",
     "isInternal": true,
-    "createdAt": "2019-07-12T17:11:47.010Z",
-    "assigneeName": "Test Seniorattorney",
+    "createdAt": "2019-08-08T13:16:27.710Z",
+    "assigneeName": "Judge Armen",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "sk": "2019-08-08T13:16:27.710Z",
     "messages": [
       {
-        "createdAt": "2019-07-12T17:11:47.010Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
-        "from": "Test Docketclerk",
-        "to": "Test Seniorattorney",
-        "message": "sign this please",
-        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:16:27.710Z",
+        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
+        "from": "Test Petitionsclerk1",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "section-seniorattorney",
+    "pk": "user-outbox-4805d1ab-18d0-43ec-bafb-654e83405416",
     "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-07-12T17:11:47.010Z"
-  },
-  {
-    "completedAt": "2019-07-12T17:11:27.244Z",
-    "docketNumberSuffix": null,
-    "caseStatus": "New",
-    "completedMessage": "completed",
-    "gsi1pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "document": {
-      "isPaper": true,
-      "serviceDate": "undefined-undefined-undefined",
-      "documentType": "Proposed Stipulated Decision",
-      "practitioner": [],
-      "partyPrimary": true,
-      "workItems": [],
-      "receivedAt": "1990-10-10",
-      "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-      "eventCode": "PSDEC",
-      "createdAt": "2019-07-12T17:11:26.955Z",
-      "processingStatus": "pending",
-      "lodged": false,
-      "scenario": "Standard",
-      "filedBy": "Petr. Denise Gould",
-      "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
-      "category": "Decision",
-      "documentTitle": "Proposed Stipulated Decision",
-      "relationship": "primaryDocument",
-      "docketNumber": "106-19"
-    },
-    "section": "docket",
-    "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": false,
-    "createdAt": "2019-07-12T17:11:27.244Z",
-    "assigneeName": "Test Docketclerk",
-    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "messages": [
-      {
-        "createdAt": "2019-07-12T17:11:27.244Z",
-        "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
-        "from": "Test Docketclerk",
-        "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "completedBy": "Test Docketclerk",
-    "updatedAt": "2019-07-12T17:11:27.244Z"
-  },
-  {
-    "completedAt": "2019-07-12T17:11:27.244Z",
-    "docketNumberSuffix": null,
-    "caseStatus": "New",
-    "completedMessage": "completed",
-    "gsi1pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "document": {
-      "isPaper": true,
-      "serviceDate": "undefined-undefined-undefined",
-      "documentType": "Proposed Stipulated Decision",
-      "practitioner": [],
-      "partyPrimary": true,
-      "workItems": [],
-      "receivedAt": "1990-10-10",
-      "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-      "eventCode": "PSDEC",
-      "createdAt": "2019-07-12T17:11:26.955Z",
-      "processingStatus": "pending",
-      "lodged": false,
-      "scenario": "Standard",
-      "filedBy": "Petr. Denise Gould",
-      "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
-      "category": "Decision",
-      "documentTitle": "Proposed Stipulated Decision",
-      "relationship": "primaryDocument",
-      "docketNumber": "106-19"
-    },
-    "section": "docket",
-    "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": false,
-    "createdAt": "2019-07-12T17:11:27.244Z",
-    "assigneeName": "Test Docketclerk",
-    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "2019-07-12T17:11:27.244Z",
-    "messages": [
-      {
-        "createdAt": "2019-07-12T17:11:27.244Z",
-        "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
-        "from": "Test Docketclerk",
-        "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "section-outbox-docket",
-    "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "completedBy": "Test Docketclerk",
-    "updatedAt": "2019-07-12T17:11:27.244Z"
+    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:16:27.710Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "seniorattorney",
-    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "section": "armensChambers",
+    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "isInitializeCase": false,
-    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk1",
+    "sentBySection": "petitions",
     "isInternal": true,
-    "createdAt": "2019-07-12T17:11:47.010Z",
-    "assigneeName": "Test Seniorattorney",
+    "createdAt": "2019-08-08T13:16:27.710Z",
+    "assigneeName": "Judge Armen",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "2019-07-12T17:11:47.010Z",
+    "sk": "2019-08-08T13:16:27.710Z",
     "messages": [
       {
-        "createdAt": "2019-07-12T17:11:47.010Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
-        "from": "Test Docketclerk",
-        "to": "Test Seniorattorney",
-        "message": "sign this please",
-        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:16:27.710Z",
+        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
+        "from": "Test Petitionsclerk1",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "section-outbox-docket",
+    "pk": "section-outbox-petitions",
     "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-07-12T17:11:47.010Z"
+    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:16:27.710Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "document": {
-      "createdAt": "2019-07-12T17:09:41.026Z",
-      "processingStatus": "pending",
-      "documentType": "Petition",
-      "filedBy": "Denise Gould",
-      "workItems": [],
-      "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
-      "receivedAt": "2019-07-12T17:09:41.026Z",
-      "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-    },
-    "section": "petitions",
-    "workItemId": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "isInitializeCase": true,
-    "assigneeId": null,
-    "sentBy": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "isInternal": false,
-    "createdAt": "2019-07-12T17:09:41.027Z",
-    "assigneeName": null,
-    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
-    "messages": [
-      {
-        "createdAt": "2019-07-12T17:09:41.027Z",
-        "messageId": "818bb44d-1512-4a82-b524-a179ed5f7589",
-        "from": "Test Petitioner",
-        "message": "Petition filed by Denise Gould is ready for review.",
-        "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "section-petitions",
-    "docketNumber": "106-19",
-    "updatedAt": "2019-07-12T17:09:41.027Z"
-  },
-  {
-    "completedAt": "2019-07-12T17:11:27.244Z",
-    "docketNumberSuffix": null,
-    "caseStatus": "New",
-    "completedMessage": "completed",
-    "gsi1pk": "workitem-2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "document": {
-      "isPaper": true,
-      "serviceDate": "undefined-undefined-undefined",
-      "documentType": "Proposed Stipulated Decision",
-      "practitioner": [],
-      "partyPrimary": true,
-      "workItems": [],
-      "receivedAt": "1990-10-10",
-      "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-      "eventCode": "PSDEC",
-      "createdAt": "2019-07-12T17:11:26.955Z",
-      "processingStatus": "pending",
-      "lodged": false,
-      "scenario": "Standard",
-      "filedBy": "Petr. Denise Gould",
-      "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-      "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
-      "category": "Decision",
-      "documentTitle": "Proposed Stipulated Decision",
-      "relationship": "primaryDocument",
-      "docketNumber": "106-19"
-    },
-    "section": "docket",
-    "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
-    "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
-    "isInternal": false,
-    "createdAt": "2019-07-12T17:11:27.244Z",
-    "assigneeName": "Test Docketclerk",
-    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "2019-07-12T17:11:27.244Z",
-    "messages": [
-      {
-        "createdAt": "2019-07-12T17:11:27.244Z",
-        "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
-        "from": "Test Docketclerk",
-        "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
-      }
-    ],
-    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
-    "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "completedBy": "Test Docketclerk",
-    "updatedAt": "2019-07-12T17:11:27.244Z"
-  },
-  {
-    "docketNumberSuffix": null,
-    "caseStatus": "New",
-    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "seniorattorney",
-    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+    "isRead": true,
+    "section": "armensChambers",
+    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "isInitializeCase": false,
-    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk1",
+    "sentBySection": "petitions",
     "isInternal": true,
-    "createdAt": "2019-07-12T17:11:47.010Z",
-    "assigneeName": "Test Seniorattorney",
+    "createdAt": "2019-08-08T13:16:27.710Z",
+    "assigneeName": "Judge Armen",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "2019-07-12T17:11:47.010Z",
+    "sk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "messages": [
       {
-        "createdAt": "2019-07-12T17:11:47.010Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
-        "from": "Test Docketclerk",
-        "to": "Test Seniorattorney",
-        "message": "sign this please",
-        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:16:27.710Z",
+        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
+        "from": "Test Petitionsclerk1",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "user-outbox-1805d1ab-18d0-43ec-bafb-654e83405416",
+    "pk": "user-dabbad00-18d0-43ec-bafb-654e83405416",
     "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-07-12T17:11:47.010Z"
+    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:16:27.710Z"
   },
   {
     "docketNumberSuffix": null,
     "caseStatus": "New",
-    "gsi1pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "gsi1pk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "document": {
       "createdAt": "2019-07-12T17:11:26.955Z",
       "documentType": "Proposed Stipulated Decision",
       "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
     },
-    "section": "seniorattorney",
-    "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+    "section": "armensChambers",
+    "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "isInitializeCase": false,
-    "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
-    "sentBy": "Test Docketclerk",
-    "sentBySection": "docket",
+    "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+    "sentBy": "Test Petitionsclerk1",
+    "sentBySection": "petitions",
     "isInternal": true,
-    "createdAt": "2019-07-12T17:11:47.010Z",
-    "assigneeName": "Test Seniorattorney",
+    "createdAt": "2019-08-08T13:16:27.710Z",
+    "assigneeName": "Judge Armen",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "sk": "workitem-fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
     "messages": [
       {
-        "createdAt": "2019-07-12T17:11:47.010Z",
-        "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
-        "from": "Test Docketclerk",
-        "to": "Test Seniorattorney",
-        "message": "sign this please",
-        "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+        "createdAt": "2019-08-08T13:16:27.710Z",
+        "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+        "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
+        "from": "Test Petitionsclerk1",
+        "to": "Judge Armen",
+        "message": "What do you think, Judge Armen?",
+        "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
       }
     ],
-    "pk": "workitem-5059e127-1796-45aa-96bc-351cd5705c66",
+    "pk": "section-armensChambers",
     "docketNumber": "106-19",
-    "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-    "updatedAt": "2019-07-12T17:11:47.010Z"
+    "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+    "updatedAt": "2019-08-08T13:16:27.710Z"
   },
   {
     "procedureType": "Regular",
@@ -585,6 +337,39 @@
             "docketNumber": "106-19",
             "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
             "updatedAt": "2019-07-12T17:11:47.010Z"
+          },
+          {
+            "docketNumberSuffix": null,
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-07-12T17:11:26.955Z",
+              "documentType": "Proposed Stipulated Decision",
+              "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+            },
+            "section": "armensChambers",
+            "workItemId": "fae6b2dd-0d19-4f7e-b363-b7b1ca608474",
+            "isInitializeCase": false,
+            "assigneeId": "dabbad00-18d0-43ec-bafb-654e83405416",
+            "sentBy": "Test Petitionsclerk1",
+            "sentBySection": "petitions",
+            "isInternal": true,
+            "createdAt": "2019-08-08T13:16:27.710Z",
+            "assigneeName": "Judge Armen",
+            "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+            "messages": [
+              {
+                "createdAt": "2019-08-08T13:16:27.710Z",
+                "fromUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+                "messageId": "29404eba-22ac-47f3-946d-10485a48f2d5",
+                "from": "Test Petitionsclerk1",
+                "to": "Judge Armen",
+                "message": "What do you think, Judge Armen?",
+                "toUserId": "dabbad00-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "106-19",
+            "sentByUserId": "4805d1ab-18d0-43ec-bafb-654e83405416",
+            "updatedAt": "2019-08-08T13:16:27.710Z"
           }
         ],
         "receivedAt": "1990-10-10",
@@ -623,7 +408,7 @@
     "noticeOfAttachments": false,
     "caseCaption": "Denise Gould, Petitioner",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "sk": "0",
+    "sk": "4",
     "filingType": "Myself",
     "orderForOds": false,
     "orderForRatification": false,
@@ -632,7 +417,7 @@
     "docketNumberSuffix": null,
     "caseTitle": "Denise Gould, Petitioner v. Commissioner of Internal Revenue, Respondent",
     "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
-    "currentVersion": "3",
+    "currentVersion": "4",
     "orderForAmendedPetition": false,
     "orderToShowCause": false,
     "preferredTrialCity": "Lubbock, Texas",
@@ -662,13 +447,5 @@
     "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
     "docketNumber": "106-19",
     "status": "New"
-  },
-  {
-    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "pk": "106-19|case"
-  },
-  {
-    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
   }
 ]

--- a/web-api/storage/fixtures/seed/106-19.json
+++ b/web-api/storage/fixtures/seed/106-19.json
@@ -433,14 +433,6 @@
     "updatedAt": "2019-07-12T17:11:47.010Z"
   },
   {
-    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "pk": "106-19|case"
-  },
-  {
-    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
-    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
-  },
-  {
     "docketNumberSuffix": null,
     "caseStatus": "New",
     "gsi1pk": "workitem-368e5d9a-6a9d-4e27-bd88-8521741f0639",
@@ -475,6 +467,237 @@
     "docketNumber": "106-19",
     "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
     "updatedAt": "2019-08-08T14:23:51.565Z"
+  },
+  {
+    "procedureType": "Regular",
+    "contactSecondary": {},
+    "isPaper": false,
+    "initialTitle": "Denise Gould, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "documents": [
+      {
+        "createdAt": "2019-07-12T17:09:41.026Z",
+        "processingStatus": "complete",
+        "documentType": "Petition",
+        "filedBy": "Denise Gould",
+        "workItems": [
+          {
+            "docketNumberSuffix": null,
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-07-12T17:09:41.026Z",
+              "processingStatus": "pending",
+              "documentType": "Petition",
+              "filedBy": "Denise Gould",
+              "workItems": [],
+              "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
+              "receivedAt": "2019-07-12T17:09:41.026Z",
+              "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+            },
+            "section": "petitions",
+            "workItemId": "85d71a2a-d1c8-448a-9c9f-2d5eb31784b7",
+            "isInitializeCase": true,
+            "assigneeId": null,
+            "sentBy": "7805d1ab-18d0-43ec-bafb-654e83405416",
+            "isInternal": false,
+            "createdAt": "2019-07-12T17:09:41.027Z",
+            "assigneeName": null,
+            "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+            "messages": [
+              {
+                "createdAt": "2019-07-12T17:09:41.027Z",
+                "messageId": "818bb44d-1512-4a82-b524-a179ed5f7589",
+                "from": "Test Petitioner",
+                "message": "Petition filed by Denise Gould is ready for review.",
+                "fromUserId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "106-19",
+            "updatedAt": "2019-07-12T17:09:41.027Z"
+          }
+        ],
+        "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+        "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
+        "receivedAt": "2019-07-12T17:09:41.026Z",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      },
+      {
+        "createdAt": "2019-07-12T17:09:41.027Z",
+        "processingStatus": "complete",
+        "documentType": "Statement of Taxpayer Identification",
+        "filedBy": "Denise Gould",
+        "workItems": [],
+        "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+        "documentId": "2da6d239-555a-40e8-af81-1949c8270cd7",
+        "receivedAt": "2019-07-12T17:09:41.027Z",
+        "userId": "7805d1ab-18d0-43ec-bafb-654e83405416"
+      },
+      {
+        "isPaper": true,
+        "serviceDate": "undefined-undefined-undefined",
+        "documentType": "Proposed Stipulated Decision",
+        "practitioner": [],
+        "partyPrimary": true,
+        "workItems": [
+          {
+            "completedAt": "2019-07-12T17:11:27.244Z",
+            "docketNumberSuffix": null,
+            "caseStatus": "New",
+            "completedMessage": "completed",
+            "document": {
+              "isPaper": true,
+              "serviceDate": "undefined-undefined-undefined",
+              "documentType": "Proposed Stipulated Decision",
+              "practitioner": [],
+              "partyPrimary": true,
+              "workItems": [],
+              "receivedAt": "1990-10-10",
+              "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+              "eventCode": "PSDEC",
+              "createdAt": "2019-07-12T17:11:26.955Z",
+              "processingStatus": "pending",
+              "lodged": false,
+              "scenario": "Standard",
+              "filedBy": "Petr. Denise Gould",
+              "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+              "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
+              "category": "Decision",
+              "documentTitle": "Proposed Stipulated Decision",
+              "relationship": "primaryDocument",
+              "docketNumber": "106-19"
+            },
+            "section": "docket",
+            "workItemId": "2b8ef08e-50be-4f9b-8a96-57baa5112f02",
+            "assigneeId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+            "completedByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+            "sentBy": "Test Docketclerk",
+            "sentBySection": "docket",
+            "isInternal": false,
+            "createdAt": "2019-07-12T17:11:27.244Z",
+            "assigneeName": "Test Docketclerk",
+            "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+            "messages": [
+              {
+                "createdAt": "2019-07-12T17:11:27.244Z",
+                "messageId": "a2573475-ed2e-4404-b3af-cd5ad6a862f4",
+                "from": "Test Docketclerk",
+                "message": "Proposed Stipulated Decision filed by Docketclerk is ready for review.",
+                "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "106-19",
+            "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+            "completedBy": "Test Docketclerk",
+            "updatedAt": "2019-07-12T17:11:27.244Z"
+          },
+          {
+            "docketNumberSuffix": null,
+            "caseStatus": "New",
+            "document": {
+              "createdAt": "2019-07-12T17:11:26.955Z",
+              "documentType": "Proposed Stipulated Decision",
+              "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f"
+            },
+            "section": "seniorattorney",
+            "workItemId": "5059e127-1796-45aa-96bc-351cd5705c66",
+            "isInitializeCase": false,
+            "assigneeId": "6805d1ab-18d0-43ec-bafb-654e83405416",
+            "sentBy": "Test Docketclerk",
+            "sentBySection": "docket",
+            "isInternal": true,
+            "createdAt": "2019-07-12T17:11:47.010Z",
+            "assigneeName": "Test Seniorattorney",
+            "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+            "messages": [
+              {
+                "createdAt": "2019-07-12T17:11:47.010Z",
+                "fromUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+                "messageId": "e6c9a265-cb21-4eb5-86d1-df9c44ef0791",
+                "from": "Test Docketclerk",
+                "to": "Test Seniorattorney",
+                "message": "sign this please",
+                "toUserId": "6805d1ab-18d0-43ec-bafb-654e83405416"
+              }
+            ],
+            "docketNumber": "106-19",
+            "sentByUserId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+            "updatedAt": "2019-07-12T17:11:47.010Z"
+          }
+        ],
+        "receivedAt": "1990-10-10",
+        "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
+        "eventCode": "PSDEC",
+        "createdAt": "2019-07-12T17:11:26.955Z",
+        "processingStatus": "complete",
+        "lodged": false,
+        "scenario": "Standard",
+        "filedBy": "Petr. Denise Gould",
+        "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+        "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
+        "category": "Decision",
+        "documentTitle": "Proposed Stipulated Decision",
+        "relationship": "primaryDocument",
+        "docketNumber": "106-19"
+      }
+    ],
+    "orderForFilingFee": false,
+    "partyType": "Petitioner",
+    "caseType": "Innocent Spouse",
+    "yearAmounts": [],
+    "contactPrimary": {
+      "address3": "Saepe proident enim",
+      "address2": "Nostrud sint lorem u",
+      "city": "Dolore est qui pers",
+      "phone": "+1 (493) 953-3442",
+      "address1": "28 North Nobel Road",
+      "postalCode": "91301",
+      "name": "Denise Gould",
+      "state": "MS",
+      "countryType": "domestic",
+      "email": "taxpayer@example.com"
+    },
+    "createdAt": "2019-07-12T17:09:41.026Z",
+    "noticeOfAttachments": false,
+    "caseCaption": "Denise Gould, Petitioner",
+    "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "sk": "0",
+    "filingType": "Myself",
+    "orderForOds": false,
+    "orderForRatification": false,
+    "hasIrsNotice": false,
+    "initialDocketNumberSuffix": "_",
+    "docketNumberSuffix": null,
+    "caseTitle": "Denise Gould, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "userId": "7805d1ab-18d0-43ec-bafb-654e83405416",
+    "currentVersion": "3",
+    "orderForAmendedPetition": false,
+    "orderToShowCause": false,
+    "preferredTrialCity": "Lubbock, Texas",
+    "respondents": [],
+    "practitioners": [],
+    "docketRecord": [
+      {
+        "description": "Petition",
+        "index": 1,
+        "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
+        "filingDate": "2019-07-12T17:09:41.026Z",
+        "filedBy": "Denise Gould"
+      },
+      {
+        "description": "Request for Place of Trial at Lubbock, Texas",
+        "filingDate": "2019-07-12T17:09:41.026Z",
+        "index": 2
+      },
+      {
+        "description": "Proposed Stipulated Decision",
+        "index": 3,
+        "documentId": "7a923abd-fc41-407a-b76b-7f724fa5d47f",
+        "filingDate": "1990-10-10"
+      }
+    ],
+    "orderForAmendedPetitionAndFilingFee": false,
+    "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "docketNumber": "106-19",
+    "status": "New"
   },
   {
     "procedureType": "Regular",
@@ -739,6 +962,14 @@
     "pk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
     "docketNumber": "106-19",
     "status": "New"
+  },
+  {
+    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "pk": "106-19|case"
+  },
+  {
+    "sk": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
+    "pk": "7805d1ab-18d0-43ec-bafb-654e83405416|case"
   },
   {
     "docketNumberSuffix": null,

--- a/web-client/src/views/TrialSessions/TrialSessionsSummary.jsx
+++ b/web-client/src/views/TrialSessions/TrialSessionsSummary.jsx
@@ -21,7 +21,7 @@ export const TrialSessionsSummary = connect(
             <div className="grid-col-4">
               <a
                 className="usa-link float-right"
-                href={`/trial-sessions?judge=${user.userId}`}
+                href={`/trial-sessions?judge[userId]=${user.userId}`}
               >
                 View All
               </a>
@@ -50,7 +50,7 @@ export const TrialSessionsSummary = connect(
             <div className="grid-col-4">
               <a
                 className="usa-link float-right"
-                href={`/trial-sessions?type=recent&judge=${user.userId}`}
+                href={`/trial-sessions?type=recent&judge[userId]=${user.userId}`}
               >
                 View All
               </a>


### PR DESCRIPTION
Is 2 messages enough?

![Screen Shot 2019-08-08 at 8 53 06 AM](https://user-images.githubusercontent.com/43251054/62708923-f579cf80-b9b9-11e9-8c2e-7158304abe4c.png)

Also fixed the View All links on the judge's dashboard trial session summary.
