### PR TITLE
Validate input when generating an IAM policy

### DIFF
--- a/generate-policy.sh
+++ b/generate-policy.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 ACCOUNT_ID=$1
+if [ -z "$ACCOUNT_ID" ]; then
+    echo "Please specify the AWS account ID"
+    exit 1
+elif [[ ! "$ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+    echo "Please specify a valid AWS account ID"
+    exit 1
+fi
+
 sed "s/ACCOUNT_ID/$ACCOUNT_ID/g" policy.json.tpl > policy.json


### PR DESCRIPTION
This makes sure that an AWS account IDs has been provided. AW account IDs are always 12-digit numbers (https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html), so they're simple to validate.