### PR TITLE
Test coverage

### DIFF
--- a/web-client/integration-tests/journey/petitionsClerkCreatesMessage.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesMessage.js
@@ -31,6 +31,8 @@ export default (test, message) => {
       }),
     );
 
+    test.workItemToCheck = workItem.workItemId;
+
     expect(updatedWorkItem.assigneeId).toEqual(assigneeId);
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkViewsUnreadMessage.js
+++ b/web-client/integration-tests/journey/petitionsClerkViewsUnreadMessage.js
@@ -4,14 +4,14 @@ import { withAppContextDecorator } from '../../src/withAppContext';
 
 const formattedWorkQueue = withAppContextDecorator(formattedWorkQueueComputed);
 
-export default (test, message) => {
+export default test => {
   it('Views an unread message marking it read', async () => {
     const workQueue = await runCompute(formattedWorkQueue, {
       state: test.getState(),
     });
 
     const workItem = workQueue.find(
-      item => item.currentMessage.message == message,
+      item => item.workItemId === test.workItemToCheck,
     );
 
     await test.runSequence('gotoDocumentDetailSequence', {

--- a/web-client/src/presenter/actions/EditDocketRecord/setDocketEntryFormForDocketEditAction.test.js
+++ b/web-client/src/presenter/actions/EditDocketRecord/setDocketEntryFormForDocketEditAction.test.js
@@ -7,6 +7,14 @@ presenter.providers.applicationContext = applicationContext;
 
 describe('setDocketEntryFormForDocketEditAction', () => {
   it("sets the given document's edit state on form.state", async () => {
+    const editState = {
+      caseId: '123',
+      documentId: '123-abc-123-abc',
+      eventCode: 'OPP',
+      lodged: true,
+      testKey: 'testValue',
+    };
+
     const result = await runAction(setDocketEntryFormForDocketEditAction, {
       props: {
         documentId: '123-abc-123-abc',
@@ -14,7 +22,58 @@ describe('setDocketEntryFormForDocketEditAction', () => {
       state: {
         caseDetail: {
           caseId: '123',
-          docketRecord: [],
+          docketRecord: [
+            {
+              documentId: '123-abc-123-abc',
+              editState: JSON.stringify(editState),
+            },
+          ],
+          documents: [
+            {
+              documentId: '123-abc-123-abc',
+              eventCode: 'OPP',
+              lodged: true,
+            },
+            { documentId: '321-cba-321-cba' },
+          ],
+        },
+        form: {},
+      },
+    });
+
+    const expectedResult = {
+      caseId: '123',
+      documentId: '123-abc-123-abc',
+      eventCode: 'OPP',
+      lodged: true,
+      testKey: 'testValue',
+    };
+
+    expect(result.state.form).toEqual(expectedResult);
+    expect(result.output.docketEntry).toEqual(expectedResult);
+  });
+
+  it("does not set the given document's edit state on form.state if the docketRecord editState does not contain a caseId", async () => {
+    const editState = {
+      documentId: '123-abc-123-abc',
+      eventCode: 'OPP',
+      lodged: true,
+      testKey: 'testValue',
+    };
+
+    const result = await runAction(setDocketEntryFormForDocketEditAction, {
+      props: {
+        documentId: '123-abc-123-abc',
+      },
+      state: {
+        caseDetail: {
+          caseId: '123',
+          docketRecord: [
+            {
+              documentId: '123-abc-123-abc',
+              editState: JSON.stringify(editState),
+            },
+          ],
           documents: [
             {
               documentId: '123-abc-123-abc',

--- a/web-client/src/presenter/actions/archiveDraftDocumentAction.test.js
+++ b/web-client/src/presenter/actions/archiveDraftDocumentAction.test.js
@@ -32,4 +32,29 @@ describe('archiveDraftDocumentAction', () => {
       title: 'This document has been deleted:',
     });
   });
+
+  it('archives a drafted document successfully, saves alerts for navigation, and returns caseId if state.archiveDraftDocument.redirectToCaseDetail is true', async () => {
+    const result = await runAction(archiveDraftDocumentAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        archiveDraftDocument: {
+          caseId: 'abc-123ghadsf-zdasdf',
+          documentId: 'def-gfed213-441-abce-312f',
+          documentTitle: 'document-title-123',
+          redirectToCaseDetail: true,
+        },
+      },
+    });
+
+    expect(archiveDraftDocumentInteractor).toHaveBeenCalled();
+    expect(result.state.alertSuccess).toMatchObject({
+      message: 'document-title-123',
+      title: 'This document has been deleted:',
+    });
+    expect(result.state.saveAlertsForNavigation).toEqual(true);
+    expect(result.output.caseId).toEqual('abc-123ghadsf-zdasdf');
+  });
 });

--- a/web-client/src/presenter/actions/chooseModalWizardStepAction.test.js
+++ b/web-client/src/presenter/actions/chooseModalWizardStepAction.test.js
@@ -1,0 +1,13 @@
+import { chooseModalWizardStepAction } from './chooseModalWizardStepAction';
+import { runAction } from 'cerebral/test';
+
+describe.only('chooseModalWizardStepAction', () => {
+  it('should set state.modal.wizardStep to the passed in props.value', async () => {
+    const result = await runAction(chooseModalWizardStepAction, {
+      props: { value: 'step1' },
+      state: { modal: {} },
+    });
+
+    expect(result.state.modal.wizardStep).toEqual('step1');
+  });
+});

--- a/web-client/src/presenter/actions/chooseStartCaseWizardStepAction.test.js
+++ b/web-client/src/presenter/actions/chooseStartCaseWizardStepAction.test.js
@@ -1,0 +1,14 @@
+import { chooseStartCaseWizardStepAction } from './chooseStartCaseWizardStepAction';
+import { runAction } from 'cerebral/test';
+
+describe.only('chooseStartCaseWizardStepAction', () => {
+  it('should set state.wizardStep to the passed in props.value and sets state.form.wizardStep to the passed in step', async () => {
+    const result = await runAction(chooseStartCaseWizardStepAction, {
+      props: { step: '1', value: 'step1' },
+      state: { form: {} },
+    });
+
+    expect(result.state.wizardStep).toEqual('step1');
+    expect(result.state.form.wizardStep).toEqual('1');
+  });
+});

--- a/web-client/src/presenter/actions/clearAdvancedSearchFormAction.test.js
+++ b/web-client/src/presenter/actions/clearAdvancedSearchFormAction.test.js
@@ -1,0 +1,16 @@
+import { clearAdvancedSearchFormAction } from './clearAdvancedSearchFormAction';
+import { runAction } from 'cerebral/test';
+
+describe.only('clearAdvancedSearchFormAction', () => {
+  it('should clear the advanced search form, setting currentPage to 1 as a default, and clear the state.searchResults', async () => {
+    const result = await runAction(clearAdvancedSearchFormAction, {
+      state: {
+        advancedSearchForm: { currentPage: 83, sure: 'yes' },
+        searchResults: [{ caseId: '1' }, { caseId: '2' }],
+      },
+    });
+
+    expect(result.state.advancedSearchForm).toEqual({ currentPage: 1 });
+    expect(result.state.searchResults).toBeUndefined();
+  });
+});

--- a/web-client/src/presenter/actions/clearAlertsAction.test.js
+++ b/web-client/src/presenter/actions/clearAlertsAction.test.js
@@ -1,0 +1,61 @@
+import { clearAlertsAction } from './clearAlertsAction';
+import { runAction } from 'cerebral/test';
+
+describe.only('clearAlertsAction', () => {
+  it('should save alertError and alertSuccess but clear caseDetailErrors and validationErrors if state.saveAlertsForNavigation is true', async () => {
+    const result = await runAction(clearAlertsAction, {
+      state: {
+        alertError: 'some error',
+        alertSuccess: 'hooray',
+        caseDetailErrors: { error: true },
+        saveAlertsForNavigation: true,
+        validationErrors: { error: true },
+      },
+    });
+
+    expect(result.state.alertError).toEqual('some error');
+    expect(result.state.alertSuccess).toEqual('hooray');
+    expect(result.state.saveAlertsForNavigation).toEqual(false);
+    expect(result.state.caseDetailErrors).toEqual({});
+    expect(result.state.validationErrors).toEqual({});
+  });
+
+  it('should clear alertError, alertSuccess, caseDetailErrors, and validationErrors if state.saveAlertsForNavigation is false and props.fromModal is not present', async () => {
+    const result = await runAction(clearAlertsAction, {
+      state: {
+        alertError: 'some error',
+        alertSuccess: 'hooray',
+        caseDetailErrors: { error: true },
+        saveAlertsForNavigation: false,
+        validationErrors: { error: true },
+      },
+    });
+
+    expect(result.state.alertError).toBeUndefined();
+    expect(result.state.alertSuccess).toBeUndefined();
+    expect(result.state.saveAlertsForNavigation).toEqual(false);
+    expect(result.state.caseDetailErrors).toEqual({});
+    expect(result.state.validationErrors).toEqual({});
+  });
+
+  it('should clear alertError, alertSuccess, caseDetailErrors, and modal.validationErrors if state.saveAlertsForNavigation is false and props.fromModal is true', async () => {
+    const result = await runAction(clearAlertsAction, {
+      props: { fromModal: true },
+      state: {
+        alertError: 'some error',
+        alertSuccess: 'hooray',
+        caseDetailErrors: { error: true },
+        modal: { validationErrors: { error: true } },
+        saveAlertsForNavigation: false,
+        validationErrors: { error: true },
+      },
+    });
+
+    expect(result.state.alertError).toBeUndefined();
+    expect(result.state.alertSuccess).toBeUndefined();
+    expect(result.state.saveAlertsForNavigation).toEqual(false);
+    expect(result.state.caseDetailErrors).toEqual({});
+    expect(result.state.modal.validationErrors).toEqual({});
+    expect(result.state.validationErrors).toEqual({ error: true });
+  });
+});

--- a/web-client/src/presenter/actions/clearDocumentAction.test.js
+++ b/web-client/src/presenter/actions/clearDocumentAction.test.js
@@ -1,0 +1,12 @@
+import { clearDocumentAction } from './clearDocumentAction';
+import { runAction } from 'cerebral/test';
+
+describe.only('clearDocumentAction', () => {
+  it('should set state.document to an empty object', async () => {
+    const result = await runAction(clearDocumentAction, {
+      state: { document: { something: 'yes' } },
+    });
+
+    expect(result.state.document).toEqual({});
+  });
+});

--- a/web-client/src/presenter/actions/clearPreferredTrialCityAction.test.js
+++ b/web-client/src/presenter/actions/clearPreferredTrialCityAction.test.js
@@ -1,0 +1,12 @@
+import { clearPreferredTrialCityAction } from './clearPreferredTrialCityAction';
+import { runAction } from 'cerebral/test';
+
+describe.only('clearPreferredTrialCityAction', () => {
+  it('should set state.form.preferredTrialCity to an empty string', async () => {
+    const result = await runAction(clearPreferredTrialCityAction, {
+      state: { form: { preferredTrialCity: 'Birmingham, Alabama' } },
+    });
+
+    expect(result.state.form.preferredTrialCity).toEqual('');
+  });
+});

--- a/web-client/src/presenter/actions/getCaseAssociationAction.test.js
+++ b/web-client/src/presenter/actions/getCaseAssociationAction.test.js
@@ -218,4 +218,34 @@ describe('getCaseAssociation', () => {
       pendingAssociation: false,
     });
   });
+
+  it('should return false for isAssociated and pendingAssociation if the user is not an external user', async () => {
+    let verifyPendingCaseForUserStub = sinon.stub().returns(false);
+    presenter.providers.applicationContext = {
+      getUseCases: () => ({
+        verifyPendingCaseForUserInteractor: verifyPendingCaseForUserStub,
+      }),
+    };
+
+    const results = await runAction(getCaseAssociationAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        ...baseState,
+        caseDetail: {
+          practitioners: [{ userId: '123' }],
+        },
+        user: {
+          role: User.ROLES.petitionsClerk,
+          userId: '123',
+        },
+      },
+    });
+    expect(results.output).toEqual({
+      isAssociated: false,
+      pendingAssociation: false,
+    });
+  });
 });

--- a/web-client/src/presenter/actions/getFormCombinedWithCaseDetailAction.js
+++ b/web-client/src/presenter/actions/getFormCombinedWithCaseDetailAction.js
@@ -136,11 +136,6 @@ export const getFormCombinedWithCaseDetailAction = ({
     caseDetail.receivedAt,
   );
 
-  // cannot store empty strings in persistence
-  if (caseDetail.preferredTrialCity === '') {
-    delete caseDetail.preferredTrialCity;
-  }
-
   if (caseCaption && (caseCaption = caseCaption.trim())) {
     caseDetail.caseCaption = caseCaption;
   }

--- a/web-client/src/presenter/actions/getFormCombinedWithCaseDetailAction.test.js
+++ b/web-client/src/presenter/actions/getFormCombinedWithCaseDetailAction.test.js
@@ -21,8 +21,18 @@ describe('castToISO', () => {
     );
   });
 
+  it('returns an iso string for 01-01-2009 when the date string of 2009 is passed in', () => {
+    expect(castToISO(applicationContext, '2009')).toEqual(
+      '2009-01-01T05:00:00.000Z',
+    );
+  });
+
   it('returns null when the date string passed in is invalid', () => {
     expect(castToISO(applicationContext, 'x-10-10')).toEqual('-1');
+  });
+
+  it('returns null when the date string passed in is an empty string', () => {
+    expect(castToISO(applicationContext, '')).toEqual(null);
   });
 
   it('returns the same iso string passed in when an iso string is passed in', () => {
@@ -37,7 +47,7 @@ describe('getFormCombinedWithCaseDetailAction', () => {
     const results = await runAction(getFormCombinedWithCaseDetailAction, {
       modules,
       state: {
-        caseDetail: {},
+        caseDetail: { payGovId: '' },
         constants: {
           CASE_CAPTION_POSTFIX: Case.CASE_CAPTION_POSTFIX,
         },
@@ -58,7 +68,7 @@ describe('getFormCombinedWithCaseDetailAction', () => {
       combinedCaseDetailWithForm: {
         irsNoticeDate: '2009-01-01T05:00:00.000Z',
         payGovDate: '2009-01-01T05:00:00.000Z',
-        payGovId: undefined,
+        payGovId: null,
         receivedAt: '2009-03-03T05:00:00.000Z',
       },
     });
@@ -225,5 +235,22 @@ describe('getFormCombinedWithCaseDetailAction', () => {
       '-1',
     );
     // expect(results.output.combinedCaseDetailWithForm.payGovDate).toEqual(null);
+  });
+
+  it('adds the props.caseCaption to the combinedCaseDetailWithForm', async () => {
+    const results = await runAction(getFormCombinedWithCaseDetailAction, {
+      modules,
+      props: { caseCaption: 'Test Petitioner, Petitioner' },
+      state: {
+        caseDetail: {},
+        constants: {
+          CASE_CAPTION_POSTFIX: Case.CASE_CAPTION_POSTFIX,
+        },
+        form: {},
+      },
+    });
+    expect(results.output.combinedCaseDetailWithForm.caseCaption).toEqual(
+      'Test Petitioner, Petitioner',
+    );
   });
 });


### PR DESCRIPTION
Also resolves the randomly-failing `petitionsClerkDocumentQCMyMessagesJourney.test.js`