### PR TITLE
1195: add manually-added icon to judge's working copy

### DIFF
--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
@@ -72,6 +72,7 @@ export const WorkingCopySessionList = connect(
                   )) || <FontAwesomeIcon icon="caret-down" />}
                 </Button>
               </th>
+              <th aria-label="manually added indicator"></th>
               <th className="no-wrap">Case name</th>
               <th className="no-wrap">
                 <Button
@@ -108,6 +109,16 @@ export const WorkingCopySessionList = connect(
                 <tr className="vertical-align-middle-row">
                   <td>
                     <CaseLink formattedCase={item} />
+                  </td>
+                  <td>
+                    {item.isManuallyAdded && (
+                      <span aria-label="manually added indicator">
+                        <FontAwesomeIcon
+                          className="mini-success"
+                          icon="calendar-plus"
+                        />
+                      </span>
+                    )}
                   </td>
                   <td>{item.caseCaptionNames}</td>
                   <td>


### PR DESCRIPTION
<img width="1382" alt="Screen Shot 2019-10-22 at 7 00 55 AM" src="https://user-images.githubusercontent.com/43251054/67295235-b7118e00-f49b-11e9-83bb-32c32f9668ba.png">
