### PR TITLE
Disable PDF Sanitizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3667,9 +3667,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.536.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.536.0.tgz",
-      "integrity": "sha512-d91ASAgDtjP5Al8nRtdOhnS6m7XczqdmVfkyFtd7GlWJ2jy2NxQ+PI4QVp7n/74BNRSSLoyxmCqz2Ulqu3TOsQ==",
+      "version": "2.537.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.537.0.tgz",
+      "integrity": "sha512-dYsy0+N5k8vEu0CupHo9sx5fYzm6LcbUB+O2Lr3Q+RJaygxNQIaqKL+JeSnYNWF55okDWkitw0K76pAF3m03ag==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -4761,9 +4761,9 @@
           }
         },
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.0.tgz",
+          "integrity": "sha512-6gpP93MR+VOOehKbCPchro3wFZNSNmek8A2kbkOAZLIZAYx1KP/zAqwO0sOHi3xJEb+UBz8NaYt/17UNit1Q9w==",
           "dev": true
         }
       }
@@ -6269,9 +6269,9 @@
       "dev": true
     },
     "csv-parse": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.6.tgz",
-      "integrity": "sha512-VisC5TBBhOF+70zjrF9FOiqI2LZOhXK/vAWlOrqyqz3lLa+P8jzJ7L/sg90MHmkSY/brAXWwrmGSZR0tM5yi4g==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.7.tgz",
+      "integrity": "sha512-QfjZ9mhBHcNDUM7Ab1sLC5HNa7wVFSl5jDK3lpM0YyvAUb9bVgO1Veht13tWJno8cEZ2eSowFDwcvRCO4BVvNA==",
       "dev": true
     },
     "cuid": {
@@ -7415,9 +7415,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.266",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.266.tgz",
-      "integrity": "sha512-UTuTZ4v8T0gLPHI7U75PXLQePWI65MTS3mckRrnLCkNljHvsutbYs+hn2Ua/RFul3Jt/L3Ht2rLP+dU/AlBfrQ==",
+      "version": "1.3.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.267.tgz",
+      "integrity": "sha512-9Q2ixAJC+oHjWNtJV0MQ4vJMCWSowIrC6V6vcr+bwPddTDHj2ddv9xxXCzf4jT/fy6HP7maPoW0gifXkRxCttQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -10516,12 +10516,6 @@
       "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
       "dev": true
     },
-    "html_codesniffer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/html_codesniffer/-/html_codesniffer-2.4.1.tgz",
-      "integrity": "sha512-7g4Z8+7agJFi7XJGu2r0onIqA7ig9b26vFEvUE6DgtFJlJzy1ELYEKzzd5Xwam4xjHiHQ/w8yHO7KTGNcXnwzg==",
-      "dev": true
-    },
     "htmlnano": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.4.tgz",
@@ -10545,9 +10539,9 @@
           "dev": true
         },
         "terser": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.2.tgz",
-          "integrity": "sha512-obxk4x19Zlzj9zY4QeXj9iPCb5W8YGn4v3pn4/fHj0Nw8+R7N02Kvwvz9VpOItCZZD8RC+vnYCDL0gP6FAJ7Xg==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.3.tgz",
+          "integrity": "sha512-Nzr7dpRjSzMEUS+z2UYQBtzE0LDm5k0Yy8RgLRPy85QUo1TjU5lIOBwzS5/FVAMaVyHZ3WTTU2BuQcMn8KXnNQ==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -15731,15 +15725,14 @@
       "dev": true
     },
     "pa11y": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-5.2.0.tgz",
-      "integrity": "sha512-cREwqossTA/GALOcvk6P/e/uaV/hooKW8hLLhmGpt6YtKOXlFTw/MlOhQ7cP2s8m0Yhtnj/quO2gy4zCzMDabQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-5.2.1.tgz",
+      "integrity": "sha512-Xc1KHosjA/p91MoQofDb2AuuMjy/uY2gH2CBbZ8a7mUdjuyzsykReUc1qzoE7tVgPxRSIFyRflzK7O1LoJXQCA==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
         "fs-extra": "^5.0.0",
-        "html_codesniffer": "^2.4.0",
-        "node.extend": "^2.0.2",
+        "node.extend": "^2.0.0",
         "p-timeout": "^2.0.1",
         "pa11y-reporter-cli": "^1.0.1",
         "pa11y-reporter-csv": "^1.0.0",
@@ -23174,9 +23167,9 @@
           "dev": true
         },
         "terser": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.2.tgz",
-          "integrity": "sha512-obxk4x19Zlzj9zY4QeXj9iPCb5W8YGn4v3pn4/fHj0Nw8+R7N02Kvwvz9VpOItCZZD8RC+vnYCDL0gP6FAJ7Xg==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.3.tgz",
+          "integrity": "sha512-Nzr7dpRjSzMEUS+z2UYQBtzE0LDm5k0Yy8RgLRPy85QUo1TjU5lIOBwzS5/FVAMaVyHZ3WTTU2BuQcMn8KXnNQ==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",

--- a/reset-dependencies.sh
+++ b/reset-dependencies.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-rm -rf node_modules dist
+rm -rf node_modules dist package-lock.json
 npm i

--- a/web-api/src/documents/sanitizePdfLambda.js
+++ b/web-api/src/documents/sanitizePdfLambda.js
@@ -12,14 +12,15 @@ exports.handler = event =>
   handle(event, async () => {
     const user = getUserFromAuthHeader(event);
     const applicationContext = createApplicationContext(user);
-    const { documentId } = event.pathParameters || {};
+    // const { documentId } = event.pathParameters || {};
 
     applicationContext.logger.info('Event', event);
     try {
-      await applicationContext.getUseCases().sanitizePdfInteractor({
-        applicationContext,
-        documentId,
-      });
+      // disable sanitizer for now
+      // await applicationContext.getUseCases().sanitizePdfInteractor({
+      //   applicationContext,
+      //   documentId,
+      // });
       applicationContext.logger.info('User', user);
     } catch (e) {
       applicationContext.logger.error(e);


### PR DESCRIPTION
Disabled the PDF Sanitizer for now because:

The GhostScript PDF -> PS -> PDF process is too slow for lambda (even async lambdas), and sometimes resulted in output that didn't match the input.

The MuPDF `convert` process is not reliable: _With PDF output, we will create a new PDF file that matches the visual appearance. The PDF output is still a work in progress, so some features may not work. If you want to do a PDF to PDF conversion, 'mutool clean' is a better tool to use._

The MuPDF `clean` process carries over all scripts into the output.