### PR TITLE
Use DateHandler functions instead of Date() or moment()

### DIFF
--- a/shared/src/business/entities/CaseDeadline.js
+++ b/shared/src/business/entities/CaseDeadline.js
@@ -3,6 +3,7 @@ const uuid = require('uuid');
 const {
   joiValidationDecorator,
 } = require('../../utilities/JoiValidationDecorator');
+const { createISODateString } = require('../utilities/DateHandler');
 
 /**
  * Case Deadline entity
@@ -13,7 +14,7 @@ const {
 function CaseDeadline(rawProps) {
   this.caseDeadlineId = rawProps.caseDeadlineId || uuid.v4();
   this.caseId = rawProps.caseId;
-  this.createdAt = rawProps.createdAt || new Date().toISOString();
+  this.createdAt = rawProps.createdAt || createISODateString();
   this.description = rawProps.description;
   this.deadlineDate = rawProps.deadlineDate;
 }

--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -4,6 +4,7 @@ const joi = require('joi-browser');
 const {
   joiValidationDecorator,
 } = require('../../utilities/JoiValidationDecorator');
+const { createISODateString } = require('../utilities/DateHandler');
 const { flatten } = require('lodash');
 const { Order } = require('./orders/Order');
 const { WorkItem } = require('./WorkItem');
@@ -31,7 +32,7 @@ function Document(rawDocument) {
   this.category = rawDocument.category;
   this.certificateOfService = rawDocument.certificateOfService;
   this.certificateOfServiceDate = rawDocument.certificateOfServiceDate;
-  this.createdAt = rawDocument.createdAt || new Date().toISOString();
+  this.createdAt = rawDocument.createdAt || createISODateString();
   this.docketNumber = rawDocument.docketNumber;
   this.documentId = rawDocument.documentId;
   this.documentTitle = rawDocument.documentTitle;
@@ -50,7 +51,7 @@ function Document(rawDocument) {
   this.practitioner = rawDocument.practitioner;
   this.previousDocument = rawDocument.previousDocument;
   this.processingStatus = rawDocument.processingStatus;
-  this.receivedAt = rawDocument.receivedAt || new Date().toISOString();
+  this.receivedAt = rawDocument.receivedAt || createISODateString();
   this.relationship = rawDocument.relationship;
   this.scenario = rawDocument.scenario;
   this.servedAt = rawDocument.servedAt;
@@ -194,7 +195,7 @@ Document.prototype.addWorkItem = function(workItem) {
 
 Document.prototype.setAsServed = function(servedParties = null) {
   this.status = 'served';
-  this.servedAt = new Date().toISOString();
+  this.servedAt = createISODateString();
   if (servedParties) {
     this.servedParties = servedParties;
   }
@@ -253,7 +254,7 @@ Document.prototype.generateFiledBy = function(caseDetail) {
  */
 Document.prototype.setSigned = function(signByUserId) {
   this.signedByUserId = signByUserId;
-  this.signedAt = new Date().toISOString();
+  this.signedAt = createISODateString();
 };
 
 exports.Document = Document;

--- a/shared/src/business/entities/Message.js
+++ b/shared/src/business/entities/Message.js
@@ -3,6 +3,7 @@ const uuid = require('uuid');
 const {
   joiValidationDecorator,
 } = require('../../utilities/JoiValidationDecorator');
+const { createISODateString } = require('../utilities/DateHandler');
 
 /**
  * constructor
@@ -11,7 +12,7 @@ const {
  * @constructor
  */
 function Message(rawMessage) {
-  this.createdAt = rawMessage.createdAt || new Date().toISOString();
+  this.createdAt = rawMessage.createdAt || createISODateString();
   this.from = rawMessage.from;
   this.fromUserId = rawMessage.fromUserId;
   this.message = rawMessage.message;

--- a/shared/src/business/entities/WorkItem.js
+++ b/shared/src/business/entities/WorkItem.js
@@ -3,6 +3,7 @@ const uuid = require('uuid');
 const {
   joiValidationDecorator,
 } = require('../../utilities/JoiValidationDecorator');
+const { createISODateString } = require('../utilities/DateHandler');
 const { IRS_BATCH_SYSTEM_SECTION, PETITIONS_SECTION } = require('./WorkQueue');
 const { Message } = require('./Message');
 const { orderBy } = require('lodash');
@@ -23,7 +24,7 @@ function WorkItem(rawWorkItem) {
   this.completedBy = rawWorkItem.completedBy;
   this.completedByUserId = rawWorkItem.completedByUserId;
   this.completedMessage = rawWorkItem.completedMessage;
-  this.createdAt = rawWorkItem.createdAt || new Date().toISOString();
+  this.createdAt = rawWorkItem.createdAt || createISODateString();
   this.docketNumber = rawWorkItem.docketNumber;
   this.docketNumberSuffix = rawWorkItem.docketNumberSuffix;
   this.document = rawWorkItem.document;
@@ -35,7 +36,7 @@ function WorkItem(rawWorkItem) {
   this.sentBy = rawWorkItem.sentBy;
   this.sentBySection = rawWorkItem.sentBySection;
   this.sentByUserId = rawWorkItem.sentByUserId;
-  this.updatedAt = rawWorkItem.updatedAt || new Date().toISOString();
+  this.updatedAt = rawWorkItem.updatedAt || createISODateString();
   this.workItemId = rawWorkItem.workItemId || uuid.v4();
   this.messages = (rawWorkItem.messages || []).map(
     message => new Message(message),
@@ -250,7 +251,7 @@ WorkItem.prototype.recallFromIRSBatchSystem = function({ user }) {
  * @returns {WorkItem} the updated work item
  */
 WorkItem.prototype.setAsCompleted = function({ message, user }) {
-  this.completedAt = new Date().toISOString();
+  this.completedAt = createISODateString();
   this.completedBy = user.name;
   this.completedByUserId = user.userId;
   this.completedMessage = message;
@@ -270,7 +271,7 @@ WorkItem.prototype.setAsSentToIRS = function({
   batchedByName,
   batchedByUserId,
 }) {
-  this.completedAt = new Date().toISOString();
+  this.completedAt = createISODateString();
   this.completedMessage = 'Served on IRS';
   this.completedBy = batchedByName;
   this.completedByUserId = batchedByUserId;

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -8,6 +8,7 @@ const {
   joiValidationDecorator,
 } = require('../../../utilities/JoiValidationDecorator');
 const { ContactFactory } = require('../contacts/ContactFactory');
+const { createISODateString } = require('../utilities/DateHandler');
 const { DocketRecord } = require('../DocketRecord');
 const { Document } = require('../Document');
 const { find, includes, uniqBy } = require('lodash');
@@ -165,7 +166,7 @@ function Case(rawCase) {
   this.caseType = rawCase.caseType;
   this.contactPrimary = rawCase.contactPrimary;
   this.contactSecondary = rawCase.contactSecondary;
-  this.createdAt = rawCase.createdAt || new Date().toISOString();
+  this.createdAt = rawCase.createdAt || createISODateString();
   this.currentVersion = rawCase.currentVersion;
   this.docketNumber = rawCase.docketNumber;
   this.docketNumberSuffix = getDocketNumberSuffix(rawCase);
@@ -531,7 +532,7 @@ Case.prototype.updateCaseTitleDocketRecord = function() {
     this.addDocketRecord(
       new DocketRecord({
         description: `Caption of case is amended from '${lastTitle}' to '${this.caseTitle}'`,
-        filingDate: new Date().toISOString(),
+        filingDate: createISODateString(),
       }),
     );
   }
@@ -574,7 +575,7 @@ Case.prototype.updateDocketNumberRecord = function() {
     this.addDocketRecord(
       new DocketRecord({
         description: `Docket Number is amended from '${oldDocketNumber}' to '${newDocketNumber}'`,
-        filingDate: new Date().toISOString(),
+        filingDate: createISODateString(),
       }),
     );
   }

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.js
@@ -1,8 +1,8 @@
 const joi = require('joi-browser');
-const moment = require('moment');
 const {
   joiValidationDecorator,
 } = require('../../../utilities/JoiValidationDecorator');
+const { formatDateString } = require('../../utilities/DateHandler');
 const { replaceBracketed } = require('../../utilities/replaceBracketed');
 
 /**
@@ -22,7 +22,7 @@ ExternalDocumentNonStandardD.prototype.getDocumentTitle = function() {
   return replaceBracketed(
     this.documentTitle,
     this.previousDocument,
-    moment.utc(this.serviceDate).format('MM-DD-YYYY'),
+    formatDateString(this.serviceDate, 'MM-DD-YYYY'),
   );
 };
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.test.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const { createISODateString } = require('../../utilities/DateHandler');
 const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
 
 describe('ExternalDocumentNonStandardD', () => {
@@ -48,7 +49,7 @@ describe('ExternalDocumentNonStandardD', () => {
   });
 
   describe('title generation', () => {
-    const serviceDate = moment('2012-04-10').format();
+    const serviceDate = '2012-04-10T00:00:00-05:00';
     it('should generate valid title', () => {
       const extDoc = ExternalDocumentFactory.get({
         category: 'Supporting Document',

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.test.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.test.js
@@ -1,5 +1,4 @@
 const moment = require('moment');
-const { createISODateString } = require('../../utilities/DateHandler');
 const { ExternalDocumentFactory } = require('./ExternalDocumentFactory');
 
 describe('ExternalDocumentNonStandardD', () => {

--- a/shared/src/business/entities/trialSessions/TrialSession.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.js
@@ -3,6 +3,7 @@ const uuid = require('uuid');
 const {
   joiValidationDecorator,
 } = require('../../../utilities/JoiValidationDecorator');
+const { createISODateString } = require('../../utilities/DateHandler');
 
 const COMMON_CITIES = [
   { city: 'Birmingham', state: 'Alabama' },
@@ -125,7 +126,7 @@ TrialSession.prototype.init = function(rawSession) {
   this.city = rawSession.city;
   this.courtReporter = rawSession.courtReporter;
   this.courthouseName = rawSession.courthouseName;
-  this.createdAt = rawSession.createdAt || new Date().toISOString();
+  this.createdAt = rawSession.createdAt || createISODateString();
   this.irsCalendarAdministrator = rawSession.irsCalendarAdministrator;
   this.isCalendared = rawSession.isCalendared || false;
   this.judge = rawSession.judge;

--- a/shared/src/business/useCases/checkForReadyForTrialCasesInteractor.js
+++ b/shared/src/business/useCases/checkForReadyForTrialCasesInteractor.js
@@ -1,4 +1,5 @@
 const { Case } = require('../entities/cases/Case');
+const { createISODateString } = require('../utilities/DateHandler');
 
 /**
  * @param {object} providers the providers object
@@ -7,7 +8,7 @@ const { Case } = require('../entities/cases/Case');
 exports.checkForReadyForTrialCasesInteractor = async ({
   applicationContext,
 }) => {
-  applicationContext.logger.info('Time', new Date().toISOString());
+  applicationContext.logger.info('Time', createISODateString());
 
   const caseCatalog = await applicationContext
     .getPersistenceGateway()
@@ -59,5 +60,5 @@ exports.checkForReadyForTrialCasesInteractor = async ({
   }
   await Promise.all(updatedCases);
 
-  applicationContext.logger.info('Time', new Date().toISOString());
+  applicationContext.logger.info('Time', createISODateString());
 };

--- a/shared/src/business/useCases/runBatchProcessInteractor.js
+++ b/shared/src/business/useCases/runBatchProcessInteractor.js
@@ -8,6 +8,7 @@ const {
   UPDATE_CASE,
 } = require('../../authorization/authorizationClientService');
 const { Case } = require('../entities/cases/Case');
+const { createISODateString } = require('../utilities/DateHandler');
 const { Document } = require('../entities/Document');
 const { UnauthorizedError } = require('../../errors/errors');
 
@@ -80,7 +81,7 @@ exports.runBatchProcessInteractor = async ({ applicationContext }) => {
     }
 
     const caseEntity = new Case(caseToBatch).markAsSentToIRS(
-      new Date().toISOString(),
+      createISODateString(),
     );
 
     const petitionDocument = caseEntity.documents.find(

--- a/shared/src/business/useCases/workitems/assignWorkItemsInteractor.js
+++ b/shared/src/business/useCases/workitems/assignWorkItemsInteractor.js
@@ -4,6 +4,7 @@ const {
 } = require('../../../authorization/authorizationClientService');
 const { Case } = require('../../entities/cases/Case');
 const { cloneDeep } = require('lodash');
+const { createISODateString } = require('../../utilities/DateHandler');
 const { Message } = require('../../entities/Message');
 const { UnauthorizedError } = require('../../../errors/errors');
 const { WorkItem } = require('../../entities/WorkItem');
@@ -51,7 +52,7 @@ exports.assignWorkItemsInteractor = async ({
   const originalWorkItem = new WorkItem(cloneDeep(fullWorkItem));
 
   const newMessage = new Message({
-    createdAt: new Date().toISOString(),
+    createdAt: createISODateString(),
     from: user.name,
     fromUserId: user.userId,
     message: workItemEntity.getLatestMessageEntity().message,

--- a/shared/src/business/useCases/workitems/completeWorkItemInteractor.js
+++ b/shared/src/business/useCases/workitems/completeWorkItemInteractor.js
@@ -2,7 +2,7 @@ const {
   isAuthorized,
   WORKITEM,
 } = require('../../../authorization/authorizationClientService');
-const { createISODateString } = require('../utilities/DateHandler');
+const { createISODateString } = require('../../utilities/DateHandler');
 
 const { Case } = require('../../entities/cases/Case');
 const { UnauthorizedError } = require('../../../errors/errors');

--- a/shared/src/business/useCases/workitems/completeWorkItemInteractor.js
+++ b/shared/src/business/useCases/workitems/completeWorkItemInteractor.js
@@ -2,6 +2,8 @@ const {
   isAuthorized,
   WORKITEM,
 } = require('../../../authorization/authorizationClientService');
+const { createISODateString } = require('../utilities/DateHandler');
+
 const { Case } = require('../../entities/cases/Case');
 const { UnauthorizedError } = require('../../../errors/errors');
 const { WorkItem } = require('../../entities/WorkItem');
@@ -45,7 +47,7 @@ exports.completeWorkItemInteractor = async ({
     applicationContext,
     workItem: {
       ...completedWorkItem,
-      createdAt: new Date().toISOString(),
+      createdAt: createISODateString(),
     },
   });
 

--- a/shared/src/business/useCases/workitems/forwardWorkItemInteractor.js
+++ b/shared/src/business/useCases/workitems/forwardWorkItemInteractor.js
@@ -3,6 +3,7 @@ const {
   WORKITEM,
 } = require('../../../authorization/authorizationClientService');
 const { Case } = require('../../entities/cases/Case');
+const { createISODateString } = require('../../utilities/DateHandler');
 const { Message } = require('../../entities/Message');
 const { UnauthorizedError } = require('../../../errors/errors');
 const { User } = require('../../entities/User');
@@ -47,7 +48,7 @@ exports.forwardWorkItemInteractor = async ({
     });
 
   const newMessage = new Message({
-    createdAt: new Date().toISOString(),
+    createdAt: createISODateString(),
     from: user.name,
     fromUserId: user.userId,
     message,
@@ -105,7 +106,7 @@ exports.forwardWorkItemInteractor = async ({
     applicationContext,
     workItem: {
       ...workItemToForward.validate().toRawObject(),
-      createdAt: new Date().toISOString(),
+      createdAt: createISODateString(),
     },
   });
 

--- a/shared/src/business/utilities/DateHandler.test.js
+++ b/shared/src/business/utilities/DateHandler.test.js
@@ -1,6 +1,17 @@
-const { createISODateString, formatDateString } = require('./DateHandler');
+const {
+  createISODateString,
+  formatDateString,
+  prepareDateFromString,
+} = require('./DateHandler');
 
 describe('DateHandler', () => {
+  describe('prepareDateFromString', () => {
+    it("Creates a new moment object for 'now' when given no inputs'", () => {
+      const myMoment = prepareDateFromString();
+      expect(myMoment).toBeDefined();
+    });
+  });
+
   describe('createISODateString', () => {
     it('creates a date anew', () => {
       const myDate = createISODateString();

--- a/shared/src/external/irsGateway.js
+++ b/shared/src/external/irsGateway.js
@@ -1,8 +1,10 @@
+const { createISODateString } = require('../utilities/DateHandler');
+
 /**
  *
  * @returns {string} the current timestamp as a string
  */
 exports.sendToIRS = async () => {
   // noop
-  return new Date().toISOString();
+  return createISODateString();
 };

--- a/shared/src/external/irsGateway.js
+++ b/shared/src/external/irsGateway.js
@@ -1,4 +1,4 @@
-const { createISODateString } = require('../utilities/DateHandler');
+const { createISODateString } = require('../business/utilities/DateHandler');
 
 /**
  *

--- a/shared/src/persistence/dynamo/workitems/getDocumentQCBatchedForSection.js
+++ b/shared/src/persistence/dynamo/workitems/getDocumentQCBatchedForSection.js
@@ -1,12 +1,13 @@
-const moment = require('moment');
+const {
+  prepareDateFromString,
+} = require('../../../business/utilities/DateHandler');
 const { query } = require('../../dynamodbClientService');
 
 exports.getDocumentQCBatchedForSection = async ({
   applicationContext,
   section,
 }) => {
-  const afterDate = moment
-    .utc(new Date().toISOString())
+  const afterDate = prepareDateFromString()
     .startOf('day')
     .subtract(7, 'd')
     .utc()

--- a/shared/src/persistence/dynamo/workitems/getDocumentQCBatchedForUser.js
+++ b/shared/src/persistence/dynamo/workitems/getDocumentQCBatchedForUser.js
@@ -1,12 +1,13 @@
-const moment = require('moment');
+const {
+  prepareDateFromString,
+} = require('../../../business/utilities/DateHandler');
 const { query } = require('../../dynamodbClientService');
 
 exports.getDocumentQCBatchedForUser = async ({
   applicationContext,
   userId,
 }) => {
-  const afterDate = moment
-    .utc(new Date().toISOString())
+  const afterDate = prepareDateFromString()
     .startOf('day')
     .subtract(7, 'd')
     .utc()

--- a/shared/src/persistence/dynamo/workitems/getDocumentQCServedForSection.js
+++ b/shared/src/persistence/dynamo/workitems/getDocumentQCServedForSection.js
@@ -1,12 +1,13 @@
-const moment = require('moment');
+const {
+  prepareDateFromString,
+} = require('../../../business/utilities/DateHandler');
 const { query } = require('../../dynamodbClientService');
 
 exports.getDocumentQCServedForSection = async ({
   applicationContext,
   section,
 }) => {
-  const afterDate = moment
-    .utc(new Date().toISOString())
+  const afterDate = prepareDateFromString()
     .startOf('day')
     .subtract(7, 'd')
     .utc()

--- a/shared/src/persistence/dynamo/workitems/getDocumentQCServedForUser.js
+++ b/shared/src/persistence/dynamo/workitems/getDocumentQCServedForUser.js
@@ -1,9 +1,10 @@
-const moment = require('moment');
+const {
+  prepareDateFromString,
+} = require('../../../business/utilities/DateHandler');
 const { query } = require('../../dynamodbClientService');
 
 exports.getDocumentQCServedForUser = async ({ applicationContext, userId }) => {
-  const afterDate = moment
-    .utc(new Date().toISOString())
+  const afterDate = prepareDateFromString()
     .startOf('day')
     .subtract(7, 'd')
     .utc()

--- a/shared/src/persistence/dynamo/workitems/getSentMessagesForSection.js
+++ b/shared/src/persistence/dynamo/workitems/getSentMessagesForSection.js
@@ -1,9 +1,10 @@
-const moment = require('moment');
+const {
+  prepareDateFromString,
+} = require('../../../business/utilities/DateHandler');
 const { query } = require('../../dynamodbClientService');
 
 exports.getSentMessagesForSection = async ({ applicationContext, section }) => {
-  const afterDate = moment
-    .utc(new Date().toISOString())
+  const afterDate = prepareDateFromString()
     .startOf('day')
     .subtract(7, 'd')
     .utc()

--- a/shared/src/persistence/dynamo/workitems/getSentMessagesForUser.js
+++ b/shared/src/persistence/dynamo/workitems/getSentMessagesForUser.js
@@ -1,9 +1,10 @@
-const moment = require('moment');
+const {
+  prepareDateFromString,
+} = require('../../../business/utilities/DateHandler');
 const { query } = require('../../dynamodbClientService');
 
 exports.getSentMessagesForUser = async ({ applicationContext, userId }) => {
-  const afterDate = moment
-    .utc(new Date().toISOString())
+  const afterDate = prepareDateFromString()
     .startOf('day')
     .subtract(7, 'd')
     .utc()

--- a/web-client/src/presenter/actions/DocketEntry/submitDocketEntryAction.js
+++ b/web-client/src/presenter/actions/DocketEntry/submitDocketEntryAction.js
@@ -34,7 +34,7 @@ export const submitDocketEntryAction = async ({
     isPaper: true,
     docketNumber,
     caseId,
-    createdAt: new Date().toISOString(),
+    createdAt: applicationContext.getUtilities().createISODateString(),
     receivedAt: documentMetadata.dateReceived,
   };
 

--- a/web-client/src/presenter/actions/DocketEntry/submitDocketEntryAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/submitDocketEntryAction.test.js
@@ -1,3 +1,4 @@
+import { applicationContext } from '../../../applicationContext';
 import { presenter } from '../../presenter';
 import { runAction } from 'cerebral/test';
 import { submitDocketEntryAction } from './submitDocketEntryAction';
@@ -12,6 +13,7 @@ describe('submitDocketEntryAction', () => {
     fileDocketEntryStub = sinon.stub();
 
     presenter.providers.applicationContext = {
+      ...applicationContext,
       getUniqueId: () => '123',
       getUseCases: () => ({
         createCoverSheet: createCoverSheetStub,

--- a/web-client/src/presenter/computeds/filterWorkItems.test.js
+++ b/web-client/src/presenter/computeds/filterWorkItems.test.js
@@ -1,5 +1,6 @@
 import * as CONSTANTS from '../../../../shared/src/business/entities/WorkQueue';
 import { Case } from '../../../../shared/src/business/entities/cases/Case';
+import { applicationContext } from '../../applicationContext';
 import { filterWorkItems } from './formattedWorkQueue';
 
 const MY_MESSAGES_INBOX = {
@@ -420,7 +421,11 @@ describe('filterWorkItems', () => {
 
   it('Returns internal messages for a Petitions Clerk in My Messages Inbox', () => {
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...MY_MESSAGES_INBOX, user: petitionsClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_MESSAGES_INBOX,
+        user: petitionsClerk1,
+      }),
     );
 
     expect(filtered.length).toEqual(1);
@@ -435,7 +440,11 @@ describe('filterWorkItems', () => {
       completedAt: '2019-07-18T18:05:54.166Z',
     };
     const filtered = [...workQueueOutbox, completedItemDoNotShow].filter(
-      filterWorkItems({ ...MY_MESSAGES_OUTBOX, user: petitionsClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_MESSAGES_OUTBOX,
+        user: petitionsClerk1,
+      }),
     );
     expect(filtered.length).toEqual(1);
     expect(filtered[0].docketNumber).toEqual(
@@ -446,7 +455,7 @@ describe('filterWorkItems', () => {
   it('Returns work items for a Petitions Clerk in Section Messages Inbox', () => {
     const user = petitionsClerk1;
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...SECTION_MESSAGES_INBOX, user }),
+      filterWorkItems({ applicationContext, ...SECTION_MESSAGES_INBOX, user }),
     );
     let assigned = null;
     let unassigned = null;
@@ -475,7 +484,7 @@ describe('filterWorkItems', () => {
       completedAt: '2019-07-18T18:05:54.166Z',
     };
     const filtered = [...workQueueOutbox, completedItemDoNotShow].filter(
-      filterWorkItems({ ...SECTION_MESSAGES_OUTBOX, user }),
+      filterWorkItems({ applicationContext, ...SECTION_MESSAGES_OUTBOX, user }),
     );
 
     let sentByUser = null;
@@ -500,14 +509,22 @@ describe('filterWorkItems', () => {
 
   it('Returns assigned messages for a Petitions Clerk in My Document QC Inbox', () => {
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...MY_DOCUMENT_QC_INBOX, user: petitionsClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_DOCUMENT_QC_INBOX,
+        user: petitionsClerk1,
+      }),
     );
     expect(filtered.length).toEqual(1);
   });
 
   it('Returns batched items for a Petitions Clerk in My Document QC Batched', () => {
     const filtered = workQueueBatched.filter(
-      filterWorkItems({ ...MY_DOCUMENT_QC_BATCHED, user: petitionsClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_DOCUMENT_QC_BATCHED,
+        user: petitionsClerk1,
+      }),
     );
 
     expect(filtered.length).toEqual(1);
@@ -518,7 +535,11 @@ describe('filterWorkItems', () => {
 
   it('Returns sent messages for a Petitions Clerk in My Document QC Outbox', () => {
     const filtered = workQueueOutbox.filter(
-      filterWorkItems({ ...MY_DOCUMENT_QC_OUTBOX, user: petitionsClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_DOCUMENT_QC_OUTBOX,
+        user: petitionsClerk1,
+      }),
     );
 
     expect(filtered.length).toEqual(1);
@@ -530,7 +551,11 @@ describe('filterWorkItems', () => {
   it('Returns section work items for a Petitions Clerk in Section Document QC Inbox', () => {
     const user = petitionsClerk1;
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...SECTION_DOCUMENT_QC_INBOX, user }),
+      filterWorkItems({
+        applicationContext,
+        ...SECTION_DOCUMENT_QC_INBOX,
+        user,
+      }),
     );
     let assigned = null;
     let unassigned = null;
@@ -555,7 +580,11 @@ describe('filterWorkItems', () => {
   it('Returns batched work items for a Petitions Clerk in Section Document QC Batched', () => {
     const user = petitionsClerk1;
     const filtered = workQueueBatched.filter(
-      filterWorkItems({ ...SECTION_DOCUMENT_QC_BATCHED, user }),
+      filterWorkItems({
+        applicationContext,
+        ...SECTION_DOCUMENT_QC_BATCHED,
+        user,
+      }),
     );
     let sentByUser = null;
     let sentByOtherUser = null;
@@ -583,7 +612,11 @@ describe('filterWorkItems', () => {
   it('Returns sent work items for a Petitions Clerk in Section Document QC Outbox', () => {
     const user = petitionsClerk1;
     const filtered = workQueueOutbox.filter(
-      filterWorkItems({ ...SECTION_DOCUMENT_QC_OUTBOX, user }),
+      filterWorkItems({
+        applicationContext,
+        ...SECTION_DOCUMENT_QC_OUTBOX,
+        user,
+      }),
     );
     let sentByUser = null;
     let sentByOtherUser = null;
@@ -612,14 +645,22 @@ describe('filterWorkItems', () => {
 
   it('Returns internal messages for a Docket Clerk in My Messages Inbox', () => {
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...MY_MESSAGES_INBOX, user: docketClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_MESSAGES_INBOX,
+        user: docketClerk1,
+      }),
     );
     expect(filtered.length).toEqual(1);
   });
 
   it('Returns sent messages for a Docket Clerk in My Messages Outbox', () => {
     const filtered = workQueueOutbox.filter(
-      filterWorkItems({ ...MY_MESSAGES_OUTBOX, user: docketClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_MESSAGES_OUTBOX,
+        user: docketClerk1,
+      }),
     );
     expect(filtered.length).toEqual(1);
   });
@@ -627,7 +668,7 @@ describe('filterWorkItems', () => {
   it('Returns work items for a Docket Clerk in Section Messages Inbox', () => {
     const user = docketClerk1;
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...SECTION_MESSAGES_INBOX, user }),
+      filterWorkItems({ applicationContext, ...SECTION_MESSAGES_INBOX, user }),
     );
     let assigned = null;
     let unassigned = null;
@@ -650,7 +691,7 @@ describe('filterWorkItems', () => {
   it('Returns sent work items for a Docket Clerk in Section Messages Outbox', () => {
     const user = docketClerk1;
     const filtered = workQueueOutbox.filter(
-      filterWorkItems({ ...SECTION_MESSAGES_OUTBOX, user }),
+      filterWorkItems({ applicationContext, ...SECTION_MESSAGES_OUTBOX, user }),
     );
     let sentByUser = null;
     let sentByOtherUser = null;
@@ -675,7 +716,11 @@ describe('filterWorkItems', () => {
 
   it('Returns assigned messages for a Docket Clerk in My Document QC Inbox', () => {
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...MY_DOCUMENT_QC_INBOX, user: docketClerk1 }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_DOCUMENT_QC_INBOX,
+        user: docketClerk1,
+      }),
     );
     expect(filtered.length).toEqual(1);
   });
@@ -683,7 +728,11 @@ describe('filterWorkItems', () => {
   it('Returns section work items for a Docket Clerk in Section Document QC Inbox', () => {
     const user = docketClerk1;
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...SECTION_DOCUMENT_QC_INBOX, user }),
+      filterWorkItems({
+        applicationContext,
+        ...SECTION_DOCUMENT_QC_INBOX,
+        user,
+      }),
     );
     let assigned = null;
     let unassigned = null;
@@ -708,7 +757,11 @@ describe('filterWorkItems', () => {
   it('Returns docket section work items for a Senior Attorney in Document QC Inbox', () => {
     const user = seniorAttorney;
     const filtered = workQueueInbox.filter(
-      filterWorkItems({ ...SECTION_DOCUMENT_QC_INBOX, user }),
+      filterWorkItems({
+        applicationContext,
+        ...SECTION_DOCUMENT_QC_INBOX,
+        user,
+      }),
     );
 
     expect(filtered).toMatchObject([
@@ -720,7 +773,11 @@ describe('filterWorkItems', () => {
   it('Returns docket section work items for a Docket Clerk in My Document QC In Progress', () => {
     const user = docketClerk1;
     const filtered = workQueueInProgress.filter(
-      filterWorkItems({ ...MY_DOCUMENT_QC_IN_PROGRESS, user }),
+      filterWorkItems({
+        applicationContext,
+        ...MY_DOCUMENT_QC_IN_PROGRESS,
+        user,
+      }),
     );
 
     expect(filtered).toEqual([workItemDocketMyDocumentQCInProgress]);
@@ -729,7 +786,11 @@ describe('filterWorkItems', () => {
   it('Returns docket section work items for a Docket Clerk in Section Document QC In Progress', () => {
     const user = docketClerk1;
     const filtered = workQueueInProgress.filter(
-      filterWorkItems({ ...SECTION_DOCUMENT_QC_IN_PROGRESS, user }),
+      filterWorkItems({
+        applicationContext,
+        ...SECTION_DOCUMENT_QC_IN_PROGRESS,
+        user,
+      }),
     );
 
     expect(filtered).toEqual([

--- a/web-client/src/presenter/computeds/formattedWorkQueue.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.js
@@ -1,4 +1,3 @@
-import { Case } from '../../../../shared/src/business/entities/cases/Case'; // TODO clean this up
 import {
   DOCKET_SECTION,
   IRS_BATCH_SYSTEM_SECTION,
@@ -144,6 +143,7 @@ export const formatWorkItem = (
 };
 
 export const filterWorkItems = ({
+  applicationContext,
   user,
   workQueueIsInternal,
   workQueueToDisplay,
@@ -151,6 +151,7 @@ export const filterWorkItems = ({
   const { box, queue } = workQueueToDisplay;
   const docQCUserSection =
     user.section === SENIOR_ATTORNEY_SECTION ? DOCKET_SECTION : user.section;
+  const { Case } = applicationContext.getEntityConstructors();
 
   const filters = {
     documentQc: {
@@ -283,6 +284,7 @@ export const formattedWorkQueue = (get, applicationContext) => {
   let workQueue = workItems
     .filter(
       filterWorkItems({
+        applicationContext,
         user,
         workQueueIsInternal: isInternal,
         workQueueToDisplay,

--- a/web-client/src/presenter/computeds/formattedWorkQueue.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.js
@@ -1,4 +1,4 @@
-import { Case } from '../../../../shared/src/business/entities/cases/Case';
+import { Case } from '../../../../shared/src/business/entities/cases/Case'; // TODO clean this up
 import {
   DOCKET_SECTION,
   IRS_BATCH_SYSTEM_SECTION,
@@ -6,7 +6,6 @@ import {
 } from '../../../../shared/src/business/entities/WorkQueue';
 import { state } from 'cerebral';
 import _ from 'lodash';
-import moment from 'moment';
 
 const isDateToday = (date, applicationContext) => {
   const now = applicationContext
@@ -26,7 +25,9 @@ const formatDateIfToday = (date, applicationContext) => {
     .getUtilities()
     .formatDateString(date, 'MMDDYY');
   const yesterday = applicationContext.getUtilities().formatDateString(
-    moment(new Date())
+    applicationContext
+      .getUtilities()
+      .prepareDateFromString()
       .add(-1, 'days')
       .toDate(),
     'MMDDYY',

--- a/web-client/src/presenter/computeds/formattedWorkQueueComputed.test.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueueComputed.test.js
@@ -1,3 +1,4 @@
+import { applicationContext } from '../../applicationContext';
 import { formattedWorkQueue as formattedWorkQueueComputed } from './formattedWorkQueue';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../withAppContext';
@@ -9,6 +10,7 @@ import {
 } from '../../../../shared/src/business/utilities/DateHandler';
 
 const formattedWorkQueue = withAppContextDecorator(formattedWorkQueueComputed, {
+  ...applicationContext,
   getCurrentUser: () => ({
     role: 'petitionsclerk',
     section: 'petitions',


### PR DESCRIPTION
Whenever possible, our codebase should be using the `shared/src/business/utilities/DateHandler` and the functions provided within.  Some exceptions are when using `moment` to validate inputs (as is done in one file) or when construction test inputs.

This effort tries to use all the DateHandler functions everywhere to become as consistent as possible.