### PR TITLE
docker-run repair (master)

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -9,5 +9,4 @@ docker run -t -i \
   -p 8001:8001 \
   -p 9000:9000 \
   --rm efcms /bin/sh \
-  -c "npx run-s start:api dynamo:admin print:success start:client"
-
+  -c "(npm run start:api &) && (npm run dynamo:admin &) && (npm run print:success &) && npm run start:client"


### PR DESCRIPTION
previous use of "run-s" was waiting for first command to complete before starting next; reverting to backgrounded/chained commands