### PR TITLE
DevEx - clear alert refactoring

### DIFF
--- a/web-api/run-serverless.sh
+++ b/web-api/run-serverless.sh
@@ -19,6 +19,7 @@ export NODE_PRESERVE_SYMLINKS=1
 find ./web-api/src -type f -exec chmod -R ugo+r {} ";"
 
 npm run "${build}"
+
 cp "./web-api/src/${handler}" /tmp
 cp "./dist/${handler}" web-api/src
 

--- a/web-client/src/presenter/sequences/gotoAddDocketEntrySequence.js
+++ b/web-client/src/presenter/sequences/gotoAddDocketEntrySequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScansAction } from '../actions/clearScansAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
@@ -14,7 +13,6 @@ export const gotoAddDocketEntry = [
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
   clearScansAction,
-  clearAlertsAction,
   clearFormAction,
   unset(state.documentId),
   clearScreenMetadataAction,

--- a/web-client/src/presenter/sequences/gotoAddTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/gotoAddTrialSessionSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
@@ -14,7 +13,6 @@ import { state } from 'cerebral';
 const gotoAddTrialSession = [
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
-  clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,
   getTrialSessionsAction,

--- a/web-client/src/presenter/sequences/gotoAdvancedSearchSequence.js
+++ b/web-client/src/presenter/sequences/gotoAdvancedSearchSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { set } from 'cerebral/factories';
@@ -8,7 +7,6 @@ import { setDefaultCountryTypeOnAdvancedSearchFormAction } from '../actions/Adva
 import { state } from 'cerebral';
 
 export const gotoAdvancedSearchSequence = [
-  clearAlertsAction,
   clearScreenMetadataAction,
   clearFormAction,
   set(state.form.currentPage, 1),

--- a/web-client/src/presenter/sequences/gotoAllCaseDeadlinesSequence.js
+++ b/web-client/src/presenter/sequences/gotoAllCaseDeadlinesSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getAllCaseDeadlinesAction } from '../actions/CaseDeadline/getAllCaseDeadlinesAction';
@@ -10,7 +9,6 @@ import { setDefaultDateOnCalendarAction } from '../actions/CaseDeadline/setDefau
 
 const gotoAllCaseDeadlines = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearScreenMetadataAction,
   clearErrorAlertsAction,
   getAllCaseDeadlinesAction,

--- a/web-client/src/presenter/sequences/gotoBeforeYouFileDocumentSequence.js
+++ b/web-client/src/presenter/sequences/gotoBeforeYouFileDocumentSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { redirectToCognitoAction } from '../actions/redirectToCognitoAction';
@@ -10,7 +9,6 @@ import { state } from 'cerebral';
 const gotoBeforeYouFileDocument = [
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
-  clearAlertsAction,
   getCaseAction,
   setCaseAction,
   setCurrentPageAction('BeforeYouFileADocument'),

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getCaseAssociationAction } from '../actions/getCaseAssociationAction';
@@ -17,7 +16,6 @@ import { state } from 'cerebral';
 
 export const gotoCaseDetailSequence = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearScreenMetadataAction,
   setDefaultCaseDetailTabAction,
   getCaseAction,

--- a/web-client/src/presenter/sequences/gotoCreateOrderSequence.js
+++ b/web-client/src/presenter/sequences/gotoCreateOrderSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearModalAction } from '../actions/clearModalAction';
 import { convertHtml2PdfSequence } from './convertHtml2PdfSequence';
@@ -18,7 +17,6 @@ const gotoCreateOrder = [
   clearModalAction,
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
-  clearAlertsAction,
   clearFormAction,
   setCasePropFromStateAction,
   unstashCreateOrderModalDataAction,

--- a/web-client/src/presenter/sequences/gotoDashboardSequence.js
+++ b/web-client/src/presenter/sequences/gotoDashboardSequence.js
@@ -1,5 +1,4 @@
 import { chooseWorkQueueSequence } from './chooseWorkQueueSequence';
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { getBaseRouteAction } from '../actions/getBaseRouteAction';
 import { getCasesByUserAction } from '../actions/getCasesByUserAction';
@@ -54,13 +53,11 @@ const goToDashboard = [
       },
     ],
     petitioner: [
-      clearAlertsAction,
       getCasesByUserAction,
       setCasesAction,
       setCurrentPageAction('DashboardPetitioner'),
     ],
     petitionsclerk: [
-      clearAlertsAction,
       parallel([
         [getUsersInSectionAction({ section: 'petitions' }), setUsersAction],
         [
@@ -80,7 +77,6 @@ const goToDashboard = [
       setCurrentPageAction('DashboardRespondent'),
     ],
     seniorattorney: [
-      clearAlertsAction,
       setCurrentPageAction('DashboardSeniorAttorney'),
       ...chooseWorkQueueSequence,
     ],

--- a/web-client/src/presenter/sequences/gotoDocumentDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoDocumentDetailSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormsAction } from '../actions/clearFormsAction';
 import { clearWorkItemActionMapAction } from '../actions/clearWorkItemActionMapAction';
 import { getCaseAction } from '../actions/getCaseAction';
@@ -26,7 +25,6 @@ import { state } from 'cerebral';
 
 export const gotoDocumentDetailSequence = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearWorkItemActionMapAction,
   clearFormsAction,
   set(state.documentDetail.tab, 'partyInfo'),

--- a/web-client/src/presenter/sequences/gotoEditDocketEntrySequence.js
+++ b/web-client/src/presenter/sequences/gotoEditDocketEntrySequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScansAction } from '../actions/clearScansAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
@@ -16,7 +15,6 @@ export const gotoEditDocketEntry = [
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
   clearScansAction,
-  clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,
   getCaseAction,

--- a/web-client/src/presenter/sequences/gotoEditOrderSequence.js
+++ b/web-client/src/presenter/sequences/gotoEditOrderSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearModalAction } from '../actions/clearModalAction';
 import { convertHtml2PdfSequence } from './convertHtml2PdfSequence';
@@ -16,7 +15,6 @@ const gotoEditOrder = [
   clearModalAction,
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
-  clearAlertsAction,
   clearFormAction,
   getCaseAction,
   setCaseAction,

--- a/web-client/src/presenter/sequences/gotoFileDocumentSequence.js
+++ b/web-client/src/presenter/sequences/gotoFileDocumentSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCaseAction } from '../actions/getCaseAction';
@@ -12,7 +11,6 @@ import { state } from 'cerebral';
 const gotoFileDocument = [
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
-  clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,
   getCaseAction,

--- a/web-client/src/presenter/sequences/gotoIdleLogoutSequence.js
+++ b/web-client/src/presenter/sequences/gotoIdleLogoutSequence.js
@@ -1,11 +1,9 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearModalAction } from '../actions/clearModalAction';
 import { clearUserAction } from '../actions/clearUserAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 
 export const gotoIdleLogoutSequence = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearModalAction,
   clearUserAction,
   setCurrentPageAction('IdleLogout'),

--- a/web-client/src/presenter/sequences/gotoLoginSequence.js
+++ b/web-client/src/presenter/sequences/gotoLoginSequence.js
@@ -1,10 +1,8 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearLoginFormAction } from '../actions/clearLoginFormAction';
 import { clearSessionMetadataAction } from '../actions/clearSessionMetadataAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 
 export const gotoLoginSequence = [
-  clearAlertsAction,
   clearLoginFormAction,
   clearSessionMetadataAction,
   setCurrentPageAction('LogIn'),

--- a/web-client/src/presenter/sequences/gotoPrimaryContactEditSequence.js
+++ b/web-client/src/presenter/sequences/gotoPrimaryContactEditSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCaseAction } from '../actions/getCaseAction';
@@ -11,7 +10,6 @@ import { startShowValidationAction } from '../actions/startShowValidationAction'
 const gotoPrimaryContactEdit = [
   setCurrentPageAction('Interstitial'),
   startShowValidationAction,
-  clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,
   getCaseAction,

--- a/web-client/src/presenter/sequences/gotoRequestAccessSequence.js
+++ b/web-client/src/presenter/sequences/gotoRequestAccessSequence.js
@@ -1,5 +1,4 @@
 import { canRequestAccessAction } from '../actions/CaseAssociationRequest/canRequestAccessAction';
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCaseAction } from '../actions/getCaseAction';
@@ -17,7 +16,6 @@ import { state } from 'cerebral';
 const gotoRequestAccess = [
   setCurrentPageAction('Interstitial'),
   set(state.showValidation, false),
-  clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,
   getCaseAction,

--- a/web-client/src/presenter/sequences/gotoSelectDocumentTypeSequence.js
+++ b/web-client/src/presenter/sequences/gotoSelectDocumentTypeSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { redirectToCognitoAction } from '../actions/redirectToCognitoAction';
@@ -7,7 +6,6 @@ import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 
 const gotoSelectDocumentType = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   getCaseAction,
   setCaseAction,
   setCurrentPageAction('SelectDocumentType'),

--- a/web-client/src/presenter/sequences/gotoStartCaseWizardSequence.js
+++ b/web-client/src/presenter/sequences/gotoStartCaseWizardSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCaseTypesAction } from '../actions/getCaseTypesAction';
@@ -14,7 +13,6 @@ import { setFilingTypesAction } from '../actions/setFilingTypesAction';
 import { setProcedureTypesAction } from '../actions/setProcedureTypesAction';
 
 export const gotoStartCaseWizardSequence = [
-  clearAlertsAction,
   clearFormAction,
   clearScreenMetadataAction,
   prepareFormAction,

--- a/web-client/src/presenter/sequences/gotoTrialSessionDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoTrialSessionDetailSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { getCalendaredCasesForTrialSessionAction } from '../actions/TrialSession/getCalendaredCasesForTrialSessionAction';
 import { getEligibleCasesForTrialSessionAction } from '../actions/TrialSession/getEligibleCasesForTrialSessionAction';
@@ -14,7 +13,6 @@ import { setTrialSessionIdAction } from '../actions/TrialSession/setTrialSession
 
 const gotoTrialSessionDetails = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearErrorAlertsAction,
   setTrialSessionIdAction,
   getTrialSessionDetailsAction,

--- a/web-client/src/presenter/sequences/gotoTrialSessionWorkingCopySequence.js
+++ b/web-client/src/presenter/sequences/gotoTrialSessionWorkingCopySequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { getCalendaredCasesForTrialSessionAction } from '../actions/TrialSession/getCalendaredCasesForTrialSessionAction';
 import { getTrialSessionDetailsAction } from '../actions/TrialSession/getTrialSessionDetailsAction';
@@ -18,7 +17,6 @@ import { setTrialSessionWorkingCopyAction } from '../actions/TrialSession/setTri
 
 const gotoTrialSessionDetails = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearErrorAlertsAction,
   setBaseUrlAction,
   setTrialSessionIdAction,

--- a/web-client/src/presenter/sequences/gotoTrialSessionsSequence.js
+++ b/web-client/src/presenter/sequences/gotoTrialSessionsSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
@@ -12,7 +11,6 @@ import { setUsersAction } from '../actions/setUsersAction';
 
 const gotoTrialSessions = [
   setCurrentPageAction('Interstitial'),
-  clearAlertsAction,
   clearScreenMetadataAction,
   clearErrorAlertsAction,
   getTrialSessionsAction,

--- a/web-client/src/presenter/sequences/gotoUserContactEditSequence.js
+++ b/web-client/src/presenter/sequences/gotoUserContactEditSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { getUserAction } from '../actions/getUserAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setUserAction } from '../actions/setUserAction';
@@ -7,6 +6,5 @@ export const gotoUserContactEditSequence = [
   setCurrentPageAction('Interstitial'),
   getUserAction,
   setUserAction,
-  clearAlertsAction,
   setCurrentPageAction('UserContactEdit'),
 ];

--- a/web-client/src/presenter/sequences/gotoViewAllDocumentsSequence.js
+++ b/web-client/src/presenter/sequences/gotoViewAllDocumentsSequence.js
@@ -1,4 +1,3 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearModalAction } from '../actions/clearModalAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
@@ -8,7 +7,6 @@ import { set } from 'cerebral/factories';
 import { state } from 'cerebral';
 
 export const gotoViewAllDocumentsSequence = [
-  clearAlertsAction,
   clearFormAction,
   clearModalAction,
   clearModalStateAction,

--- a/web-client/src/presenter/sequences/navigateToPathSequence.js
+++ b/web-client/src/presenter/sequences/navigateToPathSequence.js
@@ -1,9 +1,7 @@
-import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { navigateToPathAction } from '../actions/navigateToPathAction';
 
 export const navigateToPathSequence = [
-  clearAlertsAction,
   clearErrorAlertsAction,
   navigateToPathAction,
 ];

--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -35,6 +35,7 @@ const router = {
           const path = app.getState('cognitoLoginUrl');
           window.location.replace(path);
         } else {
+          app.getSequence('clearAlertSequence')();
           cb.apply(null, arguments);
         }
       };


### PR DESCRIPTION
@matthopson I'd like your feedback on this

we have encountered a lot of issues with certain alerts not clearing after redirecting to a new page which has caused us to put "clearAlertsAction" on some goto sequences, and not on others.

I'm thinking if we just always call `clearAlertsSequence` when the router changes routes these issues will go away and keep out sequences a bit cleaner.