### PR TITLE
2380: UX review fix; deep freeze constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6860,6 +6860,12 @@
         "lodash.isplainobject": "^4.0.6"
       }
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "core-js": "^3.4.0",
     "csv-parse": "^4.8.2",
     "cypress": "^3.6.0",
+    "deep-freeze": "0.0.1",
     "dynamodb-admin": "^3.1.3",
     "elasticsearch": "^16.5.0",
     "eslint": "^6.6.0",

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -205,6 +205,7 @@ import { verifyCaseForUserInteractor } from '../../shared/src/proxies/verifyCase
 import { verifyPendingCaseForUserInteractor } from '../../shared/src/proxies/verifyPendingCaseForUserProxy';
 import { virusScanPdfInteractor } from '../../shared/src/proxies/documents/virusScanPdfProxy';
 import axios from 'axios';
+import deepFreeze from 'deep-freeze';
 import pdfjsLib from 'pdfjs-dist';
 import uuidv4 from 'uuid/v4';
 
@@ -396,40 +397,43 @@ const applicationContext = {
       'https://auth-dev-flexion-efcms.auth.us-east-1.amazoncognito.com/oauth2/token'
     );
   },
-  getConstants: () => ({
-    BUSINESS_TYPES: ContactFactory.BUSINESS_TYPES,
-    CASE_CAPTION_POSTFIX: Case.CASE_CAPTION_POSTFIX,
-    CASE_SEARCH_PAGE_SIZE: CaseSearch.CASE_SEARCH_PAGE_SIZE,
-    CATEGORIES: Document.CATEGORIES,
-    CATEGORY_MAP: Document.CATEGORY_MAP,
-    CHAMBERS_SECTION,
-    CHAMBERS_SECTIONS,
-    COUNTRY_TYPES: ContactFactory.COUNTRY_TYPES,
-    COURT_ISSUED_EVENT_CODES: Document.COURT_ISSUED_EVENT_CODES,
-    ESTATE_TYPES: ContactFactory.ESTATE_TYPES,
-    INTERNAL_CATEGORY_MAP: Document.INTERNAL_CATEGORY_MAP,
-    MAX_FILE_SIZE_BYTES,
-    MAX_FILE_SIZE_MB,
-    ORDER_TYPES_MAP: Order.ORDER_TYPES,
-    OTHER_TYPES: ContactFactory.OTHER_TYPES,
-    PARTY_TYPES: ContactFactory.PARTY_TYPES,
-    REFRESH_INTERVAL: 20 * MINUTES,
-    ROLE_PERMISSIONS,
-    SECTIONS,
-    SESSION_DEBOUNCE: 250,
-    SESSION_MODAL_TIMEOUT: 5 * MINUTES, // 5 minutes
-    SESSION_TIMEOUT:
-      (process.env.SESSION_TIMEOUT && parseInt(process.env.SESSION_TIMEOUT)) ||
-      55 * MINUTES, // 55 minutes
-    STATUS_TYPES: Case.STATUS_TYPES,
-    STATUS_TYPES_MANUAL_UPDATE: Case.STATUS_TYPES_MANUAL_UPDATE,
-    STATUS_TYPES_WITH_ASSOCIATED_JUDGE: Case.STATUS_TYPES_WITH_ASSOCIATED_JUDGE,
-    TRIAL_CITIES: TrialSession.TRIAL_CITIES,
-    TRIAL_SESSION_TYPES: TrialSession.SESSION_TYPES,
-    TRIAL_STATUS_TYPES: TrialSessionWorkingCopy.TRIAL_STATUS_TYPES,
-    US_STATES: ContactFactory.US_STATES,
-    USER_ROLES: User.ROLES,
-  }),
+  getConstants: () =>
+    deepFreeze({
+      BUSINESS_TYPES: ContactFactory.BUSINESS_TYPES,
+      CASE_CAPTION_POSTFIX: Case.CASE_CAPTION_POSTFIX,
+      CASE_SEARCH_PAGE_SIZE: CaseSearch.CASE_SEARCH_PAGE_SIZE,
+      CATEGORIES: Document.CATEGORIES,
+      CATEGORY_MAP: Document.CATEGORY_MAP,
+      CHAMBERS_SECTION,
+      CHAMBERS_SECTIONS,
+      COUNTRY_TYPES: ContactFactory.COUNTRY_TYPES,
+      COURT_ISSUED_EVENT_CODES: Document.COURT_ISSUED_EVENT_CODES,
+      ESTATE_TYPES: ContactFactory.ESTATE_TYPES,
+      INTERNAL_CATEGORY_MAP: Document.INTERNAL_CATEGORY_MAP,
+      MAX_FILE_SIZE_BYTES,
+      MAX_FILE_SIZE_MB,
+      ORDER_TYPES_MAP: Order.ORDER_TYPES,
+      OTHER_TYPES: ContactFactory.OTHER_TYPES,
+      PARTY_TYPES: ContactFactory.PARTY_TYPES,
+      REFRESH_INTERVAL: 20 * MINUTES,
+      ROLE_PERMISSIONS,
+      SECTIONS,
+      SESSION_DEBOUNCE: 250,
+      SESSION_MODAL_TIMEOUT: 5 * MINUTES, // 5 minutes
+      SESSION_TIMEOUT:
+        (process.env.SESSION_TIMEOUT &&
+          parseInt(process.env.SESSION_TIMEOUT)) ||
+        55 * MINUTES, // 55 minutes
+      STATUS_TYPES: Case.STATUS_TYPES,
+      STATUS_TYPES_MANUAL_UPDATE: Case.STATUS_TYPES_MANUAL_UPDATE,
+      STATUS_TYPES_WITH_ASSOCIATED_JUDGE:
+        Case.STATUS_TYPES_WITH_ASSOCIATED_JUDGE,
+      TRIAL_CITIES: TrialSession.TRIAL_CITIES,
+      TRIAL_SESSION_TYPES: TrialSession.SESSION_TYPES,
+      TRIAL_STATUS_TYPES: TrialSessionWorkingCopy.TRIAL_STATUS_TYPES,
+      US_STATES: ContactFactory.US_STATES,
+      USER_ROLES: User.ROLES,
+    }),
   getCurrentUser,
   getCurrentUserPermissions: () => {
     const user = getCurrentUser();

--- a/web-client/src/constants.test.js
+++ b/web-client/src/constants.test.js
@@ -1,0 +1,22 @@
+import { applicationContext } from './applicationContext';
+
+describe('frozen constants', () => {
+  it('should not be able to modify frozen constants', () => {
+    const constants = applicationContext.getConstants();
+    Object.keys(constants).forEach(key => {
+      if (Array.isArray(constants[key])) {
+        expect(() => constants[key].push({ something: true })).toThrow(
+          TypeError,
+        );
+      } else if (typeof constants[key] === 'object') {
+        expect(() => {
+          constants[key].something = true;
+        }).toThrow(TypeError);
+      } else {
+        expect(() => {
+          constants[key] = null;
+        }).toThrow(TypeError);
+      }
+    });
+  });
+});

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
@@ -30,7 +30,7 @@ export const setCourtIssuedDocumentInitialDataAction = ({
     );
 
     if (selectedDocumentTypeValues) {
-      store.set(state.form, selectedDocumentTypeValues);
+      store.set(state.form, { ...selectedDocumentTypeValues });
       store.set(state.form.attachments, false);
     }
 

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
@@ -30,7 +30,7 @@ export const setCourtIssuedDocumentInitialDataAction = ({
     );
 
     if (selectedDocumentTypeValues) {
-      store.set(state.form, { ...selectedDocumentTypeValues });
+      store.set(state.form, { ...selectedDocumentTypeValues }); //to prevent against modifying constants
       store.set(state.form.attachments, false);
     }
 

--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.js
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.js
@@ -1,7 +1,10 @@
 import { state } from 'cerebral';
 
-export const addCourtIssuedDocketEntryNonstandardHelper = get => {
-  const { COURT_ISSUED_EVENT_CODES } = get(state.constants);
+export const addCourtIssuedDocketEntryNonstandardHelper = (
+  get,
+  applicationContext,
+) => {
+  const { COURT_ISSUED_EVENT_CODES } = applicationContext.getConstants();
 
   const selectedEventCode = get(state.form.eventCode);
 

--- a/web-client/src/presenter/computeds/addDocketEntryHelper.js
+++ b/web-client/src/presenter/computeds/addDocketEntryHelper.js
@@ -36,11 +36,12 @@ export const addDocketEntryHelper = (get, applicationContext) => {
   const supportingDocumentTypeList = INTERNAL_CATEGORY_MAP[
     'Supporting Document'
   ].map(entry => {
-    entry.documentTypeDisplay = entry.documentType.replace(
+    const entryCopy = { ...entry };
+    entryCopy.documentTypeDisplay = entryCopy.documentType.replace(
       /\sin\sSupport$/i,
       '',
     );
-    return entry;
+    return entryCopy;
   });
 
   const objectionDocumentTypes = [

--- a/web-client/src/presenter/computeds/addDocketEntryHelper.js
+++ b/web-client/src/presenter/computeds/addDocketEntryHelper.js
@@ -18,6 +18,17 @@ const getInternalDocumentTypes = typeMap => {
   return orderBy(filteredTypeList, ['label'], ['asc']);
 };
 
+const getSupportingDocumentTypeList = categoryMap => {
+  return categoryMap['Supporting Document'].map(entry => {
+    const entryCopy = { ...entry }; //to prevent against modifying constants
+    entryCopy.documentTypeDisplay = entryCopy.documentType.replace(
+      /\sin\sSupport$/i,
+      '',
+    );
+    return entryCopy;
+  });
+};
+
 export const addDocketEntryHelper = (get, applicationContext) => {
   const { INTERNAL_CATEGORY_MAP, PARTY_TYPES } = get(state.constants);
   const caseDetail = get(state.caseDetail);
@@ -33,16 +44,9 @@ export const addDocketEntryHelper = (get, applicationContext) => {
 
   const internalDocumentTypes = getInternalDocumentTypes(INTERNAL_CATEGORY_MAP);
 
-  const supportingDocumentTypeList = INTERNAL_CATEGORY_MAP[
-    'Supporting Document'
-  ].map(entry => {
-    const entryCopy = { ...entry };
-    entryCopy.documentTypeDisplay = entryCopy.documentType.replace(
-      /\sin\sSupport$/i,
-      '',
-    );
-    return entryCopy;
-  });
+  const supportingDocumentTypeList = getSupportingDocumentTypeList(
+    INTERNAL_CATEGORY_MAP,
+  );
 
   const objectionDocumentTypes = [
     ...INTERNAL_CATEGORY_MAP['Motion'].map(entry => {

--- a/web-client/src/presenter/computeds/addDocketEntryHelper.js
+++ b/web-client/src/presenter/computeds/addDocketEntryHelper.js
@@ -18,7 +18,7 @@ const getInternalDocumentTypes = typeMap => {
   return orderBy(filteredTypeList, ['label'], ['asc']);
 };
 
-const getSupportingDocumentTypeList = categoryMap => {
+export const getSupportingDocumentTypeList = categoryMap => {
   return categoryMap['Supporting Document'].map(entry => {
     const entryCopy = { ...entry }; //to prevent against modifying constants
     entryCopy.documentTypeDisplay = entryCopy.documentType.replace(

--- a/web-client/src/presenter/computeds/fileDocumentHelper.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.js
@@ -20,11 +20,12 @@ export const fileDocumentHelper = (get, applicationContext) => {
 
   const supportingDocumentTypeList = CATEGORY_MAP['Supporting Document'].map(
     entry => {
-      entry.documentTypeDisplay = entry.documentType.replace(
+      const entryCopy = { ...entry };
+      entryCopy.documentTypeDisplay = entryCopy.documentType.replace(
         /\sin\sSupport$/i,
         '',
       );
-      return entry;
+      return entryCopy;
     },
   );
 

--- a/web-client/src/presenter/computeds/fileDocumentHelper.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.js
@@ -1,3 +1,4 @@
+import { getSupportingDocumentTypeList } from './addDocketEntryHelper';
 import { state } from 'cerebral';
 
 export const supportingDocumentFreeTextTypes = [
@@ -18,15 +19,8 @@ export const fileDocumentHelper = (get, applicationContext) => {
     caseDetail.partyType === PARTY_TYPES.petitionerSpouse ||
     caseDetail.partyType === PARTY_TYPES.petitionerDeceasedSpouse;
 
-  const supportingDocumentTypeList = CATEGORY_MAP['Supporting Document'].map(
-    entry => {
-      const entryCopy = { ...entry };
-      entryCopy.documentTypeDisplay = entryCopy.documentType.replace(
-        /\sin\sSupport$/i,
-        '',
-      );
-      return entryCopy;
-    },
+  const supportingDocumentTypeList = getSupportingDocumentTypeList(
+    CATEGORY_MAP,
   );
 
   const objectionDocumentTypes = [


### PR DESCRIPTION
We found through debugging this issue that our constants were able to be modified. Using deep-freeze will disable modification of the constants. 
~This will only work when constants are retrieved using `applicationContext.getConstants()`, so we should probably refactor to use that everywhere rather than retrieving the constants from the state. A Trello card for this already exists.~ < I think this part is false. Still kind of trying to figure that out.