### PR TITLE
Hourly Deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ workflows:
             - deploy-api-east
     triggers:
       - schedule:
-          cron: '0,30 12-23 * * 1-5'
+          cron: '0 12-23 * * 1-5'
           filters:
             branches:
               only:


### PR DESCRIPTION
Going back to hourly deploys due to ClamAV layer deployment taking a while.