### PR TITLE
Sprint 26 - test updates around confusing permissions

### DIFF
--- a/web-client/src/presenter/computeds/docketRecordHelper.test.js
+++ b/web-client/src/presenter/computeds/docketRecordHelper.test.js
@@ -58,16 +58,14 @@ describe('docket record helper', () => {
     expect(result.showDocumentDetailLink).toEqual(false);
   });
 
-  it('should show document detail link and not direct download link if the user does have UPDATE_CASE permission', () => {
-    const user = {
-      role: User.ROLES.petitionsClerk,
-      userId: '789',
-    };
+  it('should show document detail link and not direct download link if the user has UPDATE_CASE permission', () => {
     const result = runCompute(docketRecordHelper, {
       state: {
-        ...getBaseState(user),
         caseDetail: {},
         form: {},
+        permissions: {
+          UPDATE_CASE: true,
+        },
       },
     });
     expect(result.showDocumentDetailLink).toEqual(true);
@@ -75,81 +73,71 @@ describe('docket record helper', () => {
   });
 
   it('should show links for editing docket entries if user has DOCKET_ENTRY permission', () => {
-    const user = {
-      role: User.ROLES.docketClerk,
-      userId: '789',
-    };
     const result = runCompute(docketRecordHelper, {
       state: {
-        ...getBaseState(user),
         caseDetail: {},
         form: {},
+        permissions: {
+          DOCKET_ENTRY: true,
+        },
       },
     });
     expect(result.showEditDocketEntry).toEqual(true);
   });
 
   it('should not show links for editing docket entries if user does not have DOCKET_ENTRY permission', () => {
-    const user = {
-      role: User.ROLES.petitionsClerk,
-      userId: '789',
-    };
     const result = runCompute(docketRecordHelper, {
       state: {
-        ...getBaseState(user),
         caseDetail: {},
         form: {},
+        permissions: {
+          DOCKET_ENTRY: false,
+        },
       },
     });
     expect(result.showEditDocketEntry).toEqual(false);
   });
 
   it('should show file document button if user has FILE_EXTERNAL_DOCUMENT permission and the user is associated with the case', () => {
-    const user = {
-      role: User.ROLES.respondent,
-      userId: '789',
-    };
     const result = runCompute(docketRecordHelper, {
       state: {
-        ...getBaseState(user),
         caseDetail: {},
         currentPage: 'CaseDetail',
-        screenMetadata: { isAssociated: true },
         form: {},
+        permissions: {
+          FILE_EXTERNAL_DOCUMENT: true,
+        },
+        screenMetadata: { isAssociated: true },
       },
     });
     expect(result.showFileDocumentButton).toEqual(true);
   });
 
   it('should not show file document button if user does not have FILE_EXTERNAL_DOCUMENT permission', () => {
-    const user = {
-      role: User.ROLES.petitionsClerk,
-      userId: '789',
-    };
     const result = runCompute(docketRecordHelper, {
       state: {
-        ...getBaseState(user),
         caseDetail: {},
         currentPage: 'CaseDetail',
-        screenMetadata: { isAssociated: true },
         form: {},
+        permissions: {
+          FILE_EXTERNAL_DOCUMENT: false,
+        },
+        screenMetadata: { isAssociated: true },
       },
     });
     expect(result.showFileDocumentButton).toEqual(false);
   });
 
   it('should not show file document button if user has FILE_EXTERNAL_DOCUMENT permission but the user is not associated with the case', () => {
-    const user = {
-      role: User.ROLES.petitioner,
-      userId: '789',
-    };
     const result = runCompute(docketRecordHelper, {
       state: {
-        ...getBaseState(user),
         caseDetail: {},
         currentPage: 'CaseDetail',
-        screenMetadata: { isAssociated: false },
         form: {},
+        permissions: {
+          FILE_EXTERNAL_DOCUMENT: true,
+        },
+        screenMetadata: { isAssociated: false },
       },
     });
     expect(result.showFileDocumentButton).toEqual(false);

--- a/web-client/src/presenter/computeds/documentDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/documentDetailHelper.test.js
@@ -130,6 +130,9 @@ describe('document detail helper', () => {
     const result = runCompute(documentDetailHelper, {
       state: {
         ...getBaseState(user),
+        permissions: {
+          COURT_ISSUED_DOCUMENT: true,
+        },
         caseDetail: {
           documents: [
             {
@@ -436,6 +439,9 @@ describe('document detail helper', () => {
       const result = runCompute(documentDetailHelper, {
         state: {
           ...getBaseState(user),
+          permissions: {
+            SERVE_DOCUMENT: false,
+          },
           caseDetail: {
             documents: [
               {


### PR DESCRIPTION
Set the permissions directly in the tests rather than building them based on the user role so the tests are more clear. 