### PR TITLE
1171: #6 navigate back to document detail upon recall of petition

### DIFF
--- a/web-client/integration-tests/journey/petitionsClerkIrsHoldingQueue.js
+++ b/web-client/integration-tests/journey/petitionsClerkIrsHoldingQueue.js
@@ -73,6 +73,7 @@ export default test => {
     expect(caseDetailHelperBatched.showRecallButton).toEqual(true);
 
     await test.runSequence('submitRecallPetitionFromIRSHoldingQueueSequence');
+    await test.runSequence('gotoDashboardSequence');
     await waitForRouter();
 
     expect(test.getState('currentPage')).toEqual('DashboardPetitionsClerk');

--- a/web-client/src/presenter/sequences/submitRecallPetitionFromIRSHoldingQueueSequence.js
+++ b/web-client/src/presenter/sequences/submitRecallPetitionFromIRSHoldingQueueSequence.js
@@ -1,8 +1,9 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearModalAction } from '../actions/clearModalAction';
-import { navigateToDashboardAction } from '../actions/navigateToDashboardAction';
+import { getCaseAction } from '../actions/getCaseAction';
 import { recallPetitionFromIRSHoldingQueueAction } from '../actions/recallPetitionFromIRSHoldingQueueAction';
 import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
+import { setCaseAction } from '../actions/setCaseAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 
 export const submitRecallPetitionFromIRSHoldingQueueSequence = [
@@ -11,5 +12,7 @@ export const submitRecallPetitionFromIRSHoldingQueueSequence = [
   recallPetitionFromIRSHoldingQueueAction,
   setCurrentPageAction('Interstitial'),
   setAlertSuccessAction,
-  navigateToDashboardAction,
+  getCaseAction,
+  setCaseAction,
+  setCurrentPageAction('DocumentDetail'),
 ];


### PR DESCRIPTION
On viewing doc detail of petition already submitted:
<img width="945" alt="Screen Shot 2019-08-27 at 2 22 00 PM" src="https://user-images.githubusercontent.com/2445917/63801664-6dab2500-c8d6-11e9-88fe-785da3d4aaaa.png">
After clicking "Recall":
<img width="957" alt="Screen Shot 2019-08-27 at 2 21 40 PM" src="https://user-images.githubusercontent.com/2445917/63801669-6f74e880-c8d6-11e9-9cb8-d24e3af54e51.png">
