### PR TITLE
DevEx - reducing the number of http requests to get the case notes

### DIFF
--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
@@ -39,6 +39,7 @@ exports.batchDownloadTrialSessionInteractor = async ({
     .getCalendaredCasesForTrialSession({
       applicationContext,
       trialSessionId,
+      userId: user.userId,
     });
 
   let s3Ids = [];

--- a/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
@@ -26,5 +26,6 @@ exports.getCalendaredCasesForTrialSessionInteractor = async ({
     .getCalendaredCasesForTrialSession({
       applicationContext,
       trialSessionId,
+      userId: user.userId,
     });
 };

--- a/shared/src/persistence/dynamo/trialSessions/getCalendaredCasesForTrialSession.test.js
+++ b/shared/src/persistence/dynamo/trialSessions/getCalendaredCasesForTrialSession.test.js
@@ -34,6 +34,6 @@ describe('getCalendaredCasesForTrialSession', () => {
     const result = await getCalendaredCasesForTrialSession({
       applicationContext,
     });
-    expect(result).toEqual([MOCK_CASE]);
+    expect(result).toMatchObject([MOCK_CASE]);
   });
 });

--- a/web-client/src/presenter/actions/TrialSession/deleteCaseNoteAction.js
+++ b/web-client/src/presenter/actions/TrialSession/deleteCaseNoteAction.js
@@ -8,13 +8,17 @@
  * @returns {object} the details of a caseNote
  */
 export const deleteCaseNoteAction = async ({ applicationContext, props }) => {
-  const { caseId } = props;
-  let caseNote;
+  const { caseId, trialSessionId } = props;
 
   await applicationContext.getUseCases().deleteCaseNoteInteractor({
     applicationContext,
     caseId,
   });
 
-  return { caseNote };
+  return {
+    caseNote: {
+      caseId,
+      trialSessionId,
+    },
+  };
 };

--- a/web-client/src/presenter/actions/TrialSession/extractNotesFromCalendaredCasesAction.js
+++ b/web-client/src/presenter/actions/TrialSession/extractNotesFromCalendaredCasesAction.js
@@ -1,0 +1,21 @@
+import { makeMap } from '../../computeds/makeMap';
+import { state } from 'cerebral';
+
+/**
+ * sets the state.trialSession.calendaredCases
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
+ */
+export const extractNotesFromCalendaredCasesAction = ({ get, store }) => {
+  const calendaredCases = get(state.trialSession.calendaredCases);
+  let caseNotes = [];
+
+  for (const calendaredCase of calendaredCases) {
+    caseNotes.push(calendaredCase.notes);
+  }
+  store.set(
+    state.trialSessionWorkingCopy.caseNotes,
+    makeMap(caseNotes, 'caseId'),
+  );
+};

--- a/web-client/src/presenter/actions/TrialSession/extractNotesFromCalendaredCasesAction.js
+++ b/web-client/src/presenter/actions/TrialSession/extractNotesFromCalendaredCasesAction.js
@@ -2,9 +2,10 @@ import { makeMap } from '../../computeds/makeMap';
 import { state } from 'cerebral';
 
 /**
- * sets the state.trialSession.calendaredCases
+ * runs through all the calendared cases to recreate the caseNotes mapping
  *
  * @param {object} providers the providers object
+ * @param {object} providers.get the cerebral get function used for getting values from the state
  * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
  */
 export const extractNotesFromCalendaredCasesAction = ({ get, store }) => {

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionWorkingCopyAction.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionWorkingCopyAction.js
@@ -1,6 +1,3 @@
-import { makeMap } from '../../computeds/makeMap';
-import { state } from 'cerebral';
-
 /**
  * Fetches the trial session working copy using the getTrialSessionWorkingCopy use case
  *
@@ -11,7 +8,6 @@ import { state } from 'cerebral';
  */
 export const getTrialSessionWorkingCopyAction = async ({
   applicationContext,
-  get,
   props,
 }) => {
   const { trialSessionId } = props;
@@ -22,24 +18,6 @@ export const getTrialSessionWorkingCopyAction = async ({
       applicationContext,
       trialSessionId,
     });
-
-  const trialSessionsCases = get(state.trialSession.caseOrder);
-  const caseIds = (trialSessionsCases || []).map(c => c.caseId);
-  let caseNotes = [];
-  let caseNote;
-
-  for (let i = 0; i < caseIds.length; i++) {
-    caseNote = await applicationContext.getUseCases().getCaseNoteInteractor({
-      applicationContext,
-      caseId: caseIds[i],
-    });
-
-    if (caseNote && caseNote.notes) {
-      caseNotes.push(caseNote);
-    }
-  }
-
-  trialSessionWorkingCopy.caseNotes = makeMap(caseNotes, 'caseId');
 
   return { trialSessionWorkingCopy };
 };

--- a/web-client/src/presenter/actions/TrialSessionWorkingCopy/updateCalendaredCaseNoteAction.js
+++ b/web-client/src/presenter/actions/TrialSessionWorkingCopy/updateCalendaredCaseNoteAction.js
@@ -1,0 +1,25 @@
+import { makeMap } from '../../computeds/makeMap';
+import { state } from 'cerebral';
+
+/**
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
+ */
+export const updateCalendaredCaseNoteAction = ({ get, props, store }) => {
+  const calendaredCases = get(state.trialSession.calendaredCases);
+  const { caseNote } = props;
+  const caseToUpdate = calendaredCases.find(
+    aCase => aCase.caseId === caseNote.caseId,
+  );
+  caseToUpdate.notes = caseNote;
+
+  let caseNotes = [];
+  for (const calendaredCase of calendaredCases) {
+    caseNotes.push(calendaredCase.notes);
+  }
+  store.set(
+    state.trialSessionWorkingCopy.caseNotes,
+    makeMap(caseNotes, 'caseId'),
+  );
+};

--- a/web-client/src/presenter/sequences/deleteCaseNoteFromWorkingCopySequence.js
+++ b/web-client/src/presenter/sequences/deleteCaseNoteFromWorkingCopySequence.js
@@ -3,6 +3,7 @@ import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { deleteCaseNoteAction } from '../actions/TrialSession/deleteCaseNoteAction';
 import { getTrialSessionWorkingCopyAction } from '../actions/TrialSession/getTrialSessionWorkingCopyAction';
 import { setTrialSessionWorkingCopyAction } from '../actions/TrialSession/setTrialSessionWorkingCopyAction';
+import { updateCalendaredCaseNoteAction } from '../actions/TrialSessionWorkingCopy/updateCalendaredCaseNoteAction';
 import { updateDeleteCaseNotePropsFromModalStateAction } from '../actions/TrialSessionWorkingCopy/updateDeleteCaseNotePropsFromModalStateAction';
 
 export const deleteCaseNoteFromWorkingCopySequence = [
@@ -10,6 +11,7 @@ export const deleteCaseNoteFromWorkingCopySequence = [
   deleteCaseNoteAction,
   getTrialSessionWorkingCopyAction,
   setTrialSessionWorkingCopyAction,
+  updateCalendaredCaseNoteAction,
   clearModalAction,
   clearModalStateAction,
 ];

--- a/web-client/src/presenter/sequences/gotoTrialSessionWorkingCopySequence.js
+++ b/web-client/src/presenter/sequences/gotoTrialSessionWorkingCopySequence.js
@@ -1,4 +1,5 @@
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
+import { extractNotesFromCalendaredCasesAction } from '../actions/TrialSession/extractNotesFromCalendaredCasesAction';
 import { getCalendaredCasesForTrialSessionAction } from '../actions/TrialSession/getCalendaredCasesForTrialSessionAction';
 import { getTrialSessionDetailsAction } from '../actions/TrialSession/getTrialSessionDetailsAction';
 import { getTrialSessionWorkingCopyAction } from '../actions/TrialSession/getTrialSessionWorkingCopyAction';
@@ -35,6 +36,7 @@ const gotoTrialSessionDetails = [
         yes: [
           getCalendaredCasesForTrialSessionAction,
           setCalendaredCasesOnTrialSessionAction,
+          extractNotesFromCalendaredCasesAction,
         ],
       },
       setCurrentPageAction('TrialSessionWorkingCopy'),

--- a/web-client/src/presenter/sequences/updateCaseNoteOnWorkingCopySequence.js
+++ b/web-client/src/presenter/sequences/updateCaseNoteOnWorkingCopySequence.js
@@ -6,6 +6,7 @@ import { setTrialSessionWorkingCopyAction } from '../actions/TrialSession/setTri
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
+import { updateCalendaredCaseNoteAction } from '../actions/TrialSessionWorkingCopy/updateCalendaredCaseNoteAction';
 import { updateCaseNoteAction } from '../actions/TrialSession/updateCaseNoteAction';
 import { updateNotePropsFromModalStateAction } from '../actions/TrialSessionWorkingCopy/updateNotePropsFromModalStateAction';
 import { validateNoteAction } from '../actions/validateNoteAction';
@@ -22,6 +23,7 @@ export const updateCaseNoteOnWorkingCopySequence = [
       updateCaseNoteAction,
       getTrialSessionWorkingCopyAction,
       setTrialSessionWorkingCopyAction,
+      updateCalendaredCaseNoteAction,
       clearModalAction,
       clearModalStateAction,
     ],


### PR DESCRIPTION
this PR refactors the multiple http `case-notes` requests and combines them with the `get-calendared-cases` endpoint.  Now each case that comes back will have a nested `case.notes` on it which are the notes associated with the judge user.