### PR TITLE
Fixing an issue with the create users scripts

### DIFF
--- a/web-api/setup-cognito-users.sh
+++ b/web-api/setup-cognito-users.sh
@@ -96,7 +96,7 @@ createAccount() {
       --region "${REGION}" \
       --challenge-name NEW_PASSWORD_REQUIRED \
       --challenge-responses 'NEW_PASSWORD="Testing1234$",'USERNAME="${email}" \
-      --session "${session}"
+      --session="${session}"
   fi
 }
 

--- a/web-api/setup-court-users.sh
+++ b/web-api/setup-court-users.sh
@@ -55,7 +55,7 @@ createAccount() {
       --region "${REGION}" \
       --challenge-name NEW_PASSWORD_REQUIRED \
       --challenge-responses 'NEW_PASSWORD="Testing1234$",'USERNAME="${email}" \
-      --session "${session}"
+      --session="${session}"
   fi
 }
 


### PR DESCRIPTION
we needed to define the session option like `--session="${session}"` instead of `--session "${session}"` because the session variable might have a leading `-`