### PR TITLE
Hide action buttons on case detail header 

### DIFF
--- a/web-client/src/views/DocketRecord/PrintableDocketRecord.jsx
+++ b/web-client/src/views/DocketRecord/PrintableDocketRecord.jsx
@@ -14,7 +14,7 @@ export const PrintableDocketRecord = connect(
   ({ formattedCaseDetail, navigateToCaseDetailSequence }) => {
     return (
       <>
-        <CaseDetailHeader />
+        <CaseDetailHeader hideActionButtons />
         <div className="grid-container print-docket-record">
           <Button
             link

--- a/web-client/src/views/FileDocument/BeforeYouFileADocument.jsx
+++ b/web-client/src/views/FileDocument/BeforeYouFileADocument.jsx
@@ -16,7 +16,7 @@ export const BeforeYouFileADocument = connect(
   ({ caseDetail, formCancelToggleCancelSequence, showModal }) => {
     return (
       <>
-        <CaseDetailHeader />
+        <CaseDetailHeader hideActionButtons />
         <section className="usa-section before-filing-document grid-container">
           <h2 className="captioned" tabIndex="-1">
             Before You File a Document…

--- a/web-client/src/views/FileDocument/FileDocumentWizard.jsx
+++ b/web-client/src/views/FileDocument/FileDocumentWizard.jsx
@@ -18,7 +18,7 @@ export const FileDocumentWizard = connect(
   ({ showModal }) => {
     return (
       <>
-        <CaseDetailHeader hideActionButtons={true} />
+        <CaseDetailHeader hideActionButtons />
         <section className="usa-section">
           <div className="grid-container">
             {showModal == 'FormCancelModalDialog' && (

--- a/web-client/src/views/FileDocument/FileDocumentWizard.jsx
+++ b/web-client/src/views/FileDocument/FileDocumentWizard.jsx
@@ -18,7 +18,7 @@ export const FileDocumentWizard = connect(
   ({ showModal }) => {
     return (
       <>
-        <CaseDetailHeader />
+        <CaseDetailHeader hideActionButtons={true} />
         <section className="usa-section">
           <div className="grid-container">
             {showModal == 'FormCancelModalDialog' && (

--- a/web-client/src/views/RequestAccess/RequestAccessWizard.jsx
+++ b/web-client/src/views/RequestAccess/RequestAccessWizard.jsx
@@ -16,7 +16,7 @@ export const RequestAccessWizard = connect(
   ({ showModal }) => {
     return (
       <>
-        <CaseDetailHeader />
+        <CaseDetailHeader hideActionButtons />
         <section className="usa-section grid-container">
           {showModal == 'FormCancelModalDialog' && (
             <FormCancelModalDialog onCancelSequence="closeModalAndReturnToDashboardSequence" />


### PR DESCRIPTION
Fix for:
https://trello.com/c/aB1SqGTq/192-request-access-button-should-be-hidden-once-a-counsel-practitioner-or-respondent-is-associated-with-the-case-button-is-displayin