### PR TITLE
996: caption edit button should not wrap to next line by itself

### DIFF
--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -240,6 +240,8 @@ const formatCase = (applicationContext, caseDetail) => {
   result.caseName = applicationContext.getCaseCaptionNames(
     caseDetail.caseCaption || '',
   );
+  result.caseTitleWithoutRespondent =
+    caseDetail.caseTitle && caseDetail.caseTitle.replace('Respondent', '');
 
   result.formattedTrialCity = result.preferredTrialCity || 'Not assigned';
   result.formattedTrialDate = 'Not scheduled';

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -108,8 +108,10 @@ describe('formatCase', () => {
     const result = formatCase(applicationContext, {
       ...mockCaseDetail,
       hasVerifiedIrsNotice: true,
-      caseCaption: 'Test Case Caption',
       trialTime: 11,
+      caseCaption: 'Test Case Caption',
+      caseTitle:
+        'Test Case Caption, Petitioners v. Internal Revenue, Respondent',
     });
 
     expect(result).toHaveProperty('createdAtFormatted');
@@ -123,6 +125,9 @@ describe('formatCase', () => {
     );
     expect(result.shouldShowIrsNoticeDate).toBeTruthy();
     expect(result.caseName).toEqual('Test Case Caption');
+    expect(result.caseTitleWithoutRespondent).toEqual(
+      'Test Case Caption, Petitioners v. Internal Revenue, ',
+    );
     expect(result.formattedTrialCity).toEqual('Not assigned');
     expect(result).toHaveProperty('formattedTrialDate');
     expect(result.formattedTrialJudge).toEqual('Not assigned');

--- a/web-client/src/views/CaseDetailHeader.jsx
+++ b/web-client/src/views/CaseDetailHeader.jsx
@@ -46,13 +46,17 @@ export const CaseDetailHeader = connect(
                 )}
               </div>
               <p className="margin-y-0" id="case-title">
-                <span>
-                  {formattedCaseDetail.caseTitle}{' '}
-                  {caseDetailHelper.showCaptionEditButton &&
-                    !hideActionButtons && (
+                {!caseDetailHelper.showCaptionEditButton && (
+                  <span>{formattedCaseDetail.caseTitle}</span>
+                )}
+                {caseDetailHelper.showCaptionEditButton && !hideActionButtons && (
+                  <span>
+                    {formattedCaseDetail.caseTitleWithoutRespondent}
+                    <span className="display-inline-block">
+                      <span>Respondent</span>
                       <Button
                         link
-                        className="margin-left-105"
+                        className="margin-left-05 padding-0"
                         id="caption-edit-button"
                         onClick={() => {
                           openCaseCaptionModalSequence();
@@ -61,8 +65,9 @@ export const CaseDetailHeader = connect(
                         <FontAwesomeIcon icon="edit" size="sm" />
                         Edit
                       </Button>
-                    )}
-                </span>
+                    </span>
+                  </span>
+                )}
               </p>
               {showModal == 'UpdateCaseCaptionModalDialog' && (
                 <UpdateCaseCaptionModalDialog />


### PR DESCRIPTION
<img width="821" alt="Screen Shot 2019-10-04 at 7 47 37 AM" src="https://user-images.githubusercontent.com/43251054/66218240-a54b8080-e67d-11e9-91d8-ba927e6f2c63.png">
