### PR TITLE
2828: update total fields limit for elasticsearch index

### DIFF
--- a/shared/src/business/useCases/processStreamRecordsInteractor.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.js
@@ -9,6 +9,13 @@ exports.processStreamRecordsInteractor = async ({
   recordsToProcess,
 }) => {
   applicationContext.logger.info('Time', createISODateString());
+  await applicationContext.getSearchClient().indices.putSettings({
+    body: {
+      'index.mapping.total_fields.limit': '2000',
+    },
+    index: 'efcms',
+  });
+
   for (const record of recordsToProcess) {
     if (['INSERT', 'MODIFY'].includes(record.eventName)) {
       try {

--- a/shared/src/business/useCases/processStreamRecordsInteractor.test.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.test.js
@@ -9,6 +9,11 @@ describe('processStreamRecordsInteractor', () => {
     environment: { stage: 'local' },
     getSearchClient: () => ({
       index: indexSpy,
+      indices: {
+        putSettings: async () => {
+          return null;
+        },
+      },
     }),
     logger: {
       info: () => {},


### PR DESCRIPTION
This really should only be run once per deploy rather than each time the processing lambda is invoked. Is there a way to sign a call to the Elasticsearch endpoint to update this setting from somewhere other than a lambda, maybe as a step in the Circle deploy?