### PR TITLE
653: genericize "back" button

### DIFF
--- a/web-client/src/views/DocketRecord/PrintableDocketRecord.jsx
+++ b/web-client/src/views/DocketRecord/PrintableDocketRecord.jsx
@@ -3,15 +3,14 @@ import { CaseDetailHeader } from '../CaseDetailHeader';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PdfPreview } from '../../ustc-ui/PdfPreview/PdfPreview';
 import { connect } from '@cerebral/react';
-import { sequences, state } from 'cerebral';
+import { sequences } from 'cerebral';
 import React from 'react';
 
 export const PrintableDocketRecord = connect(
   {
-    formattedCaseDetail: state.formattedCaseDetail,
-    navigateToCaseDetailSequence: sequences.navigateToCaseDetailSequence,
+    navigateBackSequence: sequences.navigateBackSequence,
   },
-  ({ formattedCaseDetail, navigateToCaseDetailSequence }) => {
+  ({ navigateBackSequence }) => {
     return (
       <>
         <CaseDetailHeader hideActionButtons />
@@ -20,13 +19,11 @@ export const PrintableDocketRecord = connect(
             link
             className="margin-bottom-3"
             onClick={() => {
-              navigateToCaseDetailSequence({
-                caseId: formattedCaseDetail.docketNumber,
-              });
+              navigateBackSequence();
             }}
           >
             <FontAwesomeIcon icon={['fa', 'arrow-alt-circle-left']} />
-            Back to Case
+            Back
           </Button>
           <PdfPreview />
         </div>


### PR DESCRIPTION
Instead of printable docket record's "Back to Case" link always taking someone to the case detail page, this functionality makes the button operate just like the browser's "back" button, using a sequence which talks to the router, instead.
![Screen Shot 2019-11-01 at 1 46 09 PM](https://user-images.githubusercontent.com/2445917/68048150-fadf7100-fcad-11e9-9a4b-6a2d447b4773.png)
