### PR TITLE
653 Update to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-plugin-transform-html-import-require-to-string": "^0.0.3",
     "bluebird": "^3.7.1",
     "cerebral": "^5.2.0",
-    "chrome-aws-lambda": "^1.20.2",
+    "chrome-aws-lambda": "^2.0.0",
     "classnames": "^2.2.6",
     "core-js": "^3.3.6",
     "csv-parse": "^4.6.3",

--- a/shared/src/business/entities/cases/CaseNote.test.js
+++ b/shared/src/business/entities/cases/CaseNote.test.js
@@ -12,7 +12,6 @@ describe('CaseNote', () => {
         userId: '"userId" is required',
       });
     });
-
     it('should be valid when all fields are present', () => {
       const entity = new CaseNote({
         caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',

--- a/web-api/runtimes/puppeteer/package.json
+++ b/web-api/runtimes/puppeteer/package.json
@@ -13,7 +13,7 @@
   "author": "William Bagayoko, Rachael Parris, Kris Koskelin",
   "license": "ISC",
   "dependencies": {
-    "chrome-aws-lambda": "~1.18",
+    "chrome-aws-lambda": "~2.0.0",
     "puppeteer-core": "~1.18",
     "handlebars":"~4.5.1",
     "node-sass":"~4.13.0"

--- a/web-api/serverless-api.yml
+++ b/web-api/serverless-api.yml
@@ -191,7 +191,6 @@ resources:
 
 functions:
   runBatchProcess:
-    runtime: nodejs8.10
     handler: web-api/src/apiHandlers.runBatchProcessLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest
@@ -241,7 +240,6 @@ functions:
           cors: true
 
   createCourtIssuedOrderPdfFromHtml:
-    runtime: nodejs8.10
     handler: web-api/src/apiHandlers.createCourtIssuedOrderPdfFromHtmlLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest
@@ -258,7 +256,6 @@ functions:
               Ref: ApiGatewayAuthorizer
 
   generateDocketRecordPdfLambda:
-    runtime: nodejs8.10
     handler: web-api/src/apiHandlers.generateDocketRecordPdfLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest
@@ -275,7 +272,6 @@ functions:
               Ref: ApiGatewayAuthorizer
 
   generateTrialCalendarPdfLambda:
-    runtime: nodejs8.10
     handler: web-api/src/apiHandlers.generateTrialCalendarPdfLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest

--- a/web-api/serverless-cases.yml
+++ b/web-api/serverless-cases.yml
@@ -229,7 +229,6 @@ functions:
               Ref: ApiGatewayAuthorizer
 
   updatePrimaryContact:
-    runtime: nodejs8.10
     handler: web-api/src/casesHandlers.updatePrimaryContactLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest

--- a/web-api/serverless-documents.yml
+++ b/web-api/serverless-documents.yml
@@ -230,7 +230,6 @@ functions:
           cors: true
 
   generatePrintableFilingReceiptLambda:
-    runtime: nodejs8.10
     handler: web-api/src/documentsHandlers.generatePrintableFilingReceiptLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest

--- a/web-api/serverless-puppeteer.yml
+++ b/web-api/serverless-puppeteer.yml
@@ -25,7 +25,7 @@ layers:
     name: ${self:provider.stage}-puppeteer
     description: Chrome headless binary provided via chrome-aws-lambda and puppeteer-core for interaction.
     compatibleRuntimes:
-      - nodejs8.10
+      - nodejs10.x
     path: web-api/runtimes/puppeteer
     package:
       exclude:

--- a/web-api/serverless-trial-sessions.yml
+++ b/web-api/serverless-trial-sessions.yml
@@ -301,7 +301,6 @@ functions:
               Ref: ApiGatewayAuthorizer
 
   batchDownloadTrialSession:
-    runtime: nodejs8.10
     handler: web-api/src/trialSessionsHandlers.batchDownloadTrialSessionLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest

--- a/web-api/serverless-users.yml
+++ b/web-api/serverless-users.yml
@@ -347,7 +347,6 @@ functions:
               Ref: ApiGatewayAuthorizer
 
   updateUserContactInformation:
-    runtime: nodejs8.10
     handler: web-api/src/usersHandlers.updateUserContactInformationLambda
     layers:
       - arn:aws:lambda:${opt:region}:${opt:accountId}:layer:${opt:stage}-puppeteer:latest


### PR DESCRIPTION
We can update chrome aws lambda to 2.0.0. which allows it to run on node10.x
Seemed to function on the experimental branch.
