### PR TITLE
2567: add filtering options to working copy view 

### DIFF
--- a/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.js
+++ b/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.js
@@ -39,7 +39,7 @@ TrialSessionWorkingCopy.errorToMessageMap = {};
 
 TrialSessionWorkingCopy.validationRules = {
   caseMetadata: joi.object().optional(),
-  filters: joi.string().optional(),
+  filters: joi.object().optional(),
   sort: joi.string().optional(),
   sortOrder: joi.string().optional(),
   trialSessionId: joi

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1491,3 +1491,19 @@ button.change-scanner-button {
   font-size: 17px;
   font-weight: $font-semibold;
 }
+
+.working-copy-filters {
+  .working-copy-filters--header {
+    padding: 0.75em 1.25em;
+    background-color: color($theme-color-primary-dark);
+    color: $color-white;
+
+    h3 {
+      margin-bottom: 0;
+    }
+
+    span {
+      font-weight: $font-semibold;
+    }
+  }
+}

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1506,4 +1506,18 @@ button.change-scanner-button {
       font-weight: $font-semibold;
     }
   }
+
+  .working-copy-filters--content {
+    padding: 1em;
+    border: 1px solid color($theme-color-base-lightest);
+    background-color: $color-primary-alt-lightest;
+
+    .show-all-sessions {
+      border-right: 1px solid color($theme-color-base-light);
+
+      label {
+        font-weight: $font-semibold;
+      }
+    }
+  }
 }

--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopyFilterHeader.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopyFilterHeader.jsx
@@ -1,0 +1,87 @@
+import { connect } from '@cerebral/react';
+import { sequences, state } from 'cerebral';
+import React from 'react';
+
+export const WorkingCopyFilterHeader = connect(
+  {
+    autoSaveTrialSessionWorkingCopySequence:
+      sequences.autoSaveTrialSessionWorkingCopySequence,
+    trialSessionWorkingCopy: state.trialSessionWorkingCopy,
+    trialStatusOptions: state.trialSessionWorkingCopyHelper.trialStatusOptions,
+  },
+  ({
+    autoSaveTrialSessionWorkingCopySequence,
+    trialSessionWorkingCopy,
+    trialStatusOptions,
+  }) => {
+    return (
+      <div className="working-copy-filters">
+        <div className="working-copy-filters--header">
+          <div className="grid-row">
+            <div className="grid-col-6">
+              <h3>Show Cases by Trial Status</h3>
+            </div>
+            <div className="grid-col-6 text-right">
+              <span>Total Shown: 333</span>
+            </div>
+          </div>
+        </div>
+        <div className="filter-area">
+          <div className="usa-checkbox">
+            <input
+              checked={
+                (trialSessionWorkingCopy.filters &&
+                  trialSessionWorkingCopy.filters.showAll) ||
+                false
+              }
+              className="usa-checkbox__input"
+              id="filters.showAll"
+              name="filters.showAll"
+              type="checkbox"
+              onChange={e => {
+                autoSaveTrialSessionWorkingCopySequence({
+                  key: e.target.name,
+                  value: e.target.checked,
+                });
+              }}
+            />
+            <label
+              className="usa-checkbox__label show-all-label"
+              htmlFor="filters.showAll"
+            >
+              Show All
+            </label>
+          </div>
+
+          {trialStatusOptions.map((option, idx) => (
+            <div className="usa-checkbox" key={idx}>
+              <input
+                checked={
+                  (trialSessionWorkingCopy.filters &&
+                    trialSessionWorkingCopy.filters[option.key]) ||
+                  false
+                }
+                className="usa-checkbox__input"
+                id={`filters${option.key}`}
+                name={`filters.${option.key}`}
+                type="checkbox"
+                onChange={e => {
+                  autoSaveTrialSessionWorkingCopySequence({
+                    key: e.target.name,
+                    value: e.target.checked,
+                  });
+                }}
+              />
+              <label
+                className="usa-checkbox__label show-all-label"
+                htmlFor={`filters${option.key}`}
+              >
+                {option.value}
+              </label>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);

--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopyFilterHeader.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopyFilterHeader.jsx
@@ -7,13 +7,8 @@ export const WorkingCopyFilterHeader = connect(
     autoSaveTrialSessionWorkingCopySequence:
       sequences.autoSaveTrialSessionWorkingCopySequence,
     trialSessionWorkingCopy: state.trialSessionWorkingCopy,
-    trialStatusOptions: state.trialSessionWorkingCopyHelper.trialStatusOptions,
   },
-  ({
-    autoSaveTrialSessionWorkingCopySequence,
-    trialSessionWorkingCopy,
-    trialStatusOptions,
-  }) => {
+  ({ autoSaveTrialSessionWorkingCopySequence, trialSessionWorkingCopy }) => {
     return (
       <div className="working-copy-filters">
         <div className="working-copy-filters--header">
@@ -26,60 +21,281 @@ export const WorkingCopyFilterHeader = connect(
             </div>
           </div>
         </div>
-        <div className="filter-area">
-          <div className="usa-checkbox">
-            <input
-              checked={
-                (trialSessionWorkingCopy.filters &&
-                  trialSessionWorkingCopy.filters.showAll) ||
-                false
-              }
-              className="usa-checkbox__input"
-              id="filters.showAll"
-              name="filters.showAll"
-              type="checkbox"
-              onChange={e => {
-                autoSaveTrialSessionWorkingCopySequence({
-                  key: e.target.name,
-                  value: e.target.checked,
-                });
-              }}
-            />
-            <label
-              className="usa-checkbox__label show-all-label"
-              htmlFor="filters.showAll"
-            >
-              Show All
-            </label>
-          </div>
 
-          {trialStatusOptions.map((option, idx) => (
-            <div className="usa-checkbox" key={idx}>
-              <input
-                checked={
-                  (trialSessionWorkingCopy.filters &&
-                    trialSessionWorkingCopy.filters[option.key]) ||
-                  false
-                }
-                className="usa-checkbox__input"
-                id={`filters${option.key}`}
-                name={`filters.${option.key}`}
-                type="checkbox"
-                onChange={e => {
-                  autoSaveTrialSessionWorkingCopySequence({
-                    key: e.target.name,
-                    value: e.target.checked,
-                  });
-                }}
-              />
-              <label
-                className="usa-checkbox__label show-all-label"
-                htmlFor={`filters${option.key}`}
-              >
-                {option.value}
-              </label>
+        <div className="working-copy-filters--content">
+          <div className="grid-row">
+            <div className="grid-col-1 show-all-sessions">
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.showAll) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id="filters.showAll"
+                  name="filters.showAll"
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor="filters.showAll"
+                >
+                  Show All
+                </label>
+              </div>
             </div>
-          ))}
+
+            <div className="grid-col-2 grid-offset-1">
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.setForTrial) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.setForTrial'}
+                  name={'filters.setForTrial'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.setForTrial'}
+                >
+                  Set for Trial
+                </label>
+              </div>
+
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.dismissed) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.dismissed'}
+                  name={'filters.dismissed'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.dismissed'}
+                >
+                  Dismissed
+                </label>
+              </div>
+            </div>
+
+            <div className="grid-col-2">
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.continued) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.continued'}
+                  name={'filters.continued'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.continued'}
+                >
+                  Continued
+                </label>
+              </div>
+
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.rule122) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.rule122'}
+                  name={'filters.rule122'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.rule122'}
+                >
+                  Rule 122
+                </label>
+              </div>
+            </div>
+
+            <div className="grid-col-2">
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.aBasisReached) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.aBasisReached'}
+                  name={'filters.aBasisReached'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.aBasisReached'}
+                >
+                  A Basis Reached
+                </label>
+              </div>
+
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.settled) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.settled'}
+                  name={'filters.settled'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.settled'}
+                >
+                  Settled
+                </label>
+              </div>
+            </div>
+
+            <div className="grid-col-2">
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.recall) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.recall'}
+                  name={'filters.recall'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.recall'}
+                >
+                  Recall
+                </label>
+              </div>
+
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.takenUnderAdvisement) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id={'filters.takenUnderAdvisement'}
+                  name={'filters.takenUnderAdvisement'}
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor={'filters.takenUnderAdvisement'}
+                >
+                  Taken Under Advisement
+                </label>
+              </div>
+            </div>
+
+            <div className="grid-col-2">
+              <div className="usa-checkbox">
+                <input
+                  checked={
+                    (trialSessionWorkingCopy.filters &&
+                      trialSessionWorkingCopy.filters.statusUnassigned) ||
+                    false
+                  }
+                  className="usa-checkbox__input"
+                  id="filters.statusUnassigned"
+                  name="filters.statusUnassigned"
+                  type="checkbox"
+                  onChange={e => {
+                    autoSaveTrialSessionWorkingCopySequence({
+                      key: e.target.name,
+                      value: e.target.checked,
+                    });
+                  }}
+                />
+                <label
+                  className="usa-checkbox__label show-all-label"
+                  htmlFor="filters.statusUnassigned"
+                >
+                  Status unassigned
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopyFilterHeader.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopyFilterHeader.jsx
@@ -44,7 +44,7 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
+                  className="usa-checkbox__label"
                   htmlFor="filters.showAll"
                 >
                   Show All
@@ -61,8 +61,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.setForTrial'}
-                  name={'filters.setForTrial'}
+                  id="filters.setForTrial"
+                  name="filters.setForTrial"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -72,8 +72,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.setForTrial'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.setForTrial"
                 >
                   Set for Trial
                 </label>
@@ -87,8 +87,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.dismissed'}
-                  name={'filters.dismissed'}
+                  id="filters.dismissed"
+                  name="filters.dismissed"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -98,8 +98,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.dismissed'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.dismissed"
                 >
                   Dismissed
                 </label>
@@ -115,8 +115,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.continued'}
-                  name={'filters.continued'}
+                  id="filters.continued"
+                  name="filters.continued"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -126,8 +126,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.continued'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.continued"
                 >
                   Continued
                 </label>
@@ -141,8 +141,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.rule122'}
-                  name={'filters.rule122'}
+                  id="filters.rule122"
+                  name="filters.rule122"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -152,8 +152,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.rule122'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.rule122"
                 >
                   Rule 122
                 </label>
@@ -169,8 +169,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.aBasisReached'}
-                  name={'filters.aBasisReached'}
+                  id="filters.aBasisReached"
+                  name="filters.aBasisReached"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -180,8 +180,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.aBasisReached'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.aBasisReached"
                 >
                   A Basis Reached
                 </label>
@@ -195,8 +195,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.settled'}
-                  name={'filters.settled'}
+                  id="filters.settled"
+                  name="filters.settled"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -206,8 +206,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.settled'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.settled"
                 >
                   Settled
                 </label>
@@ -223,8 +223,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.recall'}
-                  name={'filters.recall'}
+                  id="filters.recall"
+                  name="filters.recall"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -233,10 +233,7 @@ export const WorkingCopyFilterHeader = connect(
                     });
                   }}
                 />
-                <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.recall'}
-                >
+                <label className="usa-checkbox__label" htmlFor="filters.recall">
                   Recall
                 </label>
               </div>
@@ -249,8 +246,8 @@ export const WorkingCopyFilterHeader = connect(
                     false
                   }
                   className="usa-checkbox__input"
-                  id={'filters.takenUnderAdvisement'}
-                  name={'filters.takenUnderAdvisement'}
+                  id="filters.takenUnderAdvisement"
+                  name="filters.takenUnderAdvisement"
                   type="checkbox"
                   onChange={e => {
                     autoSaveTrialSessionWorkingCopySequence({
@@ -260,8 +257,8 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
-                  htmlFor={'filters.takenUnderAdvisement'}
+                  className="usa-checkbox__label"
+                  htmlFor="filters.takenUnderAdvisement"
                 >
                   Taken Under Advisement
                 </label>
@@ -288,7 +285,7 @@ export const WorkingCopyFilterHeader = connect(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label show-all-label"
+                  className="usa-checkbox__label"
                   htmlFor="filters.statusUnassigned"
                 >
                   Status unassigned

--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
@@ -1,5 +1,6 @@
 import { BindedSelect } from '../../ustc-ui/BindedSelect/BindedSelect';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { WorkingCopyFilterHeader } from './WorkingCopyFilterHeader';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -22,6 +23,7 @@ export const WorkingCopySessionList = connect(
   }) => {
     return (
       <div className="margin-top-4">
+        <WorkingCopyFilterHeader />
         <table
           aria-describedby="tab-my-queue"
           className="usa-table work-queue subsection"


### PR DESCRIPTION
I was spending way too much time trying to get the separator between Show All and the rest of the filtering options in the right place. I'll revisit later.
The total count is also hardcoded for now until the filtering has been implemented in the computed.

<img width="1391" alt="Screen Shot 2019-08-14 at 2 35 41 PM" src="https://user-images.githubusercontent.com/43251054/63050530-f9698e00-bea0-11e9-8db7-66028e85cb55.png">
