### PR TITLE
Enable websocket port for docker-run

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -5,6 +5,7 @@ docker run -t -i \
   -e AWS_SECRET_ACCESS_KEY=noop \
   -p 1234:1234 \
   -p 3000:3000 \
+  -p 3011:3011 \
   -p 8000:8000 \
   -p 8001:8001 \
   -p 9000:9000 \


### PR DESCRIPTION
This resolves the batch downloading trial session issue reported by @waldoj on the Sprint 24 PR.