### PR TITLE
2470 validation order

### DIFF
--- a/web-client/src/presenter/actions/clearFormAction.js
+++ b/web-client/src/presenter/actions/clearFormAction.js
@@ -9,4 +9,5 @@ import { state } from 'cerebral';
  */
 export const clearFormAction = ({ store }) => {
   store.set(state.form, {});
+  store.set(state.fieldOrder, []);
 };

--- a/web-client/src/presenter/actions/setFieldOrderAction.js
+++ b/web-client/src/presenter/actions/setFieldOrderAction.js
@@ -1,0 +1,15 @@
+import { state } from 'cerebral';
+
+/**
+ * appends props.field to state.fieldOrder
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.get the cerebral get function
+ * @param {object} providers.props the cerebral props object
+ * @param {object} providers.store the cerebral store
+ */
+export const setFieldOrderAction = ({ get, props, store }) => {
+  const currentFieldOrder = get(state.fieldOrder) || [];
+  currentFieldOrder.push(props.field);
+  store.set(state.fieldOrder, currentFieldOrder);
+};

--- a/web-client/src/presenter/actions/setFieldOrderAction.test.js
+++ b/web-client/src/presenter/actions/setFieldOrderAction.test.js
@@ -1,0 +1,16 @@
+import { runAction } from 'cerebral/test';
+import { setFieldOrderAction } from './setFieldOrderAction';
+
+describe('setFieldOrderAction', () => {
+  it('adds the props.field key to state.fieldOrder', async () => {
+    const result = await runAction(setFieldOrderAction, {
+      props: {
+        field: 'name',
+      },
+      state: {
+        fieldOrder: [],
+      },
+    });
+    expect(result.state.fieldOrder).toEqual(['name']);
+  });
+});

--- a/web-client/src/presenter/actions/setValidationAlertErrorsAction.js
+++ b/web-client/src/presenter/actions/setValidationAlertErrorsAction.js
@@ -15,8 +15,19 @@ export const setValidationAlertErrorsAction = ({ get, props, store }) => {
   let errorKeys = Object.keys(props.errors);
   const fieldOrder = get(state.fieldOrder);
 
-  const getErrorKeys = keys =>
-    keys.filter(key => props.errors[key] !== undefined);
+  const getErrorKeys = keys => {
+    const filteredErrorKeys = [];
+    keys.forEach(key => {
+      let topLevelKey = key;
+      if (key.indexOf('.')) {
+        topLevelKey = key.split('.')[0];
+      }
+      if (props.errors[topLevelKey] !== undefined) {
+        filteredErrorKeys.push(topLevelKey);
+      }
+    });
+    return filteredErrorKeys;
+  };
 
   if (props.errorDisplayOrder) {
     errorKeys = getErrorKeys(props.errorDisplayOrder);

--- a/web-client/src/presenter/actions/setValidationAlertErrorsAction.js
+++ b/web-client/src/presenter/actions/setValidationAlertErrorsAction.js
@@ -6,17 +6,24 @@ import { state } from 'cerebral';
  * displaying a list of bullet point alerts in a red error alert at the top of the page.
  *
  * @param {object} providers the providers object
+ * @param {object} providers.get the cerebral get function
  * @param {object} providers.props the cerebral props object used for getting the props.errors
  * @param {object} providers.store the cerebral store used for setting state.alertError
  * @returns {undefined} doesn't return anything
  */
-export const setValidationAlertErrorsAction = ({ props, store }) => {
+export const setValidationAlertErrorsAction = ({ get, props, store }) => {
   let errorKeys = Object.keys(props.errors);
+  const fieldOrder = get(state.fieldOrder);
+
+  const getErrorKeys = keys =>
+    keys.filter(key => props.errors[key] !== undefined);
+
   if (props.errorDisplayOrder) {
-    errorKeys = props.errorDisplayOrder.filter(
-      key => props.errors[key] !== undefined,
-    );
+    errorKeys = getErrorKeys(props.errorDisplayOrder);
+  } else if (Array.isArray(fieldOrder) && fieldOrder.length) {
+    errorKeys = getErrorKeys(fieldOrder);
   }
+
   const alertError = {
     messages: flattenDeep(
       errorKeys.map(key => {

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -148,6 +148,7 @@ import { setCurrentPageIndexSequence } from './sequences/setCurrentPageIndexSequ
 import { setDocumentDetailTabSequence } from './sequences/setDocumentDetailTabSequence';
 import { setDocumentForUploadSequence } from './sequences/setDocumentForUploadSequence';
 import { setDocumentUploadModeSequence } from './sequences/setDocumentUploadModeSequence';
+import { setFieldOrderSequence } from './sequences/setFieldOrderSequence';
 import { setFocusedWorkItemSequence } from './sequences/setFocusedWorkItemSequence';
 import { setFormSubmittingSequence } from './sequences/setFormSubmittingSequence';
 import { setIdleStatusIdleSequence } from './sequences/setIdleStatusIdleSequence';
@@ -407,6 +408,7 @@ export const presenter = {
     setDocumentDetailTabSequence,
     setDocumentForUploadSequence,
     setDocumentUploadModeSequence,
+    setFieldOrderSequence,
     setFocusedWorkItemSequence,
     setFormSubmittingSequence,
     setIdleStatusIdleSequence,

--- a/web-client/src/presenter/sequences/setFieldOrderSequence.js
+++ b/web-client/src/presenter/sequences/setFieldOrderSequence.js
@@ -1,0 +1,3 @@
+import { setFieldOrderAction } from '../actions/setFieldOrderAction';
+
+export const setFieldOrderSequence = [setFieldOrderAction];

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -98,6 +98,7 @@ export const state = {
   documentUploadMode: 'scan',
   extractedDocument,
   extractedPendingMessagesFromCaseDetail,
+  fieldOrder: [],
   fileDocumentHelper,
   fileUploadStatusHelper,
   filingTypes: [],

--- a/web-client/src/ustc-ui/Text/ValidationText.jsx
+++ b/web-client/src/ustc-ui/Text/ValidationText.jsx
@@ -1,0 +1,32 @@
+import { Text } from './Text';
+import { connect } from '@cerebral/react';
+import { sequences } from 'cerebral';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class ValidationTextComponent extends React.Component {
+  componentDidMount() {
+    this.props.setFieldOrderSequence({ field: this.props.field });
+  }
+
+  render() {
+    return (
+      <Text
+        bind={`validationErrors.${this.props.field}`}
+        className="usa-error-message"
+      />
+    );
+  }
+}
+
+ValidationTextComponent.propTypes = {
+  field: PropTypes.string,
+  setFieldOrderSequence: PropTypes.func,
+};
+
+export const ValidationText = connect(
+  {
+    setFieldOrderSequence: sequences.setFieldOrderSequence,
+  },
+  ValidationTextComponent,
+);

--- a/web-client/src/views/StartCase/Address.jsx
+++ b/web-client/src/views/StartCase/Address.jsx
@@ -1,6 +1,6 @@
 import { Mobile, NonMobile } from '../../ustc-ui/Responsive/Responsive';
 import { StateSelect } from './StateSelect';
-import { Text } from '../../ustc-ui/Text/Text';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { props, sequences, state } from 'cerebral';
 import React from 'react';
@@ -55,10 +55,7 @@ export const Address = connect(
               });
             }}
           />
-          <Text
-            bind={`validationErrors.${type}.address1`}
-            className="usa-error-message"
-          />
+          <ValidationText field={`${type}.address1`} />
         </div>
         <div className="usa-form-group">
           <label className="usa-label" htmlFor={`${type}.address2`}>
@@ -152,16 +149,10 @@ export const Address = connect(
             </div>
             <div className="grid-row grid-gap">
               <div className="grid-col-8">
-                <Text
-                  bind={`validationErrors.${type}.city`}
-                  className="usa-error-message"
-                />
+                <ValidationText field={`${type}.city`} />
               </div>
               <div className="grid-col-4">
-                <Text
-                  bind={`validationErrors.${type}.state`}
-                  className="usa-error-message"
-                />
+                <ValidationText field={`${type}.state`} />
               </div>
             </div>
           </div>
@@ -196,10 +187,7 @@ export const Address = connect(
                 });
               }}
             />
-            <Text
-              bind={`validationErrors.${type}.city`}
-              className="usa-error-message"
-            />
+            <ValidationText field={`${type}.city`} />
           </div>
           <div
             className={classNames(
@@ -220,10 +208,7 @@ export const Address = connect(
               usStates={usStates}
               validateStartCaseSequence={validateStartCaseSequence}
             />
-            <Text
-              bind={`validationErrors.${type}.state`}
-              className="usa-error-message"
-            />
+            <ValidationText field={`${type}.state`} />
           </div>
         </Mobile>
         <div
@@ -260,10 +245,7 @@ export const Address = connect(
               });
             }}
           />
-          <Text
-            bind={`validationErrors.${type}.postalCode`}
-            className="usa-error-message"
-          />
+          <ValidationText field={`${type}.postalCode`} />
         </div>
       </React.Fragment>
     );

--- a/web-client/src/views/StartCase/CaseTypeSelect.jsx
+++ b/web-client/src/views/StartCase/CaseTypeSelect.jsx
@@ -1,4 +1,4 @@
-import { Text } from '../../ustc-ui/Text/Text';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { props, sequences, state } from 'cerebral';
 import React from 'react';
@@ -59,10 +59,7 @@ export const CaseTypeSelect = connect(
               ))}
             </select>
           </fieldset>
-          <Text
-            bind="validationErrors.caseType"
-            className="usa-error-message"
-          />
+          <ValidationText field="caseType" />
         </div>
       </div>
     );

--- a/web-client/src/views/StartCase/ContactPrimary.jsx
+++ b/web-client/src/views/StartCase/ContactPrimary.jsx
@@ -1,7 +1,7 @@
 import { Address } from './Address';
 import { Country } from './Country';
 import { InternationalAddress } from './InternationalAddress';
-import { Text } from '../../ustc-ui/Text/Text';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { props, sequences, state } from 'cerebral';
 import React from 'react';
@@ -71,10 +71,7 @@ export const ContactPrimary = connect(
                 });
               }}
             />
-            <Text
-              bind="validationErrors.contactPrimary.name"
-              className="usa-error-message"
-            />
+            <ValidationText field="contactPrimary.name" />
           </div>
 
           {contactsHelper.contactPrimary.displaySecondaryName && (
@@ -104,10 +101,7 @@ export const ContactPrimary = connect(
                   });
                 }}
               />
-              <Text
-                bind="validationErrors.contactPrimary.secondaryName"
-                className="usa-error-message"
-              />
+              <ValidationText field="contactPrimary.secondaryName" />
             </div>
           )}
 
@@ -182,10 +176,7 @@ export const ContactPrimary = connect(
                   });
                 }}
               />
-              <Text
-                bind="validationErrors.contactPrimary.inCareOf"
-                className="usa-error-message"
-              />
+              <ValidationText field="contactPrimary.inCareOf" />
             </div>
           )}
 
@@ -251,10 +242,7 @@ export const ContactPrimary = connect(
                 });
               }}
             />
-            <Text
-              bind="validationErrors.contactPrimary.phone"
-              className="usa-error-message"
-            />
+            <ValidationText field="contactPrimary.phone" />
           </div>
         </div>
       </>

--- a/web-client/src/views/StartCase/ProcedureType.jsx
+++ b/web-client/src/views/StartCase/ProcedureType.jsx
@@ -1,4 +1,4 @@
-import { Text } from '../../ustc-ui/Text/Text';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { props, state } from 'cerebral';
 import React from 'react';
@@ -51,10 +51,7 @@ export const ProcedureType = connect(
             </div>
           ))}
         </fieldset>
-        <Text
-          bind="validationErrors.procedureType"
-          className="usa-error-message"
-        />
+        <ValidationText field="procedureType" />
       </div>
     );
   },

--- a/web-client/src/views/StartCase/StartCaseStep2.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.jsx
@@ -3,7 +3,7 @@ import { Focus } from '../../ustc-ui/Focus/Focus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Hint } from '../../ustc-ui/Hint/Hint';
 import { StateDrivenFileInput } from '../FileDocument/StateDrivenFileInput';
-import { Text } from '../../ustc-ui/Text/Text';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -82,14 +82,9 @@ export const StartCaseStep2 = connect(
                   updateFormValueSequence="updateStartCaseFormValueSequence"
                   validationSequence="validateStartCaseWizardSequence"
                 />
-                <Text
-                  bind="validationErrors.petitionFile"
-                  className="usa-error-message"
-                />
-                <Text
-                  bind="validationErrors.petitionFileSize"
-                  className="usa-error-message"
-                />
+
+                <ValidationText field="petitionFile" />
+                <ValidationText field="petitionFileSize" />
               </div>
             </div>
           </div>
@@ -136,10 +131,7 @@ export const StartCaseStep2 = connect(
                     </label>
                   </div>
                 ))}
-                <Text
-                  bind="validationErrors.hasIrsNotice"
-                  className="usa-error-message"
-                />
+                <ValidationText field="hasIrsNotice" />
               </div>
             </fieldset>
 
@@ -173,15 +165,7 @@ export const StartCaseStep2 = connect(
             id="submit-case"
             type="button"
             onClick={() => {
-              completeStartCaseWizardStepSequence({
-                errorDisplayOrder: [
-                  'petitionFile',
-                  'petitionFileSize',
-                  'hasIrsNotice',
-                  'caseType',
-                ],
-                nextStep: 3,
-              });
+              completeStartCaseWizardStepSequence({ nextStep: 3 });
             }}
           >
             Continue to Step 3 of 5

--- a/web-client/src/views/StartCase/StartCaseStep2.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.jsx
@@ -178,6 +178,7 @@ export const StartCaseStep2 = connect(
                   'petitionFile',
                   'petitionFileSize',
                   'hasIrsNotice',
+                  'caseType',
                 ],
                 nextStep: 3,
               });

--- a/web-client/src/views/StartCase/StartCaseStep2.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.jsx
@@ -173,7 +173,14 @@ export const StartCaseStep2 = connect(
             id="submit-case"
             type="button"
             onClick={() => {
-              completeStartCaseWizardStepSequence({ nextStep: 3 });
+              completeStartCaseWizardStepSequence({
+                errorDisplayOrder: [
+                  'petitionFile',
+                  'petitionFileSize',
+                  'hasIrsNotice',
+                ],
+                nextStep: 3,
+              });
             }}
           >
             Continue to Step 3 of 5

--- a/web-client/src/views/StartCase/StartCaseStep3.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep3.jsx
@@ -2,7 +2,7 @@ import { Contacts } from './Contacts';
 import { Focus } from '../../ustc-ui/Focus/Focus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { StateDrivenFileInput } from '../FileDocument/StateDrivenFileInput';
-import { Text } from '../../ustc-ui/Text/Text';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -343,10 +343,7 @@ export const StartCaseStep3 = connect(
                 </fieldset>
               </div>
             )}
-          <Text
-            bind="validationErrors.partyType"
-            className="usa-error-message"
-          />
+          <ValidationText field="partyType" />
         </div>
 
         <Contacts
@@ -404,14 +401,8 @@ export const StartCaseStep3 = connect(
                 updateFormValueSequence="updateStartCaseFormValueSequence"
                 validationSequence="validateStartCaseWizardSequence"
               />
-              <Text
-                bind="validationErrors.ownershipDisclosureFile"
-                className="usa-error-message"
-              />
-              <Text
-                bind="validationErrors.ownershipDisclosureFileSize"
-                className="usa-error-message"
-              />
+              <ValidationText field="ownershipDisclosureFile" />
+              <ValidationText field="ownershipDisclosureFileSize" />
             </div>
           </>
         )}

--- a/web-client/src/views/StartCase/StartCaseStep4.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep4.jsx
@@ -162,7 +162,10 @@ export const StartCaseStep4 = connect(
             id="submit-case"
             type="button"
             onClick={() => {
-              completeStartCaseWizardStepSequence({ nextStep: 5 });
+              completeStartCaseWizardStepSequence({
+                errorDisplayOrder: ['procedureType', 'preferredTrialCity'],
+                nextStep: 5,
+              });
             }}
           >
             Continue to Step 5 of 5

--- a/web-client/src/views/StartCase/StartCaseStep4.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep4.jsx
@@ -4,8 +4,8 @@ import { Focus } from '../../ustc-ui/Focus/Focus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Mobile, NonMobile } from '../../ustc-ui/Responsive/Responsive';
 import { ProcedureType } from './ProcedureType';
-import { Text } from '../../ustc-ui/Text/Text';
 import { TrialCity } from './TrialCity';
+import { ValidationText } from '../../ustc-ui/Text/ValidationText';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -148,10 +148,7 @@ export const StartCaseStep4 = connect(
                   validateStartCaseWizardSequence();
                 }}
               />
-              <Text
-                bind="validationErrors.preferredTrialCity"
-                className="usa-error-message"
-              />
+              <ValidationText field="preferredTrialCity" />
             </div>
           </>
         )}


### PR DESCRIPTION
Usage of `<ValidationText />` instead of `<Text />` for field-level validation warnings in forms will store the order the components are mounted, and thus generate the error message alert map in that order.