### PR TITLE
2380: fixes for generic order freeText and filed date

### DIFF
--- a/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.js
@@ -39,6 +39,10 @@ exports.fileCourtIssuedOrderInteractor = async ({
 
   const caseEntity = new Case(caseToUpdate, { applicationContext });
 
+  if (documentMetadata.eventCode === 'O') {
+    documentMetadata.freeText = documentMetadata.documentTitle;
+  }
+
   const documentEntity = new Document(
     {
       ...documentMetadata,

--- a/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.test.js
+++ b/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.test.js
@@ -64,7 +64,7 @@ describe('fileCourtIssuedOrderInteractor', () => {
     expect(error.message).toContain('Unauthorized');
   });
 
-  it('add order document to case', async () => {
+  it('should add order document to case', async () => {
     let error;
     let getCaseByCaseIdSpy = sinon.stub().returns(caseRecord);
     let updateCaseSpy = sinon.spy();
@@ -103,5 +103,51 @@ describe('fileCourtIssuedOrderInteractor', () => {
     expect(
       updateCaseSpy.getCall(0).args[0].caseToUpdate.documents.length,
     ).toEqual(4);
+  });
+
+  it('should add order document to case and set freeText to the document title if it is a generic order (eventCode O)', async () => {
+    let error;
+    let getCaseByCaseIdSpy = sinon.stub().returns(caseRecord);
+    let updateCaseSpy = sinon.spy();
+    try {
+      applicationContext = {
+        environment: { stage: 'local' },
+        getCurrentUser: () => {
+          return new User({
+            name: 'Olivia Jade',
+            role: User.ROLES.petitionsClerk,
+            userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+          });
+        },
+        getPersistenceGateway: () => ({
+          getCaseByCaseId: getCaseByCaseIdSpy,
+          getUserById: async () => ({
+            name: 'bob',
+            userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+          }),
+          updateCase: updateCaseSpy,
+        }),
+      };
+      await fileCourtIssuedOrderInteractor({
+        applicationContext,
+        documentMetadata: {
+          caseId: caseRecord.caseId,
+          documentTitle: 'Order to do anything',
+          documentType: 'Order',
+          eventCode: 'O',
+        },
+        primaryDocumentFileId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      });
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeUndefined();
+    expect(getCaseByCaseIdSpy.called).toEqual(true);
+    expect(
+      updateCaseSpy.getCall(0).args[0].caseToUpdate.documents.length,
+    ).toEqual(4);
+    expect(
+      updateCaseSpy.getCall(0).args[0].caseToUpdate.documents[3],
+    ).toMatchObject({ freeText: 'Order to do anything' });
   });
 });

--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -99,6 +99,10 @@ const formatDocketRecordWithDocument = (
       document.isCourtIssuedDocument =
         isOrder || !!courtIssuedDocumentTypes.includes(document.documentType);
 
+      if ((isOrder || document.isCourtIssuedDocument) && !document.servedAt) {
+        record.createdAtFormatted = undefined;
+      }
+
       if (document.certificateOfServiceDate) {
         document.certificateOfServiceDateFormatted = applicationContext
           .getUtilities()

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -112,18 +112,18 @@ describe('formatCase', () => {
   it('should format docket records and set createdAtFormatted to the formatted createdAt date if document is not a court-issued document', () => {
     const result = formatCase(applicationContext, {
       ...mockCaseDetail,
-      documents: [
-        {
-          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
-          documentType: 'Petition',
-        },
-      ],
       docketRecord: [
         {
           createdAt: getDateISO(),
           documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
           filingDate: getDateISO(),
           index: '1',
+        },
+      ],
+      documents: [
+        {
+          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
+          documentType: 'Petition',
         },
       ],
     });
@@ -137,6 +137,14 @@ describe('formatCase', () => {
   it('should format docket records and set createdAtFormatted to undefined if document is an unserved court-issued document', () => {
     const result = formatCase(applicationContext, {
       ...mockCaseDetail,
+      docketRecord: [
+        {
+          createdAt: getDateISO(),
+          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
+          filingDate: getDateISO(),
+          index: '1',
+        },
+      ],
       documents: [
         {
           documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
@@ -144,14 +152,6 @@ describe('formatCase', () => {
           documentType: 'OAJ - Order that case is assigned',
           eventCode: 'OAJ',
           scenario: 'Type B',
-        },
-      ],
-      docketRecord: [
-        {
-          createdAt: getDateISO(),
-          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
-          filingDate: getDateISO(),
-          index: '1',
         },
       ],
     });

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -109,6 +109,59 @@ describe('formatCase', () => {
     expect(result).toHaveProperty('docketRecordWithDocument');
   });
 
+  it('should format docket records and set createdAtFormatted to the formatted createdAt date if document is not a court-issued document', () => {
+    const result = formatCase(applicationContext, {
+      ...mockCaseDetail,
+      documents: [
+        {
+          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
+          documentType: 'Petition',
+        },
+      ],
+      docketRecord: [
+        {
+          createdAt: getDateISO(),
+          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
+          filingDate: getDateISO(),
+          index: '1',
+        },
+      ],
+    });
+
+    expect(result).toHaveProperty('docketRecordWithDocument');
+    expect(
+      result.docketRecordWithDocument[0].record.createdAtFormatted,
+    ).toBeDefined();
+  });
+
+  it('should format docket records and set createdAtFormatted to undefined if document is an unserved court-issued document', () => {
+    const result = formatCase(applicationContext, {
+      ...mockCaseDetail,
+      documents: [
+        {
+          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
+          documentTitle: 'Order [Judge Name] [Anything]',
+          documentType: 'OAJ - Order that case is assigned',
+          eventCode: 'OAJ',
+          scenario: 'Type B',
+        },
+      ],
+      docketRecord: [
+        {
+          createdAt: getDateISO(),
+          documentId: '47d9735b-ac41-4adf-8a3c-74d73d3622fb',
+          filingDate: getDateISO(),
+          index: '1',
+        },
+      ],
+    });
+
+    expect(result).toHaveProperty('docketRecordWithDocument');
+    expect(
+      result.docketRecordWithDocument[0].record.createdAtFormatted,
+    ).toBeUndefined();
+  });
+
   it('should format respondents if the respondents array is set', () => {
     const result = formatCase(applicationContext, {
       ...mockCaseDetail,

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
@@ -11,7 +11,7 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  * @param {object} providers.store the cerebral store
  */
-export const setCourtIssuedDocumentInitialTypeAction = ({
+export const setCourtIssuedDocumentInitialDataAction = ({
   applicationContext,
   get,
   props,
@@ -32,6 +32,10 @@ export const setCourtIssuedDocumentInitialTypeAction = ({
     if (selectedDocumentTypeValues) {
       store.set(state.form, selectedDocumentTypeValues);
       store.set(state.form.attachments, false);
+    }
+
+    if (document.freeText) {
+      store.set(state.form.freeText, document.freeText);
     }
   }
 };

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.test.js
@@ -2,25 +2,33 @@ import { MOCK_CASE } from '../../../../../shared/src/test/mockCase';
 import { applicationContext } from '../../../applicationContext';
 import { presenter } from '../../presenter';
 import { runAction } from 'cerebral/test';
-import { setCourtIssuedDocumentInitialTypeAction } from './setCourtIssuedDocumentInitialTypeAction';
+import { setCourtIssuedDocumentInitialDataAction } from './setCourtIssuedDocumentInitialDataAction';
 
 presenter.providers.applicationContext = applicationContext;
 
-const documentId = 'ddfd978d-6be6-4877-b004-2b5735a41fee';
+const documentIds = [
+  'ddfd978d-6be6-4877-b004-2b5735a41fee',
+  '11597d22-0874-4c5e-ac98-a843d1472baf',
+];
 
 MOCK_CASE.documents.push({
-  documentId,
+  documentId: documentIds[0],
   eventCode: 'OF',
 });
+MOCK_CASE.documents.push({
+  documentId: documentIds[1],
+  eventCode: 'O',
+  freeText: 'something',
+});
 
-describe('setCourtIssuedDocumentInitialTypeAction', () => {
+describe('setCourtIssuedDocumentInitialDataAction', () => {
   it('should set correct values on state.form for the documentId passed in via props', async () => {
-    const result = await runAction(setCourtIssuedDocumentInitialTypeAction, {
+    const result = await runAction(setCourtIssuedDocumentInitialDataAction, {
       modules: {
         presenter,
       },
       props: {
-        documentId,
+        documentId: documentIds[0],
       },
       state: {
         caseDetail: MOCK_CASE,
@@ -37,8 +45,32 @@ describe('setCourtIssuedDocumentInitialTypeAction', () => {
     });
   });
 
+  it('should set state.form.freeText if the selected document has a freeText property', async () => {
+    const result = await runAction(setCourtIssuedDocumentInitialDataAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        documentId: documentIds[1],
+      },
+      state: {
+        caseDetail: MOCK_CASE,
+        form: {},
+      },
+    });
+
+    expect(result.state.form).toEqual({
+      attachments: false,
+      documentTitle: 'Order [Anything]',
+      documentType: 'O - Order',
+      eventCode: 'O',
+      freeText: 'something',
+      scenario: 'Type A',
+    });
+  });
+
   it('should not set state.form if the documentId cannot be found in caseDetail', async () => {
-    const result = await runAction(setCourtIssuedDocumentInitialTypeAction, {
+    const result = await runAction(setCourtIssuedDocumentInitialDataAction, {
       modules: {
         presenter,
       },
@@ -55,7 +87,7 @@ describe('setCourtIssuedDocumentInitialTypeAction', () => {
   });
 
   it("should not set state.form if the selected document's eventCode is not found in the court-issued document list", async () => {
-    const result = await runAction(setCourtIssuedDocumentInitialTypeAction, {
+    const result = await runAction(setCourtIssuedDocumentInitialDataAction, {
       modules: {
         presenter,
       },

--- a/web-client/src/presenter/sequences/gotoAddCourtIssuedDocketEntrySequence.js
+++ b/web-client/src/presenter/sequences/gotoAddCourtIssuedDocketEntrySequence.js
@@ -1,4 +1,5 @@
 import { clearFormAction } from '../actions/clearFormAction';
+import { generateCourtIssuedDocumentTitleAction } from '../actions/CourtIssuedDocketEntry/generateCourtIssuedDocumentTitleAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getUsersInSectionAction } from '../actions/getUsersInSectionAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
@@ -6,7 +7,7 @@ import { redirectToCognitoAction } from '../actions/redirectToCognitoAction';
 import { set } from 'cerebral/factories';
 import { setBaseUrlAction } from '../actions/setBaseUrlAction';
 import { setCaseAction } from '../actions/setCaseAction';
-import { setCourtIssuedDocumentInitialTypeAction } from '../actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialTypeAction';
+import { setCourtIssuedDocumentInitialDataAction } from '../actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setDocumentIdAction } from '../actions/setDocumentIdAction';
 import { setUsersByKeyAction } from '../actions/setUsersByKeyAction';
@@ -26,7 +27,8 @@ export const gotoAddCourtIssuedDocketEntrySequence = [
       getCaseAction,
       setCaseAction,
       setDocumentIdAction,
-      setCourtIssuedDocumentInitialTypeAction,
+      setCourtIssuedDocumentInitialDataAction,
+      generateCourtIssuedDocumentTitleAction,
       set(state.isEditingDocketEntry, false),
       setCurrentPageAction('CourtIssuedDocketEntry'),
     ],


### PR DESCRIPTION
* Fix for test scenario 4a: Set freeText on document when creating a generic order
* Fix for test scenario 12: don't show filed date on docket record for in-progress court-issued docs
