### PR TITLE
2875 - voice over fixes for buttons

### DIFF
--- a/web-client/src/views/PDFSignerPageButtons.jsx
+++ b/web-client/src/views/PDFSignerPageButtons.jsx
@@ -1,3 +1,4 @@
+import { Button } from '../ustc-ui/Button/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
@@ -40,21 +41,23 @@ export const PDFSignerPageButtons = connect(
 
     return (
       <>
-        <FontAwesomeIcon
-          className={'icon-button' + (disablePrevious ? ' disabled' : '')}
-          icon={['fas', 'caret-left']}
-          size="2x"
-          onClick={getPreviousPage}
-        />
+        <Button link aria-label="previous page" onClick={getPreviousPage}>
+          <FontAwesomeIcon
+            className={'icon-button' + (disablePrevious ? ' disabled' : '')}
+            icon={['fas', 'caret-left']}
+            size="2x"
+          />
+        </Button>
         <span className="pages">
           Page {currentPageNumber} of {totalPages}
         </span>
-        <FontAwesomeIcon
-          className={'icon-button' + (disableNext ? ' disabled' : '')}
-          icon={['fas', 'caret-right']}
-          size="2x"
-          onClick={getNextPage}
-        />
+        <Button link aria-label="next page" onClick={getNextPage}>
+          <FontAwesomeIcon
+            className={'icon-button' + (disableNext ? ' disabled' : '')}
+            icon={['fas', 'caret-right']}
+            size="2x"
+          />
+        </Button>
       </>
     );
   },


### PR DESCRIPTION
- using tab was not selecting the next / previous page buttons in the signer page buttons component
- voice over was not reading anything when selecting the buttons other than "button, main"