### PR TITLE
Fix focus state outline on advanced search link

### DIFF
--- a/web-client/src/styles/nav.scss
+++ b/web-client/src/styles/nav.scss
@@ -42,7 +42,7 @@
             display: none;
           }
         }
-        .advanced {
+        .usa-link.advanced {
           margin-top: 0.25rem;
         }
       }
@@ -155,8 +155,6 @@
     }
 
     .usa-search.ustc-search {
-      margin-right: 0.5em;
-
       [role='search'] {
         max-width: unset;
       }
@@ -176,7 +174,7 @@
       }
       .usa-link.advanced {
         display: inline-block;
-        margin-top: 0.5em;
+        padding: 0.5em;
         color: color($theme-color-primary);
         font-size: 15px;
       }

--- a/web-client/src/views/SearchBox.jsx
+++ b/web-client/src/views/SearchBox.jsx
@@ -42,7 +42,7 @@ export const SearchBox = connect(
           </button>
           <a
             aria-label="advanced search"
-            className="usa-link advanced margin-left-2"
+            className="usa-link advanced margin-left-105"
             href="/search"
           >
             Advanced


### PR DESCRIPTION
<img width="435" alt="Screen Shot 2019-09-17 at 2 22 13 PM" src="https://user-images.githubusercontent.com/43251054/65068464-b8104680-d956-11e9-96c4-3a8cdaf940b6.png">
