### PR TITLE
2448 Messages 'Received'

### DIFF
--- a/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
+++ b/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
@@ -22,7 +22,7 @@ export const RecentMessagesInbox = connect(
               <th aria-label="Docket Number" className="small" colSpan="2">
                 <span className="padding-left-2px">Docket</span>
               </th>
-              <th className="small">Filed</th>
+              <th className="small">Received</th>
               <th>Case name</th>
               <th>Document</th>
               {workQueueHelper.showCaseStatusColumn && (


### PR DESCRIPTION

![Screenshot 2019-11-08 15 15 53](https://user-images.githubusercontent.com/1385752/68511056-a94d5e00-023a-11ea-93a1-657172f99e44.png)

Messages view should use 'Received'
Document QC should use 'Filed'