### PR TITLE
Remove layer pruning from plugin, solely use SLS retention

### DIFF
--- a/web-api/serverless-clamav.yml
+++ b/web-api/serverless-clamav.yml
@@ -9,7 +9,6 @@ custom:
   region: ${opt:region, 'us-east-1'}
   prune:
     automatic: true
-    includeLayers: true
     number: 3
   jetpack:
     mode: yarn

--- a/web-api/serverless-puppeteer.yml
+++ b/web-api/serverless-puppeteer.yml
@@ -8,7 +8,6 @@ custom:
   region: ${opt:region, 'us-east-1'}
   prune:
     automatic: true
-    includeLayers: true
     number: 3
 
 provider:


### PR DESCRIPTION
**Theory**: Serverless's new-ish retention logic may be conflicting with the `serverless-prune-plugin`'s logic for retaining the last X layers. Serverless retains the last 10 layer versions by default, whereas we've been retaining the last 3 with the prune plugin, which is ran _after_ Serverless's retention logic.