### PR TITLE
making sure web-client/.cache is deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "build:api": "parcel build --no-source-maps --bundle-node-modules --target node web-api/src/apiHandlers.js",
     "build:client": "USTC_ENV=prod GIT_COMMIT=$(git log --pretty=format:'%h' -n 1 2>/dev/null) parcel build --no-source-maps web-client/src/index.pug; npm run build:jsdoc",
     "build:jsdoc": "jsdoc -c web-client/jsdoc.conf.json",
-    "clean": "rm -rf dist/ .cache/",
+    "clean": "rm -rf dist/ web-client/.cache/",
     "cypress:open": "cypress open --config watchForFileChanges=true",
     "cypress": "cypress run",
     "dynamo:admin": "DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin",


### PR DESCRIPTION
As it turns out, parcel's `.cache` folder resides within `web-client`, not at the root of the project.