### PR TITLE
439: case deadline table header fix

### DIFF
--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.js
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.js
@@ -25,7 +25,7 @@ export const caseDeadlineReportHelper = (get, applicationContext) => {
     .getUtilities()
     .formatDateString(filterStartDate, 'MMMM D, YYYY');
 
-  if (filterEndDate && filterStartDate !== filterEndDate) {
+  if (filterEndDate && !filterStartDate.isSame(filterEndDate, 'day')) {
     filterEndDate = applicationContext
       .getUtilities()
       .prepareDateFromString(filterEndDate);

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.js
@@ -38,6 +38,17 @@ describe('caseDeadlineReportHelper', () => {
     expect(result.formattedFilterDateHeader).toBeTruthy();
   });
 
+  it('should only use formatted startDate in header if start and end date are on the same day', () => {
+    let result = runCompute(caseDeadlineReportHelper, {
+      state: {
+        allCaseDeadlines: caseDeadlines,
+        filterEndDate: '2019-08-21T12:59:59.000Z',
+        filterStartDate: '2019-08-21T04:00:00.000Z',
+      },
+    });
+    expect(result.formattedFilterDateHeader).toEqual('August 21, 2019');
+  });
+
   it('should filter deadlines by filterStartDate without a filterEndDate and sort by docket number', () => {
     let result = runCompute(caseDeadlineReportHelper, {
       state: {


### PR DESCRIPTION
When you click the same date twice on the calendar component, it's storing them with different times, so they do not exactly match for setting the formatted header to a single date instead of a range. Switched to use `isSame 'day'` instead.