### PR TITLE
Add receivedAt date to seed data cases

### DIFF
--- a/web-api/storage/fixtures/seed/101-19.json
+++ b/web-api/storage/fixtures/seed/101-19.json
@@ -81,9 +81,7 @@
         "receivedAt": "2019-10-07T14:29:30.288Z",
         "relationship": "primaryDocument",
         "userId": "1805d1ab-18d0-43ec-bafb-654e83405416",
-        "workItems": [
-          
-        ]
+        "workItems": []
       }
     ],
     "partyType": "Petitioner",
@@ -104,6 +102,7 @@
     },
     "preferredTrialCity": "Birmingham, Alabama",
     "createdAt": "2019-03-01T21:40:46.415Z",
+    "receivedAt": "2019-03-01T21:40:46.415Z",
     "caseId": "2fa6da8d-4328-4a20-a5d7-b76637e1dc02",
     "docketRecord": [
       {

--- a/web-api/storage/fixtures/seed/102-19.json
+++ b/web-api/storage/fixtures/seed/102-19.json
@@ -87,6 +87,7 @@
       "email": "taxpayer"
     },
     "createdAt": "2019-03-01T21:42:29.073Z",
+    "receivedAt": "2019-03-01T21:42:29.073Z",
     "caseId": "fa1179bd-04f5-4934-a716-964d8d7babc6",
     "sk": "0",
     "filingType": "Myself and my spouse",

--- a/web-api/storage/fixtures/seed/103-19.json
+++ b/web-api/storage/fixtures/seed/103-19.json
@@ -206,6 +206,7 @@
       "email": "taxpayer"
     },
     "createdAt": "2019-03-01T22:53:50.097Z",
+    "receivedAt": "2019-03-01T22:53:50.097Z",
     "noticeOfAttachments": false,
     "caseCaption": "Samson Workman, Petitioner",
     "caseId": "491b05b4-483f-4b85-8dd7-2dd4c069eb50",

--- a/web-api/storage/fixtures/seed/104-19.json
+++ b/web-api/storage/fixtures/seed/104-19.json
@@ -87,6 +87,7 @@
       "email": "taxpayer"
     },
     "createdAt": "2019-03-05T17:34:13.490Z",
+    "receivedAt": "2019-03-05T17:34:13.490Z",
     "noticeOfAttachments": true,
     "payGovId": null,
     "caseId": "5f6e8b8e-4fac-4fd7-bf3c-42f0d7c3ca05",

--- a/web-api/storage/fixtures/seed/105-19.json
+++ b/web-api/storage/fixtures/seed/105-19.json
@@ -75,6 +75,7 @@
       "email": "taxpayer@example.com"
     },
     "createdAt": "2019-03-27T21:53:00.297Z",
+    "receivedAt": "2019-03-27T21:53:00.297Z",
     "noticeOfAttachments": false,
     "caseId": "6f3d97f8-1bdd-4779-a150-c076d08ad8fd",
     "caseCaption": "Caryn Wall, Petitioner",

--- a/web-api/storage/fixtures/seed/106-19.json
+++ b/web-api/storage/fixtures/seed/106-19.json
@@ -659,6 +659,7 @@
       "email": "taxpayer@example.com"
     },
     "createdAt": "2019-07-12T17:09:41.026Z",
+    "receivedAt": "2019-07-12T17:09:41.026Z",
     "noticeOfAttachments": false,
     "caseCaption": "Denise Gould, Petitioner",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
@@ -923,6 +924,7 @@
       "email": "taxpayer@example.com"
     },
     "createdAt": "2019-07-12T17:09:41.026Z",
+    "receivedAt": "2019-07-12T17:09:41.026Z",
     "noticeOfAttachments": false,
     "caseCaption": "Denise Gould, Petitioner",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",

--- a/web-api/storage/fixtures/seed/107-19.json
+++ b/web-api/storage/fixtures/seed/107-19.json
@@ -262,7 +262,6 @@
     "irsNoticeDate": null,
     "orderForFilingFee": false,
     "partyType": "Partnership (as a partnership representative under the BBA regime)",
-    "receivedAt": null,
     "irsSendDate": "2019-08-16T17:30:10.522Z",
     "caseType": "CDP (Lien/Levy)",
     "contactPrimary": {
@@ -279,6 +278,7 @@
       "email": "taxpayer"
     },
     "createdAt": "2019-08-16T17:29:10.132Z",
+    "receivedAt": "2019-08-16T17:29:10.132Z",
     "noticeOfAttachments": false,
     "caseCaption": "Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s)",
     "caseId": "58c1f7a3-8062-42f0-a73e-8bd69b419878",

--- a/web-api/storage/fixtures/seed/108-19.json
+++ b/web-api/storage/fixtures/seed/108-19.json
@@ -157,7 +157,6 @@
     "irsNoticeDate": null,
     "orderForFilingFee": false,
     "partyType": "Trust",
-    "receivedAt": null,
     "trialJudge": "Judge Armen",
     "irsSendDate": "2019-08-16T19:22:13.919Z",
     "caseType": "Worker Classification",
@@ -176,6 +175,7 @@
       "email": "taxpayer"
     },
     "createdAt": "2019-08-16T19:21:46.146Z",
+    "receivedAt": "2019-08-16T19:21:46.146Z",
     "noticeOfAttachments": false,
     "trialTime": "10:00",
     "caseCaption": "Garrett Carpenter, Leslie Bullock, Trustee, Petitioner(s)",


### PR DESCRIPTION
Elasticsearch is using the `receivedAt` date for filtering by the year filed. All newly created cases have a `receivedAt` date that is the same as the `createdAt` date if they are not created from paper. This fix will allow us to search for our seed data cases and filter by the year filed. 