### PR TITLE
cleanup progress indicators

### DIFF
--- a/web-client/src/presenter/sequences/submitCaseAssociationRequestSequence.js
+++ b/web-client/src/presenter/sequences/submitCaseAssociationRequestSequence.js
@@ -8,7 +8,9 @@ import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
 import { setCaseAction } from '../actions/setCaseAction';
 import { setPractitionerOnFormAction } from '../actions/FileDocument/setPractitionerOnFormAction';
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
+import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { submitCaseAssociationRequestAction } from '../actions/FileDocument/submitCaseAssociationRequestAction';
+import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 import { uploadExternalDocumentsAction } from '../actions/FileDocument/uploadExternalDocumentsAction';
 
 export const submitCaseAssociationRequestSequence = [
@@ -21,10 +23,12 @@ export const submitCaseAssociationRequestSequence = [
       submitCaseAssociationRequestAction,
       setCaseAction,
       closeFileUploadStatusModalAction,
-      ...getPrintableFilingReceiptSequence,
+      setWaitingForResponseAction,
+      getPrintableFilingReceiptSequence,
       getFileExternalDocumentAlertSuccessAction,
       setAlertSuccessAction,
       setSaveAlertsForNavigationAction,
+      unsetWaitingForResponseAction,
       navigateToCaseDetailAction,
     ],
   },

--- a/web-client/src/presenter/sequences/submitDocketEntrySequence.js
+++ b/web-client/src/presenter/sequences/submitDocketEntrySequence.js
@@ -26,12 +26,14 @@ import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNav
 import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
+import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
 import { stashWizardDataAction } from '../actions/DocketEntry/stashWizardDataAction';
 import { state } from 'cerebral';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
 import { submitDocketEntryWithFileAction } from '../actions/DocketEntry/submitDocketEntryWithFileAction';
 import { submitDocketEntryWithoutFileAction } from '../actions/DocketEntry/submitDocketEntryWithoutFileAction';
+import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 import { updateDocketEntryWithFileAction } from '../actions/DocketEntry/updateDocketEntryWithFileAction';
 import { updateDocketEntryWithoutFileAction } from '../actions/DocketEntry/updateDocketEntryWithoutFileAction';
 import { uploadDocketEntryFileAction } from '../actions/DocketEntry/uploadDocketEntryFileAction';
@@ -82,6 +84,7 @@ export const submitDocketEntrySequence = [
           setValidationAlertErrorsAction,
         ],
         success: [
+          setWaitingForResponseAction,
           unset(state.isUpdatingWithFile),
           generateTitleAction,
           stopShowValidationAction,
@@ -95,7 +98,7 @@ export const submitDocketEntrySequence = [
                 no: [submitDocketEntryWithoutFileAction],
                 yes: [updateDocketEntryWithoutFileAction],
               },
-              ...afterEntryCreatedOrUpdated,
+              afterEntryCreatedOrUpdated,
             ],
             yes: [
               openFileUploadStatusModalAction,
@@ -109,11 +112,12 @@ export const submitDocketEntrySequence = [
                     no: [submitDocketEntryWithFileAction],
                     yes: [updateDocketEntryWithFileAction],
                   },
-                  ...afterEntryCreatedOrUpdated,
+                  afterEntryCreatedOrUpdated,
                 ],
               },
             ],
           },
+          unsetWaitingForResponseAction,
         ],
       },
     ],

--- a/web-client/src/presenter/sequences/submitExternalDocumentSequence.js
+++ b/web-client/src/presenter/sequences/submitExternalDocumentSequence.js
@@ -7,7 +7,9 @@ import { openFileUploadStatusModalAction } from '../actions/openFileUploadStatus
 import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
 import { setCaseAction } from '../actions/setCaseAction';
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
+import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { submitRespondentCaseAssociationRequestAction } from '../actions/FileDocument/submitRespondentCaseAssociationRequestAction';
+import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 import { uploadExternalDocumentsAction } from '../actions/FileDocument/uploadExternalDocumentsAction';
 
 export const submitExternalDocumentSequence = [
@@ -19,10 +21,12 @@ export const submitExternalDocumentSequence = [
       submitRespondentCaseAssociationRequestAction,
       setCaseAction,
       closeFileUploadStatusModalAction,
-      ...getPrintableFilingReceiptSequence,
+      setWaitingForResponseAction,
+      getPrintableFilingReceiptSequence,
       getFileExternalDocumentAlertSuccessAction,
       setAlertSuccessAction,
       setSaveAlertsForNavigationAction,
+      unsetWaitingForResponseAction,
       navigateToCaseDetailAction,
     ],
   },

--- a/web-client/src/presenter/sequences/submitFilePetitionSequence.js
+++ b/web-client/src/presenter/sequences/submitFilePetitionSequence.js
@@ -11,8 +11,10 @@ import { setCaseAction } from '../actions/setCaseAction';
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
+import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
+import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 import { validatePetitionAction } from '../actions/validatePetitionAction';
 
 export const submitFilePetitionSequence = [
@@ -34,9 +36,11 @@ export const submitFilePetitionSequence = [
         success: [
           setCaseAction,
           closeFileUploadStatusModalAction,
+          setWaitingForResponseAction,
           getCreateCaseAlertSuccessAction,
           setAlertSuccessAction,
           setSaveAlertsForNavigationAction,
+          unsetWaitingForResponseAction,
           navigateToDashboardAction,
         ],
       },

--- a/web-client/src/presenter/sequences/submitPetitionFromPaperSequence.js
+++ b/web-client/src/presenter/sequences/submitPetitionFromPaperSequence.js
@@ -41,7 +41,7 @@ export const submitPetitionFromPaperSequence = [
               setCaseAction,
               setPetitionIdAction,
               closeFileUploadStatusModalAction,
-              ...gotoDocumentDetailSequence,
+              gotoDocumentDetailSequence,
             ],
           },
         ],

--- a/web-client/src/ustc-ui/Modal/ConfirmModal.jsx
+++ b/web-client/src/ustc-ui/Modal/ConfirmModal.jsx
@@ -87,7 +87,7 @@ export const ConfirmModal = connect(
             )}
           </div>
         </div>
-        {children}
+        <div className="margin-bottom-2">{children}</div>
         {(!noConfirm || !noCancel) && (
           <>
             {!noConfirm && (

--- a/web-client/src/views/CaseDetailHeader.jsx
+++ b/web-client/src/views/CaseDetailHeader.jsx
@@ -51,31 +51,24 @@ export const CaseDetailHeader = connect(
                       aria-label="associated judge"
                       className="margin-left-1 usa-tag"
                     >
-                      <span aria-hidden="true">
-                        <FontAwesomeIcon
-                          className="margin-right-05"
-                          icon="gavel"
-                          size="1x"
-                        />
-                      </span>
+                      <FontAwesomeIcon
+                        className="margin-right-05"
+                        icon="gavel"
+                        size="1x"
+                      />
                       {formattedCaseDetail.associatedJudge}
                     </span>
                   )}
 
                 {caseDetailHelper.hidePublicCaseInformation &&
                   formattedCaseDetail.showBlockedTag && (
-                    <span
-                      aria-label="blocked"
-                      className="margin-left-1 usa-tag red-tag"
-                    >
-                      <span aria-hidden="true">
-                        <FontAwesomeIcon
-                          className="margin-right-1"
-                          icon="hand-paper"
-                          size="1x"
-                        />
-                        BLOCKED
-                      </span>
+                    <span className="margin-left-1 usa-tag red-tag">
+                      <FontAwesomeIcon
+                        className="margin-right-1"
+                        icon="hand-paper"
+                        size="1x"
+                      />
+                      BLOCKED
                     </span>
                   )}
               </div>


### PR DESCRIPTION
some code was missing spinner or progress indicators while waiting for async to complete;
some confirm modals were acquiring children as text nodes which had NO margins or padding or block-level elements; fixed.
sequences don't need to be brought in with the array-spread operator.
Also: `aria-hidden` removed from span-wrappers of FontAwesome icons as they themselves already render with an `aria-hidden` attribute on them.

![Screen Shot 2019-11-05 at 3 37 49 PM](https://user-images.githubusercontent.com/2445917/68252629-a01a8200-ffeb-11e9-9619-edca206eb57b.png)
![Screen Shot 2019-11-05 at 3 46 27 PM](https://user-images.githubusercontent.com/2445917/68252632-a3157280-ffeb-11e9-89e7-b55c7e9ceb49.png)

