### PR TITLE
2448 Link to Highlighted Message

### DIFF
--- a/web-client/src/views/CaseDetail/MessagesInProgress.jsx
+++ b/web-client/src/views/CaseDetail/MessagesInProgress.jsx
@@ -48,6 +48,7 @@ export const MessagesInProgress = connect(
                         href={documentHelper({
                           docketNumber: workItem.docketNumber,
                           documentId: workItem.document.documentId,
+                          messageId: workItem.currentMessage.messageId,
                           shouldLinkToComplete:
                             workItem.document.isFileAttached === false,
                         })}


### PR DESCRIPTION
Needs a messageId to get the document helper to link to the message