### PR TITLE
devex - updating existing user roles in cognito

### DIFF
--- a/shared/src/persistence/dynamo/users/createUser.js
+++ b/shared/src/persistence/dynamo/users/createUser.js
@@ -104,12 +104,27 @@ exports.createUser = async ({ applicationContext, user }) => {
       .promise();
     userId = response.User.Username;
   } catch (err) {
+    // the user already exists
     const response = await cognito
       .adminGetUser({
         UserPoolId: process.env.USER_POOL_ID,
         Username: user.email,
       })
       .promise();
+
+    await cognito
+      .adminUpdateUserAttributes({
+        UserAttributes: [
+          {
+            Name: 'custom:role',
+            Value: user.role,
+          },
+        ],
+        UserPoolId: process.env.USER_POOL_ID,
+        Username: user.email,
+      })
+      .promise();
+
     userId = response.Username;
   }
 

--- a/shared/src/persistence/dynamo/users/createUser.js
+++ b/shared/src/persistence/dynamo/users/createUser.js
@@ -121,7 +121,7 @@ exports.createUser = async ({ applicationContext, user }) => {
           },
         ],
         UserPoolId: process.env.USER_POOL_ID,
-        Username: user.email,
+        Username: response.Username,
       })
       .promise();
 


### PR DESCRIPTION
- when the setup-court-users.sh script runs, it isn't updating users that already exist with a new role; this fixes that