### PR TITLE
fixing missing `usa-fieldset` class

### DIFF
--- a/web-client/src/views/StartCase/StartCaseStep2.jsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.jsx
@@ -94,7 +94,7 @@ export const StartCaseStep2 = connect(
         <div className="blue-container margin-bottom-5">
           <div className="usa-form-group">
             <FormGroup errorText={validationErrors.hasIrsNotice}>
-              <fieldset id="irs-notice-radios">
+              <fieldset className="usa-fieldset" id="irs-notice-radios">
                 <legend className="usa-legend" id="notice-legend">
                   {startCaseHelper.noticeLegend}
                 </legend>


### PR DESCRIPTION
Only fieldset tag missing it afaict
![Screen Shot 2019-11-05 at 1 05 24 PM](https://user-images.githubusercontent.com/2445917/68237746-5b7fee00-ffcd-11e9-83e9-c7918c93325b.png)
Screenshot above shows *before* the change, indicating the border we're removing by properly using the USWDS class.
