### PR TITLE
2377: move buttons on case detail page

### DIFF
--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -256,8 +256,6 @@ const formatCase = (applicationContext, caseDetail) => {
   result.caseName = applicationContext.getCaseCaptionNames(
     caseDetail.caseCaption || '',
   );
-  result.caseTitleWithoutRespondent =
-    caseDetail.caseTitle && caseDetail.caseTitle.replace('Respondent', '');
 
   result.formattedPreferredTrialCity =
     result.preferredTrialCity || 'No location selected';

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -159,9 +159,6 @@ describe('formatCase', () => {
     );
     expect(result.shouldShowIrsNoticeDate).toBeTruthy();
     expect(result.caseName).toEqual('Test Case Caption');
-    expect(result.caseTitleWithoutRespondent).toEqual(
-      'Test Case Caption, Petitioners v. Internal Revenue, ',
-    );
     expect(result.formattedPreferredTrialCity).toEqual('No location selected');
   });
 

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -157,8 +157,6 @@ export const caseDetailHelper = (get, applicationContext) => {
       modalState.respondentMatches.length,
     showActionRequired,
     showAddDocketEntryButton,
-    showCaptionEditButton:
-      caseDetail.status !== 'Batched for IRS' && !isExternalUser,
     showCaseDeadlinesExternal,
     showCaseDeadlinesInternal,
     showCaseDeadlinesInternalEmpty,
@@ -168,6 +166,8 @@ export const caseDetailHelper = (get, applicationContext) => {
     showCreateOrderButton,
     showDocketRecordInProgressState: !isExternalUser,
     showDocumentStatus: !caseDetail.irsSendDate,
+    showEditCaseButton:
+      caseDetail.status !== 'Batched for IRS' && !isExternalUser,
     showEditContacts,
     showEditSecondaryContactModal:
       get(state.showModal) === 'EditSecondaryContact',

--- a/web-client/src/views/CaseDetailHeader.jsx
+++ b/web-client/src/views/CaseDetailHeader.jsx
@@ -1,6 +1,5 @@
 import { Button } from '../ustc-ui/Button/Button';
 import { CaseLink } from '../ustc-ui/CaseLink/CaseLink';
-import { CreateOrderChooseTypeModal } from './CreateOrder/CreateOrderChooseTypeModal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { UpdateCaseCaptionModalDialog } from './CaseDetailEdit/UpdateCaseCaptionModalDialog';
 import { connect } from '@cerebral/react';
@@ -22,7 +21,6 @@ export const CaseDetailHeader = connect(
     formattedCaseDetail,
     hideActionButtons,
     openCaseCaptionModalSequence,
-    openCreateOrderChooseTypeModalSequence,
     showModal,
   }) => {
     return (
@@ -73,28 +71,7 @@ export const CaseDetailHeader = connect(
                   )}
               </div>
               <p className="margin-y-0" id="case-title">
-                {!caseDetailHelper.showCaptionEditButton && (
-                  <span>{formattedCaseDetail.caseTitle}</span>
-                )}
-                {caseDetailHelper.showCaptionEditButton && !hideActionButtons && (
-                  <span>
-                    {formattedCaseDetail.caseTitleWithoutRespondent}
-                    <span className="display-inline-block">
-                      <span>Respondent</span>
-                      <Button
-                        link
-                        className="margin-left-05 padding-0"
-                        id="caption-edit-button"
-                        onClick={() => {
-                          openCaseCaptionModalSequence();
-                        }}
-                      >
-                        <FontAwesomeIcon icon="edit" size="sm" />
-                        Edit
-                      </Button>
-                    </span>
-                  </span>
-                )}
+                <span>{formattedCaseDetail.caseTitle}</span>
               </p>
               {showModal == 'UpdateCaseCaptionModalDialog' && (
                 <UpdateCaseCaptionModalDialog />
@@ -133,18 +110,17 @@ export const CaseDetailHeader = connect(
                   </Button>
                 )}
 
-                {caseDetailHelper.showCreateOrderButton && (
+                {caseDetailHelper.showEditCaseButton && (
                   <Button
-                    className="margin-right-0 float-right"
-                    id="button-create-order"
-                    onClick={() => openCreateOrderChooseTypeModalSequence()}
+                    className="tablet-full-width push-right margin-right-0"
+                    id="caption-edit-button"
+                    onClick={() => {
+                      openCaseCaptionModalSequence();
+                    }}
                   >
-                    <FontAwesomeIcon icon="clipboard-list" size="1x" /> Create
-                    Order
+                    <FontAwesomeIcon icon="edit" size="sm" />
+                    Edit
                   </Button>
-                )}
-                {showModal == 'CreateOrderChooseTypeModal' && (
-                  <CreateOrderChooseTypeModal />
                 )}
               </div>
             )}

--- a/web-client/src/views/DraftDocuments/DraftDocuments.jsx
+++ b/web-client/src/views/DraftDocuments/DraftDocuments.jsx
@@ -1,7 +1,9 @@
 import { ArchiveDraftDocumentModal } from './ArchiveDraftDocumentModal';
 import { Button } from '../../ustc-ui/Button/Button';
 import { ConfirmEditModal } from './ConfirmEditModal';
+import { CreateOrderChooseTypeModal } from '../CreateOrder/CreateOrderChooseTypeModal';
 import { FilingsAndProceedings } from '../DocketRecord/FilingsAndProceedings';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -10,18 +12,32 @@ export const DraftDocuments = connect(
   {
     archiveDraftDocumentModalSequence:
       sequences.archiveDraftDocumentModalSequence,
+    caseDetailHelper: state.caseDetailHelper,
     formattedCaseDetail: state.formattedCaseDetail,
     openConfirmEditModalSequence: sequences.openConfirmEditModalSequence,
+    openCreateOrderChooseTypeModalSequence:
+      sequences.openCreateOrderChooseTypeModalSequence,
     showModal: state.showModal,
   },
   ({
     archiveDraftDocumentModalSequence,
+    caseDetailHelper,
     formattedCaseDetail,
     openConfirmEditModalSequence,
+    openCreateOrderChooseTypeModalSequence,
     showModal,
   }) => {
     return (
       <>
+        {caseDetailHelper.showCreateOrderButton && (
+          <Button
+            className="margin-bottom-3"
+            id="button-create-order"
+            onClick={() => openCreateOrderChooseTypeModalSequence()}
+          >
+            <FontAwesomeIcon icon="clipboard-list" size="1x" /> Create Order
+          </Button>
+        )}
         {formattedCaseDetail.draftDocuments.length === 0 && (
           <p>There are no draft documents.</p>
         )}
@@ -116,6 +132,9 @@ export const DraftDocuments = connect(
           <ArchiveDraftDocumentModal />
         )}
         {showModal === 'ConfirmEditModal' && <ConfirmEditModal />}
+        {showModal === 'CreateOrderChooseTypeModal' && (
+          <CreateOrderChooseTypeModal />
+        )}
       </>
     );
   },


### PR DESCRIPTION
* Moved Create Order button into Draft Documents tab
* Removed Edit button next to case caption and replaced with Edit button on the right side of the case detail header
<img width="1377" alt="Screen Shot 2019-11-06 at 9 43 29 AM" src="https://user-images.githubusercontent.com/43251054/68323279-ff26d800-0079-11ea-8c6a-3cc475840164.png">
