### PR TITLE
1402 - cloning the input file to fix mac ios mobile bug

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -40,7 +40,7 @@ Cypress.Commands.add('upload_file', (fileName, selector, contentType) => {
         dataTransfer.items.add(testFile);
         el.files = dataTransfer.files;
         if (subject.is(':visible')) {
-          return cy.wrap(subject).trigger('change');
+          return cy.wrap(subject).trigger('change', { force: true });
         } else {
           return cy.wrap(subject);
         }

--- a/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
+++ b/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
@@ -1,3 +1,4 @@
+import { cloneFile } from '../cloneFile';
 import { connect } from '@cerebral/react';
 import { limitFileSize } from '../limitFileSize';
 import { props, sequences, state } from 'cerebral';
@@ -38,16 +39,20 @@ export const StateDrivenFileInput = connect(
           }}
           type="file"
           onChange={e => {
+            const { name } = e.target;
             limitFileSize(e, constants.MAX_FILE_SIZE_MB, () => {
-              updateFormValueSequence({
-                key: e.target.name,
-                value: e.target.files[0],
+              const file = e.target.files[0];
+              cloneFile(file).then(clonedFile => {
+                updateFormValueSequence({
+                  key: name,
+                  value: clonedFile,
+                });
+                updateFormValueSequence({
+                  key: `${name}Size`,
+                  value: clonedFile.size,
+                });
+                validationSequence();
               });
-              updateFormValueSequence({
-                key: `${e.target.name}Size`,
-                value: e.target.files[0].size,
-              });
-              validationSequence();
             });
           }}
           onClick={e => {

--- a/web-client/src/views/cloneFile.js
+++ b/web-client/src/views/cloneFile.js
@@ -1,0 +1,21 @@
+/**
+ * clones a file
+ *
+ * @param {file} file the file to clone
+ * @returns {file} the cloned file
+ */
+export const cloneFile = file =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsArrayBuffer(file);
+    reader.addEventListener('load', () => {
+      resolve(
+        new File([reader.result], file.name, {
+          type: file.type,
+        }),
+      );
+    });
+    reader.addEventListener('error', () => {
+      reject();
+    });
+  });


### PR DESCRIPTION
- there is a mac ios bug where the browser clears the file byte array if too much time has passed which results in a blank pdf (0 bytes) being uploaded to the backend causing it to fail validation; this takes the file and clones the byte array so that ios doesn't clear it out.