### PR TITLE
Show action url for unserved court issued docs per permission

### DIFF
--- a/web-client/src/presenter/computeds/docketRecordHelper.js
+++ b/web-client/src/presenter/computeds/docketRecordHelper.js
@@ -11,7 +11,10 @@ export const docketRecordHelper = get => {
     ['CaseDetail'].includes(currentPage) &&
     userAssociatedWithCase;
 
+  const canShowEditDocketEntryLink = permissions.DOCKET_ENTRY;
+
   return {
+    canShowEditDocketEntryLink,
     showDirectDownloadLink,
     showDocumentDetailLink: !showDirectDownloadLink,
     showEditDocketEntry: permissions.DOCKET_ENTRY,

--- a/web-client/src/presenter/computeds/docketRecordHelper.test.js
+++ b/web-client/src/presenter/computeds/docketRecordHelper.test.js
@@ -142,4 +142,32 @@ describe('docket record helper', () => {
     });
     expect(result.showFileDocumentButton).toEqual(false);
   });
+
+  it('should allow the actionable docket entry link to be displayed for user roles that have the DOCKET_ENTRY permissions', async () => {
+    let result = runCompute(docketRecordHelper, {
+      state: {
+        caseDetail: {},
+        currentPage: 'CaseDetail',
+        form: {},
+        permissions: {
+          DOCKET_ENTRY: false,
+        },
+        screenMetadata: { isAssociated: false },
+      },
+    });
+    expect(result.canShowEditDocketEntryLink).toEqual(false);
+
+    result = runCompute(docketRecordHelper, {
+      state: {
+        caseDetail: {},
+        currentPage: 'CaseDetail',
+        form: {},
+        permissions: {
+          DOCKET_ENTRY: true,
+        },
+        screenMetadata: { isAssociated: false },
+      },
+    });
+    expect(result.canShowEditDocketEntryLink).toEqual(true);
+  });
 });

--- a/web-client/src/views/DocketRecord/FilingsAndProceedings.jsx
+++ b/web-client/src/views/DocketRecord/FilingsAndProceedings.jsx
@@ -39,40 +39,42 @@ export const FilingsAndProceedings = connect(
     ) => {
       return (
         <React.Fragment>
-          {caseDetailHelper.userHasAccessToCase && !document.isInProgress && (
-            <React.Fragment>
-              <NonMobile>
-                <a
-                  aria-label={`View PDF: ${description}`}
-                  href={`${baseUrl}/documents/${documentId}/document-download-url?token=${token}`}
-                  rel="noreferrer noopener"
-                  target="_blank"
-                >
-                  {isPaper && (
-                    <span className="filing-type-icon-mobile">
-                      <FontAwesomeIcon icon={['fas', 'file-alt']} />
-                    </span>
-                  )}
-                  {description}
-                </a>
-              </NonMobile>
-              <Mobile>
-                <Button
-                  link
-                  aria-roledescription="button to view document details"
-                  className="padding-0 border-0"
-                  onClick={() => {
-                    showDocketRecordDetailModalSequence({
-                      docketRecordIndex,
-                      showModal: 'DocketRecordOverlay',
-                    });
-                  }}
-                >
-                  {description}
-                </Button>
-              </Mobile>
-            </React.Fragment>
-          )}
+          {caseDetailHelper.userHasAccessToCase &&
+            !document.isInProgress &&
+            !document.isNotServedCourtIssuedDocument && (
+              <React.Fragment>
+                <NonMobile>
+                  <a
+                    aria-label={`View PDF: ${description}`}
+                    href={`${baseUrl}/documents/${documentId}/document-download-url?token=${token}`}
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    {isPaper && (
+                      <span className="filing-type-icon-mobile">
+                        <FontAwesomeIcon icon={['fas', 'file-alt']} />
+                      </span>
+                    )}
+                    {description}
+                  </a>
+                </NonMobile>
+                <Mobile>
+                  <Button
+                    link
+                    aria-roledescription="button to view document details"
+                    className="padding-0 border-0"
+                    onClick={() => {
+                      showDocketRecordDetailModalSequence({
+                        docketRecordIndex,
+                        showModal: 'DocketRecordOverlay',
+                      });
+                    }}
+                  >
+                    {description}
+                  </Button>
+                </Mobile>
+              </React.Fragment>
+            )}
           {(!caseDetailHelper.userHasAccessToCase || document.isInProgress) &&
             description}
         </React.Fragment>

--- a/web-client/src/views/DocketRecord/FilingsAndProceedings.jsx
+++ b/web-client/src/views/DocketRecord/FilingsAndProceedings.jsx
@@ -107,29 +107,38 @@ export const FilingsAndProceedings = connect(
             </React.Fragment>
           )}
 
-        {document && docketRecordHelper.showDocumentDetailLink && (
-          <a
-            aria-label="View PDF"
-            href={documentEditLinkHelper({
-              docketNumber: formattedCaseDetail.docketNumber,
-              documentId: document.documentId,
-              shouldLinkToComplete: document.isFileAttached === false,
-              shouldLinkToEdit:
-                docketRecordHelper.showEditDocketEntry && document.canEdit,
-              shouldLinkToEditCourtIssued:
-                docketRecordHelper.showEditDocketEntry &&
-                document.isCourtIssuedDocument,
-              shouldLinkedToDetails: !!document.servedAt,
-            })}
-          >
-            {document && document.isPaper && (
-              <span className="filing-type-icon-mobile">
-                <FontAwesomeIcon icon={['fas', 'file-alt']} />
-              </span>
-            )}
-            {document.documentTitle || record.description}
-          </a>
-        )}
+        {document &&
+          docketRecordHelper.showDocumentDetailLink &&
+          (!document.isNotServedCourtIssuedDocument ||
+            (document.isNotServedCourtIssuedDocument &&
+              docketRecordHelper.canShowEditDocketEntryLink)) && (
+            <a
+              aria-label="View PDF"
+              href={documentEditLinkHelper({
+                docketNumber: formattedCaseDetail.docketNumber,
+                documentId: document.documentId,
+                shouldLinkToComplete: document.isFileAttached === false,
+                shouldLinkToEdit:
+                  docketRecordHelper.showEditDocketEntry && document.canEdit,
+                shouldLinkToEditCourtIssued:
+                  docketRecordHelper.showEditDocketEntry &&
+                  document.isCourtIssuedDocument,
+                shouldLinkedToDetails: !!document.servedAt,
+              })}
+            >
+              {document && document.isPaper && (
+                <span className="filing-type-icon-mobile">
+                  <FontAwesomeIcon icon={['fas', 'file-alt']} />
+                </span>
+              )}
+              {document.documentTitle || record.description}
+            </a>
+          )}
+
+        {document &&
+          document.isNotServedCourtIssuedDocument &&
+          !docketRecordHelper.canShowEditDocketEntryLink &&
+          (document.documentTitle || record.description)}
 
         <span> {record.signatory}</span>
 


### PR DESCRIPTION
You should only see an unserved, court-issued document's actionable link in the docket record if you have the `DOCKET_ENTRY` permission.