### PR TITLE
omit password from being stored on dynamo when creating the user

### DIFF
--- a/shared/src/persistence/dynamo/users/createUser.js
+++ b/shared/src/persistence/dynamo/users/createUser.js
@@ -5,6 +5,8 @@ const {
 } = require('../../dynamo/helpers/createMappingRecord');
 
 exports.createUserRecords = async ({ applicationContext, user, userId }) => {
+  delete user.password;
+
   if (user.barNumber === '') {
     delete user.barNumber;
   }

--- a/web-api/setup-cognito-users.sh
+++ b/web-api/setup-cognito-users.sh
@@ -20,6 +20,7 @@ generate_post_data() {
   cat <<EOF
 {
   "email": "$email",
+  "password": "Testing1234$",
   "role": "$role",
   "section": "$section",
   "name": "$name",

--- a/web-api/setup-cognito-users.sh
+++ b/web-api/setup-cognito-users.sh
@@ -20,7 +20,6 @@ generate_post_data() {
   cat <<EOF
 {
   "email": "$email",
-  "password": "Testing1234$",
   "role": "$role",
   "section": "$section",
   "name": "$name",


### PR DESCRIPTION
- there isn't a reason to have passwords stored on dynamo; they only belong in cognito