### PR TITLE
1272: integration test to send messages to a judge

### DIFF
--- a/web-client/integration-tests/journey/docketClerkCreatesMessageToJudge.js
+++ b/web-client/integration-tests/journey/docketClerkCreatesMessageToJudge.js
@@ -1,5 +1,5 @@
 export default (test, message) => {
-  return it('Petitions clerk sends message to judgeArmen', async () => {
+  return it('Docket clerk sends message to judgeArmen', async () => {
     const workItem = test.taxpayerNewCases[0].documents[3].workItems[0];
     await test.runSequence('gotoDocumentDetailSequence', {
       docketNumber: test.taxpayerNewCases[0].docketNumber,

--- a/web-client/integration-tests/journey/docketClerkCreatesMessageToJudge.js
+++ b/web-client/integration-tests/journey/docketClerkCreatesMessageToJudge.js
@@ -1,0 +1,36 @@
+export default (test, message) => {
+  return it('Petitions clerk sends message to judgeArmen', async () => {
+    const workItem = test.taxpayerNewCases[0].documents[3].workItems[0];
+    await test.runSequence('gotoDocumentDetailSequence', {
+      docketNumber: test.taxpayerNewCases[0].docketNumber,
+      documentId: test.taxpayerNewCases[0].documents[3].documentId,
+    });
+
+    // judgeArmen
+    const assigneeId = 'dabbad00-18d0-43ec-bafb-654e83405416';
+
+    test.setState('form', {
+      [workItem.workItemId]: {
+        assigneeId: assigneeId,
+        forwardMessage: message,
+        section: 'armensChambers',
+      },
+    });
+
+    await test.runSequence('submitForwardSequence', {
+      workItemId: workItem.workItemId,
+    });
+
+    const caseDetail = test.getState('caseDetail');
+    let updatedWorkItem;
+    caseDetail.documents.forEach(document =>
+      document.workItems.forEach(item => {
+        if (item.workItemId === workItem.workItemId) {
+          updatedWorkItem = item;
+        }
+      }),
+    );
+
+    expect(updatedWorkItem.assigneeId).toEqual(assigneeId);
+  });
+};

--- a/web-client/integration-tests/journey/petitionsClerkCreatesMessageToJudge.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesMessageToJudge.js
@@ -1,0 +1,36 @@
+export default (test, message) => {
+  return it('Petitions clerk sends message to judgeArmen', async () => {
+    const workItem = test.taxpayerNewCases[0].documents[0].workItems[0];
+    await test.runSequence('gotoDocumentDetailSequence', {
+      docketNumber: test.taxpayerNewCases[0].docketNumber,
+      documentId: test.taxpayerNewCases[0].documents[0].documentId,
+    });
+
+    // judgeArmen
+    const assigneeId = 'dabbad00-18d0-43ec-bafb-654e83405416';
+
+    test.setState('form', {
+      [workItem.workItemId]: {
+        assigneeId: assigneeId,
+        forwardMessage: message,
+        section: 'armensChambers',
+      },
+    });
+
+    await test.runSequence('submitForwardSequence', {
+      workItemId: workItem.workItemId,
+    });
+
+    const caseDetail = test.getState('caseDetail');
+    let updatedWorkItem;
+    caseDetail.documents.forEach(document =>
+      document.workItems.forEach(item => {
+        if (item.workItemId === workItem.workItemId) {
+          updatedWorkItem = item;
+        }
+      }),
+    );
+
+    expect(updatedWorkItem.assigneeId).toEqual(assigneeId);
+  });
+};

--- a/web-client/integration-tests/journey/taxpayerFilesDocumentForCase.js
+++ b/web-client/integration-tests/journey/taxpayerFilesDocumentForCase.js
@@ -29,6 +29,18 @@ export default (test, fakeFile) => {
       key: 'documentType',
       value: 'Answer',
     });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'documentTitle',
+      value: 'Answer',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'eventCode',
+      value: 'A',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'scenario',
+      value: 'Standard',
+    });
 
     await test.runSequence('validateSelectDocumentTypeSequence');
 
@@ -59,10 +71,18 @@ export default (test, fakeFile) => {
       key: 'documentType',
       value: 'Motion for Leave to File Out of Time',
     });
-
-    await test.runSequence('selectDocumentSequence');
-
-    expect(test.getState('validationErrors')).toEqual({});
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'documentTitle',
+      value: 'Motion for Leave to File Out of Time [Document Name]',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'eventCode',
+      value: 'M014',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'scenario',
+      value: 'Nonstandard H',
+    });
 
     await test.runSequence('selectDocumentSequence');
 
@@ -82,10 +102,18 @@ export default (test, fakeFile) => {
       key: 'secondaryDocument.documentType',
       value: 'Statement',
     });
-
-    await test.runSequence('selectDocumentSequence');
-
-    expect(test.getState('validationErrors')).toEqual({});
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondaryDocument.documentTitle',
+      value: 'Statement [anything]',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondaryDocument.eventCode',
+      value: 'STAT',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondaryDocument.scenario',
+      value: 'Nonstandard B',
+    });
 
     await test.runSequence('selectDocumentSequence');
 
@@ -99,6 +127,10 @@ export default (test, fakeFile) => {
       key: 'secondaryDocument.freeText',
       value: 'Anything',
     });
+
+    await test.runSequence('selectDocumentSequence');
+
+    expect(test.getState('validationErrors')).toEqual({});
 
     await test.runSequence('selectDocumentSequence');
 
@@ -204,6 +236,18 @@ export default (test, fakeFile) => {
     });
 
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'supportingDocuments.0.category',
+      value: 'Supporting Document',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'supportingDocuments.0.documentType',
+      value: 'Affidavit in Support',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'supportingDocuments.0.previousDocument',
+      value: test.getState('form.documentTitle'),
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'supportingDocuments.0.supportingDocument',
       value: 'Affidavit in Support',
     });
@@ -268,6 +312,18 @@ export default (test, fakeFile) => {
       ],
     });
 
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondarySupportingDocuments.0.category',
+      value: 'Supporting Document',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondarySupportingDocuments.0.documentType',
+      value: 'Declaration in Support',
+    });
+    await test.runSequence('updateFileDocumentWizardFormValueSequence', {
+      key: 'secondarySupportingDocuments.0.previousDocument',
+      value: test.getState('form.secondaryDocument.documentTitle'),
+    });
     await test.runSequence('updateFileDocumentWizardFormValueSequence', {
       key: 'secondarySupportingDocuments.0.supportingDocument',
       value: 'Declaration in Support',

--- a/web-client/integration-tests/journey/taxpayerViewsCaseDetailAfterFilingDocument.js
+++ b/web-client/integration-tests/journey/taxpayerViewsCaseDetailAfterFilingDocument.js
@@ -1,0 +1,38 @@
+import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+export default (test, overrides = {}) => {
+  return it('Taxpayer views case detail after filing a document', async () => {
+    await test.runSequence('gotoCaseDetailSequence', {
+      docketNumber: test.docketNumber,
+    });
+
+    const docketNumberSuffix = overrides.docketNumberSuffix || 'W';
+
+    const caseDetail = test.getState('caseDetail');
+    const caseDetailFormatted = runCompute(
+      withAppContextDecorator(formattedCaseDetail),
+      {
+        state: test.getState(),
+      },
+    );
+
+    expect(test.getState('currentPage')).toEqual('CaseDetail');
+    expect(caseDetail.docketNumber).toEqual(test.docketNumber);
+    expect(caseDetail.docketNumberSuffix).toEqual(docketNumberSuffix);
+    expect(caseDetailFormatted.docketNumberWithSuffix).toEqual(
+      `${test.docketNumber}${docketNumberSuffix}`,
+    );
+    expect(caseDetail.documents.length).toEqual(6);
+
+    //verify that the documents were added in the correct order
+    expect(caseDetail.documents[0].eventCode).toEqual('P');
+    expect(caseDetail.documents[1].eventCode).toEqual('STIN');
+    expect(caseDetail.docketRecord[1].eventCode).toEqual('RQT');
+    expect(caseDetail.documents[2].eventCode).toEqual('M014');
+    expect(caseDetail.documents[3].eventCode).toEqual('AFF');
+    expect(caseDetail.documents[4].eventCode).toEqual('MISL');
+    expect(caseDetail.documents[5].eventCode).toEqual('MISL');
+  });
+};

--- a/web-client/integration-tests/judgeMessagesJourney.test.js
+++ b/web-client/integration-tests/judgeMessagesJourney.test.js
@@ -1,0 +1,107 @@
+import { Case } from '../../shared/src/business/entities/cases/Case';
+import { CerebralTest } from 'cerebral/test';
+const {
+  ContactFactory,
+} = require('../../shared/src/business/entities/contacts/ContactFactory');
+import { Document } from '../../shared/src/business/entities/Document';
+import { TrialSession } from '../../shared/src/business/entities/trialSessions/TrialSession';
+import { applicationContext } from '../src/applicationContext';
+import { isFunction, mapValues } from 'lodash';
+import { presenter } from '../src/presenter/presenter';
+import { withAppContextDecorator } from '../src/withAppContext';
+import FormData from 'form-data';
+import docketClerkCreatesMessageToJudge from './journey/docketClerkCreatesMessageToJudge';
+import docketClerkLogIn from './journey/docketClerkLogIn';
+import docketClerkSignsOut from './journey/docketClerkSignsOut';
+import petitionsClerkCreatesMessageToJudge from './journey/petitionsClerkCreatesMessageToJudge';
+import petitionsClerkLogIn from './journey/petitionsClerkLogIn';
+import petitionsClerkSignsOut from './journey/petitionsClerkSignsOut';
+import taxpayerAddNewCaseToTestObj from './journey/taxpayerAddNewCaseToTestObj';
+import taxpayerChoosesCaseType from './journey/taxpayerChoosesCaseType';
+import taxpayerChoosesProcedureType from './journey/taxpayerChoosesProcedureType';
+import taxpayerCreatesNewCase from './journey/taxpayerCreatesNewCase';
+import taxpayerFilesDocumentForCase from './journey/taxpayerFilesDocumentForCase';
+import taxpayerLogin from './journey/taxpayerLogIn';
+import taxpayerNavigatesToCreateCase from './journey/taxpayerCancelsCreateCase';
+import taxpayerSignsOut from './journey/taxpayerSignsOut';
+import taxpayerViewsCaseDetail from './journey/taxpayerViewsCaseDetail';
+import taxpayerViewsCaseDetailAfterFilingDocument from './journey/taxpayerViewsCaseDetailAfterFilingDocument';
+import taxpayerViewsDashboard from './journey/taxpayerViewsDashboard';
+
+let test;
+global.FormData = FormData;
+global.Blob = () => {};
+presenter.providers.applicationContext = applicationContext;
+presenter.providers.router = {
+  externalRoute: () => {},
+  route: async url => {
+    if (url === `/case-detail/${test.docketNumber}`) {
+      await test.runSequence('gotoCaseDetailSequence', {
+        docketNumber: test.docketNumber,
+      });
+    }
+
+    if (url === '/') {
+      await test.runSequence('gotoDashboardSequence');
+    }
+  },
+};
+
+presenter.state = mapValues(presenter.state, value => {
+  if (isFunction(value)) {
+    return withAppContextDecorator(value, applicationContext);
+  }
+  return value;
+});
+
+const fakeData =
+  'JVBERi0xLjEKJcKlwrHDqwoKMSAwIG9iagogIDw8IC9UeXBlIC9DYXRhbG9nCiAgICAgL1BhZ2VzIDIgMCBSCiAgPj4KZW5kb2JqCgoyIDAgb2JqCiAgPDwgL1R5cGUgL1BhZ2VzCiAgICAgL0tpZHMgWzMgMCBSXQogICAgIC9Db3VudCAxCiAgICAgL01lZGlhQm94IFswIDAgMzAwIDE0NF0KICA+PgplbmRvYmoKCjMgMCBvYmoKICA8PCAgL1R5cGUgL1BhZ2UKICAgICAgL1BhcmVudCAyIDAgUgogICAgICAvUmVzb3VyY2VzCiAgICAgICA8PCAvRm9udAogICAgICAgICAgIDw8IC9GMQogICAgICAgICAgICAgICA8PCAvVHlwZSAvRm9udAogICAgICAgICAgICAgICAgICAvU3VidHlwZSAvVHlwZTEKICAgICAgICAgICAgICAgICAgL0Jhc2VGb250IC9UaW1lcy1Sb21hbgogICAgICAgICAgICAgICA+PgogICAgICAgICAgID4+CiAgICAgICA+PgogICAgICAvQ29udGVudHMgNCAwIFIKICA+PgplbmRvYmoKCjQgMCBvYmoKICA8PCAvTGVuZ3RoIDg0ID4+CnN0cmVhbQogIEJUCiAgICAvRjEgMTggVGYKICAgIDUgODAgVGQKICAgIChDb25ncmF0aW9ucywgeW91IGZvdW5kIHRoZSBFYXN0ZXIgRWdnLikgVGoKICBFVAplbmRzdHJlYW0KZW5kb2JqCgp4cmVmCjAgNQowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMTggMDAwMDAgbiAKMDAwMDAwMDA3NyAwMDAwMCBuIAowMDAwMDAwMTc4IDAwMDAwIG4gCjAwMDAwMDA0NTcgMDAwMDAgbiAKdHJhaWxlcgogIDw8ICAvUm9vdCAxIDAgUgogICAgICAvU2l6ZSA1CiAgPj4Kc3RhcnR4cmVmCjU2NQolJUVPRgo=';
+const fakeFile = Buffer.from(fakeData, 'base64');
+fakeFile.name = 'fakeFile.pdf';
+
+test = CerebralTest(presenter);
+
+describe('Judge messages journey', () => {
+  beforeEach(() => {
+    jest.setTimeout(30000);
+    global.window = {
+      localStorage: {
+        removeItem: () => null,
+        setItem: () => null,
+      },
+    };
+
+    test.setState('constants', {
+      CASE_CAPTION_POSTFIX: Case.CASE_CAPTION_POSTFIX,
+      CATEGORIES: Document.CATEGORIES,
+      CATEGORY_MAP: Document.CATEGORY_MAP,
+      COUNTRY_TYPES: ContactFactory.COUNTRY_TYPES,
+      PARTY_TYPES: ContactFactory.PARTY_TYPES,
+      TRIAL_CITIES: TrialSession.TRIAL_CITIES,
+    });
+  });
+
+  taxpayerLogin(test);
+  taxpayerNavigatesToCreateCase(test);
+  taxpayerChoosesProcedureType(test);
+  taxpayerChoosesCaseType(test);
+  taxpayerCreatesNewCase(test, fakeFile);
+  taxpayerViewsDashboard(test);
+  taxpayerViewsCaseDetail(test);
+  taxpayerFilesDocumentForCase(test, fakeFile);
+  taxpayerViewsCaseDetailAfterFilingDocument(test);
+  taxpayerViewsDashboard(test);
+  taxpayerAddNewCaseToTestObj(test);
+  taxpayerSignsOut(test);
+
+  petitionsClerkLogIn(test);
+  petitionsClerkCreatesMessageToJudge(test, "don't forget to be awesome");
+  petitionsClerkSignsOut(test);
+
+  docketClerkLogIn(test);
+  docketClerkCreatesMessageToJudge(
+    test,
+    'karma karma karma karma karma chameleon',
+  );
+  docketClerkSignsOut(test);
+});

--- a/web-client/integration-tests/petitionerFilesADocument.test.js
+++ b/web-client/integration-tests/petitionerFilesADocument.test.js
@@ -16,6 +16,7 @@ import taxpayerLogin from './journey/taxpayerLogIn';
 import taxpayerNavigatesToCreateCase from './journey/taxpayerCancelsCreateCase';
 import taxpayerSignsOut from './journey/taxpayerSignsOut';
 import taxpayerViewsCaseDetail from './journey/taxpayerViewsCaseDetail';
+import taxpayerViewsCaseDetailAfterFilingDocument from './journey/taxpayerViewsCaseDetailAfterFilingDocument';
 import taxpayerViewsDashboard from './journey/taxpayerViewsDashboard';
 const {
   ContactFactory,
@@ -83,5 +84,6 @@ describe('Taxpayer files document', () => {
   taxpayerViewsDashboard(test);
   taxpayerViewsCaseDetail(test);
   taxpayerFilesDocumentForCase(test, fakeFile);
+  taxpayerViewsCaseDetailAfterFilingDocument(test);
   taxpayerSignsOut(test);
 });


### PR DESCRIPTION
Also fixed the taxpayer filing a document integration test that had apparently been broken for a while. Added some more checks to ensure that it can't fail unnoticed anymore.