### PR TITLE
Clear calendar filter date when navigating to case deadlines report

### DIFF
--- a/web-client/src/presenter/actions/CaseDeadline/updateDateFromCalendarAction.js
+++ b/web-client/src/presenter/actions/CaseDeadline/updateDateFromCalendarAction.js
@@ -13,11 +13,11 @@ const formatDateFromCalendar = ({ applicationContext, date }) => {
 };
 
 /**
- * sets the state.filterStartDate and state.filterEndDate
+ * sets the state.screenMetadata.filterStartDate and state.screenMetadata.filterEndDate
  * based on the props.startDate and props.endDate passed in.
  *
  * @param {object} providers the providers object
- * @param {object} providers.store the cerebral store used for setting the state.filterStartDate and state.filterEndDate
+ * @param {object} providers.store the cerebral store used for setting the state.screenMetadata.filterStartDate and state.screenMetadata.filterEndDate
  * @param {object} providers.props the cerebral props object used for passing the props.startDate and props.endDate
  */
 export const updateDateFromCalendarAction = ({
@@ -32,15 +32,15 @@ export const updateDateFromCalendarAction = ({
     applicationContext,
     date: filterStartDate,
   });
-  store.set(state.filterStartDate, formattedFilterStartDate);
+  store.set(state.screenMetadata.filterStartDate, formattedFilterStartDate);
 
   if (filterEndDate) {
     const formattedFilterEndDate = formatDateFromCalendar({
       applicationContext,
       date: filterEndDate,
     });
-    store.set(state.filterEndDate, formattedFilterEndDate);
+    store.set(state.screenMetadata.filterEndDate, formattedFilterEndDate);
   } else {
-    store.unset(state.filterEndDate);
+    store.unset(state.screenMetadata.filterEndDate);
   }
 };

--- a/web-client/src/presenter/actions/CaseDeadline/updateDateFromCalendarAction.test.js
+++ b/web-client/src/presenter/actions/CaseDeadline/updateDateFromCalendarAction.test.js
@@ -14,7 +14,7 @@ describe('updateDateFromCalendarAction', () => {
     };
   });
 
-  it('sets only state.filterStartDate to the formatted props.startDate if props.endDate is not passed in', async () => {
+  it('sets only state.screenMetadata.filterStartDate to the formatted props.startDate if props.endDate is not passed in', async () => {
     const testDate = new Date('2019-05-14T07:12:12.457Z');
 
     const result = await runAction(updateDateFromCalendarAction, {
@@ -22,13 +22,17 @@ describe('updateDateFromCalendarAction', () => {
       props: {
         startDate: testDate,
       },
-      state: {},
+      state: {
+        screenMetadata: {},
+      },
     });
 
-    expect(result.state.filterStartDate).toEqual('2019-05-14T04:00:00.000Z');
+    expect(result.state.screenMetadata.filterStartDate).toEqual(
+      '2019-05-14T04:00:00.000Z',
+    );
   });
 
-  it('sets state.filterStartDate and state.filterEndDate to the formatted props.startDate and props.endDate if both are passed in', async () => {
+  it('sets state.screenMetadata.filterStartDate and state.screenMetadata.filterEndDate to the formatted props.startDate and props.endDate if both are passed in', async () => {
     const testStartDate = new Date('2019-05-14T07:12:12.457Z');
     const testEndDate = new Date('2019-05-17T07:12:12.457Z');
 
@@ -38,10 +42,14 @@ describe('updateDateFromCalendarAction', () => {
         endDate: testEndDate,
         startDate: testStartDate,
       },
-      state: {},
+      state: { screenMetadata: {} },
     });
 
-    expect(result.state.filterStartDate).toEqual('2019-05-14T04:00:00.000Z');
-    expect(result.state.filterEndDate).toEqual('2019-05-17T04:00:00.000Z');
+    expect(result.state.screenMetadata.filterStartDate).toEqual(
+      '2019-05-14T04:00:00.000Z',
+    );
+    expect(result.state.screenMetadata.filterEndDate).toEqual(
+      '2019-05-17T04:00:00.000Z',
+    );
   });
 });

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.js
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.js
@@ -14,8 +14,8 @@ export const sortByDateAndDocketNumber = (a, b) => {
 
 export const caseDeadlineReportHelper = (get, applicationContext) => {
   let caseDeadlines = get(state.allCaseDeadlines) || [];
-  let filterStartDate = get(state.filterStartDate);
-  let filterEndDate = get(state.filterEndDate);
+  let filterStartDate = get(state.screenMetadata.filterStartDate);
+  let filterEndDate = get(state.screenMetadata.filterEndDate);
 
   filterStartDate = applicationContext
     .getUtilities()

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.js
@@ -42,8 +42,10 @@ describe('caseDeadlineReportHelper', () => {
     let result = runCompute(caseDeadlineReportHelper, {
       state: {
         allCaseDeadlines: caseDeadlines,
-        filterEndDate: '2019-08-21T12:59:59.000Z',
-        filterStartDate: '2019-08-21T04:00:00.000Z',
+        screenMetadata: {
+          filterEndDate: '2019-08-21T12:59:59.000Z',
+          filterStartDate: '2019-08-21T04:00:00.000Z',
+        },
       },
     });
     expect(result.formattedFilterDateHeader).toEqual('August 21, 2019');
@@ -53,7 +55,9 @@ describe('caseDeadlineReportHelper', () => {
     let result = runCompute(caseDeadlineReportHelper, {
       state: {
         allCaseDeadlines: caseDeadlines,
-        filterStartDate: '2019-08-21T04:00:00.000Z',
+        screenMetadata: {
+          filterStartDate: '2019-08-21T04:00:00.000Z',
+        },
       },
     });
     expect(result.caseDeadlineCount).toEqual(2);
@@ -74,8 +78,10 @@ describe('caseDeadlineReportHelper', () => {
     let result = runCompute(caseDeadlineReportHelper, {
       state: {
         allCaseDeadlines: caseDeadlines,
-        filterEndDate: '2019-08-23T04:00:00.000Z',
-        filterStartDate: '2019-08-21T04:00:00.000Z',
+        screenMetadata: {
+          filterEndDate: '2019-08-23T04:00:00.000Z',
+          filterStartDate: '2019-08-21T04:00:00.000Z',
+        },
       },
     });
     expect(result.caseDeadlineCount).toEqual(3);


### PR DESCRIPTION
Moved the filter dates into screenMetadata so they will be cleared when navigating.