### PR TITLE
3111 - Reduce # of network requests

### DIFF
--- a/web-client/src/app.jsx
+++ b/web-client/src/app.jsx
@@ -94,14 +94,6 @@ const app = {
       scannerSourceName,
     };
 
-    const user =
-      (await applicationContext
-        .getUseCases()
-        .getItemInteractor({ applicationContext, key: 'user' })) ||
-      presenter.state.user;
-    presenter.state.user = user;
-    applicationContext.setCurrentUser(user);
-
     // decorate all computed functions so they receive applicationContext as second argument ('get' is first)
     presenter.state = mapValues(presenter.state, value => {
       if (isFunction(value)) {
@@ -110,6 +102,7 @@ const app = {
       return value;
     });
 
+    // first, fetch the token from local storage
     const token =
       (await applicationContext
         .getUseCases()
@@ -117,6 +110,18 @@ const app = {
       presenter.state.token;
     presenter.state.token = token;
     applicationContext.setCurrentUserToken(token);
+
+    // fetch the user if the token is set
+
+    if (token) {
+      try {
+        const user = await applicationContext
+          .getUseCases()
+          .getUserInteractor({ applicationContext });
+        presenter.state.user = user;
+        applicationContext.setCurrentUser(user);
+      } catch (err) {}
+    }
 
     presenter.state.cognitoLoginUrl = applicationContext.getCognitoLoginUrl();
 

--- a/web-client/src/presenter/actions/getUserAction.js
+++ b/web-client/src/presenter/actions/getUserAction.js
@@ -8,12 +8,15 @@ import { state } from 'cerebral';
  * @param {Function} providers.props the cerebral props object used for getting the props.user
  * @returns {object} the user
  */
-export const getUserAction = async ({ applicationContext, get }) => {
+export const getUserAction = async ({ applicationContext, get, store }) => {
   let user = get(state.user);
-  if (!user) {
+  let forceLoadUser = get(state.forceLoadUser);
+
+  if (!user || forceLoadUser) {
     user = await applicationContext
       .getUseCases()
       .getUserInteractor({ applicationContext });
+    store.set(state.forceLoadUser, false);
   }
   return { user };
 };

--- a/web-client/src/presenter/actions/getUserAction.js
+++ b/web-client/src/presenter/actions/getUserAction.js
@@ -1,3 +1,5 @@
+import { state } from 'cerebral';
+
 /**
  * gets the user based on the name provided.
  *
@@ -6,9 +8,12 @@
  * @param {Function} providers.props the cerebral props object used for getting the props.user
  * @returns {object} the user
  */
-export const getUserAction = async ({ applicationContext }) => {
-  const user = await applicationContext
-    .getUseCases()
-    .getUserInteractor({ applicationContext });
+export const getUserAction = async ({ applicationContext, get }) => {
+  let user = get(state.user);
+  if (!user) {
+    user = await applicationContext
+      .getUseCases()
+      .getUserInteractor({ applicationContext });
+  }
   return { user };
 };

--- a/web-client/src/presenter/actions/getUsersInSectionAction.js
+++ b/web-client/src/presenter/actions/getUsersInSectionAction.js
@@ -1,4 +1,5 @@
 import { sortBy } from 'lodash';
+import { state } from 'cerebral';
 
 /**
  * returns a callback function scoped to a section the users in a section
@@ -14,10 +15,17 @@ export const getUsersInSectionAction = ({ section }) =>
    * @param {object} providers.applicationContext the cerebral get function used for getting the state.user
    * @returns {object} the list of users in a section
    */
-  async ({ applicationContext }) => {
-    const users = await applicationContext
-      .getUseCases()
-      .getUsersInSectionInteractor({ applicationContext, section });
+  async ({ applicationContext, get, store }) => {
+    // cache the users since they don't often change
+    const sectionUsers = get(state.sectionUsers);
+    let users = sectionUsers[section];
+    if (!users) {
+      users = await applicationContext
+        .getUseCases()
+        .getUsersInSectionInteractor({ applicationContext, section });
+      sectionUsers[section] = users;
+      store.set(state.sectionUsers, sectionUsers);
+    }
 
     return {
       users: sortBy(users, 'name'),

--- a/web-client/src/presenter/actions/isInternalUserAction.js
+++ b/web-client/src/presenter/actions/isInternalUserAction.js
@@ -1,0 +1,24 @@
+import { state } from 'cerebral';
+
+/**
+ * invokes the path depending on if the user is an internal user
+ *
+ * @param {object} providers the providers object
+ * @param {Function} providers.get the cerebral get method for getting the state.user
+ * @param {object} providers.path the cerebral path which is contains the next paths that can be invoked
+ * @returns {object} the list of section work items
+ */
+export const isInternalUserAction = ({ get, path }) => {
+  const user = get(state.user);
+  const internalRoles = [
+    'docketclerk',
+    'judge',
+    'petitionsclerk',
+    'seniorattorney',
+  ];
+  if (internalRoles.includes(user.role)) {
+    return path['yes']();
+  } else {
+    return path['no']();
+  }
+};

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -52,6 +52,7 @@ import { dismissCreateMessageModalSequence } from './sequences/dismissCreateMess
 import { dismissModalSequence } from './sequences/dismissModalSequence';
 import { editSelectedDocumentSequence } from './sequences/editSelectedDocumentSequence';
 import { editSelectedSecondaryDocumentSequence } from './sequences/editSelectedSecondaryDocumentSequence';
+
 import { fetchUserNotificationsSequence } from './sequences/fetchUserNotificationsSequence';
 import { formCancelToggleCancelSequence } from './sequences/formCancelToggleCancelSequence';
 import { generatePdfFromScanSessionSequence } from './sequences/generatePdfFromScanSessionSequence';
@@ -128,6 +129,7 @@ import { printFromBrowserSequence } from './sequences/printFromBrowserSequence';
 import { printTrialCalendarSequence } from './sequences/printTrialCalendarSequence';
 import { redirectToLoginSequence } from './sequences/redirectToLoginSequence';
 import { refreshCaseSequence } from './sequences/refreshCaseSequence';
+import { refreshUserNotificationsSequence } from './sequences/refreshUserNotificationsSequence';
 import { removeBatchSequence } from './sequences/removeBatchSequence';
 import { removeScannedPdfSequence } from './sequences/removeScannedPdfSequence';
 import { removeSecondarySupportingDocumentSequence } from './sequences/removeSecondarySupportingDocumentSequence';
@@ -399,6 +401,7 @@ export const presenter = {
     printTrialCalendarSequence,
     redirectToLoginSequence,
     refreshCaseSequence,
+    refreshUserNotificationsSequence,
     removeBatchSequence,
     removeScannedPdfSequence,
     removeSecondarySupportingDocumentSequence,

--- a/web-client/src/presenter/sequences/chooseWorkQueueSequence.js
+++ b/web-client/src/presenter/sequences/chooseWorkQueueSequence.js
@@ -8,11 +8,8 @@ import { getDocumentQCServedForSectionAction } from '../actions/getDocumentQCSer
 import { getDocumentQCServedForUserAction } from '../actions/getDocumentQCServedForUserAction';
 import { getInboxMessagesForSectionAction } from '../actions/getInboxMessagesForSectionAction';
 import { getInboxMessagesForUserAction } from '../actions/getInboxMessagesForUserAction';
-import { getNotificationsAction } from '../actions/getNotificationsAction';
 import { getSentMessagesForSectionAction } from '../actions/getSentMessagesForSectionAction';
 import { getSentMessagesForUserAction } from '../actions/getSentMessagesForUserAction';
-import { parallel } from 'cerebral/factories';
-import { setNotificationsAction } from '../actions/setNotificationsAction';
 import { setSectionInboxCountAction } from '../actions/setSectionInboxCountAction';
 import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { setWorkItemsAction } from '../actions/setWorkItemsAction';
@@ -21,58 +18,47 @@ import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForRespons
 export const chooseWorkQueueSequence = [
   setWaitingForResponseAction,
   clearWorkQueueAction,
-  parallel([
-    [getNotificationsAction, setNotificationsAction],
-    [
-      chooseWorkQueueAction,
-      {
-        documentqcmybatched: [
-          getDocumentQCBatchedForUserAction,
-          setWorkItemsAction,
-        ],
-        documentqcmyinProgress: [
-          getDocumentQCInboxForUserAction,
-          setWorkItemsAction,
-        ],
-        documentqcmyinbox: [
-          getDocumentQCInboxForUserAction,
-          setWorkItemsAction,
-        ],
-        documentqcmyoutbox: [
-          getDocumentQCServedForUserAction,
-          setWorkItemsAction,
-        ],
-        documentqcsectionbatched: [
-          getDocumentQCBatchedForSectionAction,
-          setWorkItemsAction,
-        ],
-        documentqcsectioninProgress: [
-          getDocumentQCInboxForSectionAction,
-          setWorkItemsAction,
-          setSectionInboxCountAction,
-        ],
-        documentqcsectioninbox: [
-          getDocumentQCInboxForSectionAction,
-          setWorkItemsAction,
-          setSectionInboxCountAction,
-        ],
-        documentqcsectionoutbox: [
-          getDocumentQCServedForSectionAction,
-          setWorkItemsAction,
-        ],
-        messagesmyinbox: [getInboxMessagesForUserAction, setWorkItemsAction],
-        messagesmyoutbox: [getSentMessagesForUserAction, setWorkItemsAction],
-        messagessectioninbox: [
-          getInboxMessagesForSectionAction,
-          setWorkItemsAction,
-          setSectionInboxCountAction,
-        ],
-        messagessectionoutbox: [
-          getSentMessagesForSectionAction,
-          setWorkItemsAction,
-        ],
-      },
+  chooseWorkQueueAction,
+  {
+    documentqcmybatched: [
+      getDocumentQCBatchedForUserAction,
+      setWorkItemsAction,
     ],
-  ]),
+    documentqcmyinProgress: [
+      getDocumentQCInboxForUserAction,
+      setWorkItemsAction,
+    ],
+    documentqcmyinbox: [getDocumentQCInboxForUserAction, setWorkItemsAction],
+    documentqcmyoutbox: [getDocumentQCServedForUserAction, setWorkItemsAction],
+    documentqcsectionbatched: [
+      getDocumentQCBatchedForSectionAction,
+      setWorkItemsAction,
+    ],
+    documentqcsectioninProgress: [
+      getDocumentQCInboxForSectionAction,
+      setWorkItemsAction,
+      setSectionInboxCountAction,
+    ],
+    documentqcsectioninbox: [
+      getDocumentQCInboxForSectionAction,
+      setWorkItemsAction,
+      setSectionInboxCountAction,
+    ],
+    documentqcsectionoutbox: [
+      getDocumentQCServedForSectionAction,
+      setWorkItemsAction,
+    ],
+    messagesmyinbox: [getInboxMessagesForUserAction, setWorkItemsAction],
+    messagesmyoutbox: [getSentMessagesForUserAction, setWorkItemsAction],
+    messagessectioninbox: [
+      getInboxMessagesForSectionAction,
+      setWorkItemsAction,
+      setSectionInboxCountAction,
+    ],
+    messagessectionoutbox: [
+      getSentMessagesForSectionAction,
+      setWorkItemsAction,
+    ],
+  },
   unsetWaitingForResponseAction,
 ];

--- a/web-client/src/presenter/sequences/gotoDashboardSequence.js
+++ b/web-client/src/presenter/sequences/gotoDashboardSequence.js
@@ -3,7 +3,6 @@ import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
 import { getCasesByUserAction } from '../actions/getCasesByUserAction';
 import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
-import { getUserAction } from '../actions/getUserAction';
 import { getUserRoleAction } from '../actions/getUserRoleAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { navigateToMessagesAction } from '../actions/navigateToMessagesAction';
@@ -13,14 +12,11 @@ import { setCasesAction } from '../actions/setCasesAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setMessageInboxPropsAction } from '../actions/setMessageInboxPropsAction';
 import { setTrialSessionsAction } from '../actions/TrialSession/setTrialSessionsAction';
-import { setUserAction } from '../actions/setUserAction';
 import { state } from 'cerebral';
 
 const goToDashboard = [
   setCurrentPageAction('Interstitial'),
   closeMobileMenuAction,
-  getUserAction,
-  setUserAction,
   set(state.selectedWorkItems, []),
   clearErrorAlertsAction,
   getUserRoleAction,

--- a/web-client/src/presenter/sequences/gotoMessagesSequence.js
+++ b/web-client/src/presenter/sequences/gotoMessagesSequence.js
@@ -2,7 +2,6 @@ import { chooseWorkQueueSequence } from './chooseWorkQueueSequence';
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
 import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
-import { getUserAction } from '../actions/getUserAction';
 import { getUserRoleAction } from '../actions/getUserRoleAction';
 import { getUsersInSectionAction } from '../actions/getUsersInSectionAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
@@ -10,15 +9,12 @@ import { redirectToCognitoAction } from '../actions/redirectToCognitoAction';
 import { set } from 'cerebral/factories';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setTrialSessionsAction } from '../actions/TrialSession/setTrialSessionsAction';
-import { setUserAction } from '../actions/setUserAction';
 import { setUsersAction } from '../actions/setUsersAction';
 import { state } from 'cerebral';
 
 const goToMessages = [
   setCurrentPageAction('Interstitial'),
   closeMobileMenuAction,
-  getUserAction,
-  setUserAction,
   set(state.selectedWorkItems, []),
   clearErrorAlertsAction,
   getUserRoleAction,

--- a/web-client/src/presenter/sequences/gotoUserContactEditSequence.js
+++ b/web-client/src/presenter/sequences/gotoUserContactEditSequence.js
@@ -1,9 +1,12 @@
 import { getUserAction } from '../actions/getUserAction';
+import { set } from 'cerebral/factories';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setUserAction } from '../actions/setUserAction';
+import { state } from 'cerebral';
 
 export const gotoUserContactEditSequence = [
   setCurrentPageAction('Interstitial'),
+  set(state.forceLoadUser, true),
   getUserAction,
   setUserAction,
   setCurrentPageAction('UserContactEdit'),

--- a/web-client/src/presenter/sequences/refreshUserNotificationsSequence.js
+++ b/web-client/src/presenter/sequences/refreshUserNotificationsSequence.js
@@ -1,0 +1,11 @@
+import { getNotificationsAction } from '../actions/getNotificationsAction';
+import { isLoggedInAction } from '../actions/isLoggedInAction';
+import { setNotificationsAction } from '../actions/setNotificationsAction';
+
+export const refreshUserNotificationsSequence = [
+  isLoggedInAction,
+  {
+    isLoggedIn: [getNotificationsAction, setNotificationsAction],
+    unauthorized: [],
+  },
+];

--- a/web-client/src/presenter/sequences/refreshUserNotificationsSequence.js
+++ b/web-client/src/presenter/sequences/refreshUserNotificationsSequence.js
@@ -1,11 +1,18 @@
 import { getNotificationsAction } from '../actions/getNotificationsAction';
+import { isInternalUserAction } from '../actions/isInternalUserAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { setNotificationsAction } from '../actions/setNotificationsAction';
 
 export const refreshUserNotificationsSequence = [
   isLoggedInAction,
   {
-    isLoggedIn: [getNotificationsAction, setNotificationsAction],
+    isLoggedIn: [
+      isInternalUserAction,
+      {
+        no: [],
+        yes: [getNotificationsAction, setNotificationsAction],
+      },
+    ],
     unauthorized: [],
   },
 ];

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -148,6 +148,7 @@ export const state = {
   screenMetadata: {},
   searchTerm: '',
   sectionInboxCount: 0,
+  sectionUsers: {},
   selectDocumentSelectHelper,
   selectDocumentTypeHelper,
   selectedBatchIndex: 0,

--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -39,6 +39,7 @@ import { TrialSessions } from './TrialSessions/TrialSessions';
 import { UsaBanner } from './UsaBanner';
 import { UserContactEdit } from './UserContactEdit';
 import { connect } from '@cerebral/react';
+import { sequences } from 'cerebral';
 import { state } from 'cerebral';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -91,6 +92,12 @@ class App extends React.Component {
     this.focusMain();
   }
 
+  componentDidMount() {
+    setInterval(() => {
+      this.props.refreshUserNotificationsSequence();
+    }, 30000);
+  }
+
   focusMain(e) {
     e && e.preventDefault();
     const header = document.querySelector('#main-content h1');
@@ -125,12 +132,15 @@ class App extends React.Component {
 App.propTypes = {
   currentPage: PropTypes.string,
   currentPageHeader: PropTypes.string,
+  refreshUserNotificationsSequence: PropTypes.func,
 };
 
 export const AppComponent = connect(
   {
     currentPage: state.currentPage,
     currentPageHeader: state.currentPageHeader,
+    refreshUserNotificationsSequence:
+      sequences.refreshUserNotificationsSequence,
   },
   App,
 );

--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -95,7 +95,7 @@ class App extends React.Component {
   componentDidMount() {
     setInterval(() => {
       this.props.refreshUserNotificationsSequence();
-    }, 30000);
+    }, 5000);
   }
 
   focusMain(e) {


### PR DESCRIPTION
This is an attempt to reduce the number of network requests made when navigating around the user's work queue and dashboard.  

Before we were loading the user's data on almost every work queue change, along with the users in the section, and the notifications.  This PR changes to do the following:

- cache the user info so it only does that request once
- cache the section users so it only does the request once
- make the notifications request on an interval of 30s (in the future, we might want to look into the web sockets, but that is a larger effort)