### PR TITLE
Devex document filedby

### DIFF
--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -87,6 +87,8 @@ function Document(rawDocument, { applicationContext }) {
   this.workItems = (this.workItems || []).map(
     workItem => new WorkItem(workItem, { applicationContext }),
   );
+
+  this.generateFiledBy(rawDocument);
 }
 
 const practitionerAssociationDocumentTypes = [
@@ -301,42 +303,36 @@ Document.prototype.setAsServed = function(servedParties = null) {
  * @param {object} caseDetail the case detail
  */
 Document.prototype.generateFiledBy = function(caseDetail) {
-  if (!this.filedBy) {
-    let filedByArray = [];
-    this.partyRespondent && filedByArray.push('Resp.');
+  let filedByArray = [];
+  this.partyRespondent && filedByArray.push('Resp.');
 
-    Array.isArray(this.practitioner) &&
-      this.practitioner.forEach(practitioner => {
-        practitioner.partyPractitioner &&
-          filedByArray.push(`Counsel ${practitioner.name}`);
-      });
+  Array.isArray(this.practitioner) &&
+    this.practitioner.forEach(practitioner => {
+      practitioner.partyPractitioner &&
+        filedByArray.push(`Counsel ${practitioner.name}`);
+    });
 
-    if (
-      this.partyPrimary &&
-      !this.partySecondary &&
-      caseDetail.contactPrimary
-    ) {
-      filedByArray.push(`Petr. ${caseDetail.contactPrimary.name}`);
-    } else if (
-      this.partySecondary &&
-      !this.partyPrimary &&
-      caseDetail.contactSecondary
-    ) {
-      filedByArray.push(`Petr. ${caseDetail.contactSecondary.name}`);
-    } else if (
-      this.partyPrimary &&
-      this.partySecondary &&
-      caseDetail.contactPrimary &&
-      caseDetail.contactSecondary
-    ) {
-      filedByArray.push(
-        `Petrs. ${caseDetail.contactPrimary.name} & ${caseDetail.contactSecondary.name}`,
-      );
-    }
+  if (this.partyPrimary && !this.partySecondary && caseDetail.contactPrimary) {
+    filedByArray.push(`Petr. ${caseDetail.contactPrimary.name}`);
+  } else if (
+    this.partySecondary &&
+    !this.partyPrimary &&
+    caseDetail.contactSecondary
+  ) {
+    filedByArray.push(`Petr. ${caseDetail.contactSecondary.name}`);
+  } else if (
+    this.partyPrimary &&
+    this.partySecondary &&
+    caseDetail.contactPrimary &&
+    caseDetail.contactSecondary
+  ) {
+    filedByArray.push(
+      `Petrs. ${caseDetail.contactPrimary.name} & ${caseDetail.contactSecondary.name}`,
+    );
+  }
 
-    if (filedByArray.length) {
-      this.filedBy = filedByArray.join(' & ');
-    }
+  if (filedByArray.length) {
+    this.filedBy = filedByArray.join(' & ');
   }
 };
 /**

--- a/shared/src/business/entities/Document.test.js
+++ b/shared/src/business/entities/Document.test.js
@@ -472,6 +472,260 @@ describe('Document entity', () => {
       document.generateFiledBy(caseDetail);
       expect(document.filedBy).toEqual('Resp. & Counsel Test Practitioner1');
     });
+
+    it('should generate correct filedBy string for partyPrimary in the constructor when called with a contactPrimary property', () => {
+      const document = new Document(
+        {
+          attachments: false,
+          category: 'Petition',
+          certificateOfService: false,
+          contactPrimary: caseDetail.contactPrimary,
+          createdAt: '2019-04-19T17:29:13.120Z',
+          documentId: '88cd2c25-b8fa-4dc0-bfb6-57245c86bb0d',
+          documentTitle: 'Amended Petition',
+          documentType: 'Amended Petition',
+          eventCode: 'PAP',
+          exhibits: false,
+          hasSupportingDocuments: true,
+          objections: 'No',
+          partyPrimary: true,
+          relationship: 'primaryDocument',
+          scenario: 'Standard',
+          supportingDocument:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          supportingDocumentFreeText: 'Test',
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Petr. Bob');
+    });
+
+    it('should generate correct filedBy string for partySecondary in the constructor when called with a contactSecondary property', () => {
+      const document = new Document(
+        {
+          attachments: false,
+          category: 'Petition',
+          certificateOfService: false,
+          contactSecondary: caseDetail.contactSecondary,
+          createdAt: '2019-04-19T17:29:13.120Z',
+          documentId: '88cd2c25-b8fa-4dc0-bfb6-57245c86bb0d',
+          documentTitle: 'Amended Petition',
+          documentType: 'Amended Petition',
+          eventCode: 'PAP',
+          exhibits: false,
+          hasSupportingDocuments: true,
+          objections: 'No',
+          partyPrimary: false,
+          partySecondary: true,
+          relationship: 'primaryDocument',
+          scenario: 'Standard',
+          supportingDocument:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          supportingDocumentFreeText: 'Test',
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Petr. Bill');
+    });
+
+    it('should generate correct filedBy string for partyPrimary and partyRespondent in the constructor when values are present', () => {
+      const document = new Document(
+        {
+          attachments: false,
+          category: 'Miscellaneous',
+          certificateOfService: false,
+          createdAt: '2019-04-19T18:24:09.515Z',
+          documentId: 'c501a558-7632-497e-87c1-0c5f39f66718',
+          documentTitle:
+            'First Amended Unsworn Declaration under Penalty of Perjury in Support',
+          documentType: 'Amended',
+          eventCode: 'ADED',
+          exhibits: true,
+          hasSupportingDocuments: true,
+          ordinalValue: 'First',
+          partyPrimary: true,
+          partyRespondent: true,
+          previousDocument:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          relationship: 'primaryDocument',
+          scenario: 'Nonstandard F',
+          supportingDocument: 'Brief in Support',
+          supportingDocumentFreeText: null,
+          ...caseDetail,
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Resp. & Petr. Bob');
+    });
+
+    it('should generate correct filedBy string for partyPrimary and partySecondary in the constructor when values are present', () => {
+      const document = new Document(
+        {
+          attachments: true,
+          category: 'Motion',
+          certificateOfService: true,
+          certificateOfServiceDate: '2018-06-07',
+          certificateOfServiceDay: '7',
+          certificateOfServiceMonth: '6',
+          certificateOfServiceYear: '2018',
+          createdAt: '2019-04-19T17:39:10.476Z',
+          documentId: '362baeaf-7692-4b04-878b-2946dcfa26ee',
+          documentTitle:
+            'Motion for Leave to File Computation for Entry of Decision',
+          documentType: 'Motion for Leave to File',
+          eventCode: 'M115',
+          exhibits: true,
+          hasSecondarySupportingDocuments: false,
+          hasSupportingDocuments: true,
+          objections: 'Yes',
+          partyPrimary: true,
+          partySecondary: true,
+          relationship: 'primaryDocument',
+          scenario: 'Nonstandard H',
+          secondarySupportingDocument: null,
+          secondarySupportingDocumentFreeText: null,
+          supportingDocument: 'Declaration in Support',
+          supportingDocumentFreeText: 'Rachael',
+          ...caseDetail,
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Petrs. Bob & Bill');
+    });
+
+    it('should generate correct filedBy string for partyRespondent and partyPractitioner in the constructor when values are present', () => {
+      const document = new Document(
+        {
+          category: 'Supporting Document',
+          createdAt: '2019-04-19T17:29:13.122Z',
+          documentId: '3ac23dd8-b0c4-4538-86e1-52b715f54838',
+          documentTitle:
+            'Unsworn Declaration of Test under Penalty of Perjury in Support of Amended Petition',
+          documentType:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          eventCode: 'USDL',
+          freeText: 'Test',
+          lodged: true,
+          partyPractitioner: true,
+          partyRespondent: true,
+          practitioner: [
+            {
+              name: 'Test Practitioner',
+              partyPractitioner: true,
+            },
+          ],
+          previousDocument: 'Amended Petition',
+          relationship: 'primarySupportingDocument',
+          scenario: 'Nonstandard C',
+          ...caseDetail,
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Resp. & Counsel Test Practitioner');
+    });
+
+    it('should generate correct filedBy string for partyRespondent and partyPractitioner set to false in the constructor when values are present', () => {
+      const document = new Document(
+        {
+          category: 'Supporting Document',
+          createdAt: '2019-04-19T17:29:13.122Z',
+          documentId: '3ac23dd8-b0c4-4538-86e1-52b715f54838',
+          documentTitle:
+            'Unsworn Declaration of Test under Penalty of Perjury in Support of Amended Petition',
+          documentType:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          eventCode: 'USDL',
+          freeText: 'Test',
+          lodged: true,
+          partyPractitioner: true,
+          partyRespondent: true,
+          practitioner: [
+            {
+              name: 'Test Practitioner',
+              partyPractitioner: false,
+            },
+          ],
+          previousDocument: 'Amended Petition',
+          relationship: 'primarySupportingDocument',
+          scenario: 'Nonstandard C',
+          ...caseDetail,
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Resp.');
+    });
+
+    it('should generate correct filedBy string for partyRespondent and multiple partyPractitioners in the constructor when values are present', () => {
+      const document = new Document(
+        {
+          category: 'Supporting Document',
+          createdAt: '2019-04-19T17:29:13.122Z',
+          documentId: '3ac23dd8-b0c4-4538-86e1-52b715f54838',
+          documentTitle:
+            'Unsworn Declaration of Test under Penalty of Perjury in Support of Amended Petition',
+          documentType:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          eventCode: 'USDL',
+          freeText: 'Test',
+          lodged: true,
+          partyPractitioner: true,
+          partyRespondent: true,
+          practitioner: [
+            {
+              name: 'Test Practitioner',
+              partyPractitioner: true,
+            },
+            {
+              name: 'Test Practitioner1',
+              partyPractitioner: true,
+            },
+          ],
+          previousDocument: 'Amended Petition',
+          relationship: 'primarySupportingDocument',
+          scenario: 'Nonstandard C',
+          ...caseDetail,
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual(
+        'Resp. & Counsel Test Practitioner & Counsel Test Practitioner1',
+      );
+    });
+
+    it('should generate correct filedBy string for partyRespondent and multiple partyPractitioners with one set to false in the constructor when values are present', () => {
+      const document = new Document(
+        {
+          category: 'Supporting Document',
+          createdAt: '2019-04-19T17:29:13.122Z',
+          documentId: '3ac23dd8-b0c4-4538-86e1-52b715f54838',
+          documentTitle:
+            'Unsworn Declaration of Test under Penalty of Perjury in Support of Amended Petition',
+          documentType:
+            'Unsworn Declaration under Penalty of Perjury in Support',
+          eventCode: 'USDL',
+          freeText: 'Test',
+          lodged: true,
+          partyPractitioner: true,
+          partyRespondent: true,
+          practitioner: [
+            {
+              name: 'Test Practitioner',
+              partyPractitioner: false,
+            },
+            {
+              name: 'Test Practitioner1',
+              partyPractitioner: true,
+            },
+          ],
+          previousDocument: 'Amended Petition',
+          relationship: 'primarySupportingDocument',
+          scenario: 'Nonstandard C',
+          ...caseDetail,
+        },
+        { applicationContext },
+      );
+      expect(document.filedBy).toEqual('Resp. & Counsel Test Practitioner1');
+    });
   });
 
   describe('unsignDocument', () => {

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -1186,4 +1186,32 @@ Case.prototype.setCaseTitle = function(caseCaption) {
   return this;
 };
 
+/**
+ * get case contacts
+ *
+ * @returns {object} object containing case contacts
+ * @param shape
+ */
+Case.prototype.getCaseContacts = function(shape = {}) {
+  const caseContacts = {};
+
+  if (this.contactPrimary && shape.contactPrimary) {
+    caseContacts.contactPrimary = this.contactPrimary;
+  }
+
+  if (this.contactSecondary && shape.contactSecondary) {
+    caseContacts.contactPrimary = this.contactSecondary;
+  }
+
+  if (this.practitioners && shape.practitioners) {
+    caseContacts.practitioners = this.practitioners;
+  }
+
+  if (this.respondents && shape.respondents) {
+    caseContacts.respondents = this.respondents;
+  }
+
+  return caseContacts;
+};
+
 module.exports = { Case };

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -1190,26 +1190,20 @@ Case.prototype.setCaseTitle = function(caseCaption) {
  * get case contacts
  *
  * @returns {object} object containing case contacts
- * @param shape
+ * @param shape specific contact params to be returned
  */
-Case.prototype.getCaseContacts = function(shape = {}) {
+Case.prototype.getCaseContacts = function(shape) {
   const caseContacts = {};
-
-  if (this.contactPrimary && shape.contactPrimary) {
-    caseContacts.contactPrimary = this.contactPrimary;
-  }
-
-  if (this.contactSecondary && shape.contactSecondary) {
-    caseContacts.contactPrimary = this.contactSecondary;
-  }
-
-  if (this.practitioners && shape.practitioners) {
-    caseContacts.practitioners = this.practitioners;
-  }
-
-  if (this.respondents && shape.respondents) {
-    caseContacts.respondents = this.respondents;
-  }
+  [
+    'contactPrimary',
+    'contactSecondary',
+    'practitioners',
+    'respondents',
+  ].forEach(contact => {
+    if (!shape || (shape && shape[contact] === true)) {
+      caseContacts[contact] = this[contact];
+    }
+  });
 
   return caseContacts;
 };

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -1926,7 +1926,7 @@ describe('Case entity', () => {
       });
     });
 
-    fit('should return an object contacts matching the `shape` if provided', () => {
+    it('should return an object contacts matching the `shape` if provided', () => {
       const testCase = new Case(
         {
           ...MOCK_CASE,

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -1882,4 +1882,72 @@ describe('Case entity', () => {
       );
     });
   });
+
+  describe('getCaseContacts', () => {
+    const contactPrimary = {
+      name: 'Test Petitioner',
+      title: 'Executor',
+    };
+
+    const contactSecondary = { name: 'Contact Secondary' };
+
+    const practitioners = [
+      {
+        name: 'Petitioner One',
+      },
+    ];
+
+    const respondents = [
+      {
+        name: 'Respondent One',
+      },
+    ];
+
+    it('should return an object containing all contact types', () => {
+      const testCase = new Case(
+        {
+          ...MOCK_CASE,
+          contactPrimary,
+          contactSecondary,
+          practitioners,
+          respondents,
+        },
+        {
+          applicationContext,
+        },
+      );
+
+      const caseContacts = testCase.getCaseContacts();
+      expect(caseContacts).toMatchObject({
+        contactPrimary,
+        contactSecondary,
+        practitioners,
+        respondents,
+      });
+    });
+
+    fit('should return an object contacts matching the `shape` if provided', () => {
+      const testCase = new Case(
+        {
+          ...MOCK_CASE,
+          contactPrimary,
+          contactSecondary,
+          practitioners,
+          respondents,
+        },
+        {
+          applicationContext,
+        },
+      );
+
+      const caseContacts = testCase.getCaseContacts({
+        contactPrimary: true,
+        contactSecondary: true,
+      });
+      expect(caseContacts).toMatchObject({
+        contactPrimary,
+        contactSecondary,
+      });
+    });
+  });
 });

--- a/shared/src/business/useCases/createCaseFromPaperInteractor.js
+++ b/shared/src/business/useCases/createCaseFromPaperInteractor.js
@@ -141,10 +141,13 @@ exports.createCaseFromPaperInteractor = async ({
       partySecondary,
       receivedAt: caseToAdd.receivedAt,
       userId: user.userId,
+      ...caseToAdd.getCaseContacts({
+        contactPrimary: true,
+        contactSecondary: true,
+      }),
     },
     { applicationContext },
   );
-  petitionDocumentEntity.generateFiledBy(caseToAdd);
 
   const {
     message: newMessage,
@@ -177,11 +180,14 @@ exports.createCaseFromPaperInteractor = async ({
         partySecondary,
         receivedAt: caseToAdd.receivedAt,
         userId: user.userId,
+        ...caseToAdd.getCaseContacts({
+          contactPrimary: true,
+          contactSecondary: true,
+        }),
       },
       { applicationContext },
     );
 
-    applicationForWaiverOfFilingFeeDocumentEntity.generateFiledBy(caseToAdd);
     caseToAdd.addDocument(applicationForWaiverOfFilingFeeDocumentEntity);
   }
 
@@ -210,10 +216,14 @@ exports.createCaseFromPaperInteractor = async ({
         partySecondary,
         receivedAt: caseToAdd.receivedAt,
         userId: user.userId,
+        ...caseToAdd.getCaseContacts({
+          contactPrimary: true,
+          contactSecondary: true,
+        }),
       },
       { applicationContext },
     );
-    requestForPlaceOfTrialDocumentEntity.generateFiledBy(caseToAdd);
+
     caseToAdd.addDocument(requestForPlaceOfTrialDocumentEntity);
   }
 
@@ -229,10 +239,14 @@ exports.createCaseFromPaperInteractor = async ({
         partySecondary,
         receivedAt: caseToAdd.receivedAt,
         userId: user.userId,
+        ...caseToAdd.getCaseContacts({
+          contactPrimary: true,
+          contactSecondary: true,
+        }),
       },
       { applicationContext },
     );
-    stinDocumentEntity.generateFiledBy(caseToAdd);
+
     caseToAdd.addDocumentWithoutDocketRecord(stinDocumentEntity);
   }
 
@@ -250,10 +264,14 @@ exports.createCaseFromPaperInteractor = async ({
         partySecondary,
         receivedAt: caseToAdd.receivedAt,
         userId: user.userId,
+        ...caseToAdd.getCaseContacts({
+          contactPrimary: true,
+          contactSecondary: true,
+        }),
       },
       { applicationContext },
     );
-    odsDocumentEntity.generateFiledBy(caseToAdd);
+
     caseToAdd.addDocument(odsDocumentEntity);
   }
 

--- a/shared/src/business/useCases/createCaseInteractor.js
+++ b/shared/src/business/useCases/createCaseInteractor.js
@@ -149,10 +149,14 @@ exports.createCaseInteractor = async ({
       partySecondary,
       practitioner: practitioners[0],
       userId: user.userId,
+      ...caseToAdd.getCaseContacts({
+        contactPrimary: true,
+        contactSecondary: true,
+      }),
     },
     { applicationContext },
   );
-  petitionDocumentEntity.generateFiledBy(caseToAdd);
+
   const newWorkItem = addPetitionDocumentToCase({
     applicationContext,
     caseToAdd,
@@ -178,10 +182,14 @@ exports.createCaseInteractor = async ({
       partySecondary,
       practitioner: practitioners[0],
       userId: user.userId,
+      ...caseToAdd.getCaseContacts({
+        contactPrimary: true,
+        contactSecondary: true,
+      }),
     },
     { applicationContext },
   );
-  stinDocumentEntity.generateFiledBy(caseToAdd);
+
   caseToAdd.addDocumentWithoutDocketRecord(stinDocumentEntity);
 
   if (ownershipDisclosureFileId) {
@@ -196,10 +204,14 @@ exports.createCaseInteractor = async ({
         partySecondary,
         practitioner: practitioners[0],
         userId: user.userId,
+        ...caseToAdd.getCaseContacts({
+          contactPrimary: true,
+          contactSecondary: true,
+        }),
       },
       { applicationContext },
     );
-    odsDocumentEntity.generateFiledBy(caseToAdd);
+
     caseToAdd.addDocument(odsDocumentEntity);
   }
 

--- a/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
@@ -103,10 +103,13 @@ exports.fileDocketEntryInteractor = async ({
           documentType: metadata.documentType,
           relationship,
           userId: user.userId,
+          ...caseToAdd.getCaseContacts({
+            contactPrimary: true,
+            contactSecondary: true,
+          }),
         },
         { applicationContext },
       );
-      documentEntity.generateFiledBy(caseToUpdate);
 
       const workItem = new WorkItem(
         {

--- a/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
@@ -103,7 +103,7 @@ exports.fileDocketEntryInteractor = async ({
           documentType: metadata.documentType,
           relationship,
           userId: user.userId,
-          ...caseToAdd.getCaseContacts({
+          ...caseEntity.getCaseContacts({
             contactPrimary: true,
             contactSecondary: true,
           }),

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryInteractor.js
@@ -54,10 +54,13 @@ exports.updateDocketEntryInteractor = async ({
       documentType: documentMetadata.documentType,
       relationship: 'primaryDocument',
       userId: user.userId,
+      ...caseEntity.getCaseContacts({
+        contactPrimary: true,
+        contactSecondary: true,
+      }),
     },
     { applicationContext },
   );
-  documentEntity.generateFiledBy(caseToUpdate);
 
   const docketRecordEntry = new DocketRecord({
     description: documentMetadata.documentTitle,

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
@@ -58,11 +58,14 @@ exports.completeDocketEntryQCInteractor = async ({
       documentType,
       relationship: 'primaryDocument',
       userId: user.userId,
+      ...caseEntity.getCaseContacts({
+        contactPrimary: true,
+        contactSecondary: true,
+      }),
     },
     { applicationContext },
   ).validate();
 
-  documentEntity.generateFiledBy(caseToUpdate);
   documentEntity.setQCed(user);
 
   const docketRecordEntry = new DocketRecord({

--- a/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.js
+++ b/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.js
@@ -113,10 +113,13 @@ exports.fileExternalDocumentInteractor = async ({
           documentType: metadata.documentType,
           relationship,
           userId: user.userId,
+          ...caseEntity.getCaseContacts({
+            contactPrimary: true,
+            contactSecondary: true,
+          }),
         },
         { applicationContext },
       );
-      documentEntity.generateFiledBy(caseToUpdate);
 
       const workItem = new WorkItem(
         {

--- a/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.js
+++ b/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.js
@@ -21,8 +21,16 @@ export const generatePrintableFilingReceiptAction = async ({
   const caseDetail = get(state.caseDetail);
 
   const getDocumentInfo = documentData => {
-    const document = new Document(documentData, { applicationContext });
-    document.generateFiledBy(caseDetail);
+    const document = new Document(
+      {
+        ...documentData,
+        ...caseDetail.getCaseContacts({
+          contactPrimary: true,
+          contactSecondary: true,
+        }),
+      },
+      { applicationContext },
+    );
     return {
       attachments: document.attachments,
       certificateOfService: document.certificateOfService,

--- a/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.js
+++ b/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.js
@@ -21,16 +21,8 @@ export const generatePrintableFilingReceiptAction = async ({
   const caseDetail = get(state.caseDetail);
 
   const getDocumentInfo = documentData => {
-    const document = new Document(
-      {
-        ...documentData,
-        ...caseDetail.getCaseContacts({
-          contactPrimary: true,
-          contactSecondary: true,
-        }),
-      },
-      { applicationContext },
-    );
+    const document = new Document(documentData, { applicationContext });
+    document.generateFiledBy(caseDetail);
     return {
       attachments: document.attachments,
       certificateOfService: document.certificateOfService,


### PR DESCRIPTION
Per DevEx task to remove the calling `generateFiledBy` every time we create a new document in an interactor, this keeps the method around and calls it in the constructor.

Considerations
- One instance of it being called separately in an action was left in place since raw case data from state was being consumed, which would need to be converted to a Case entity. I opted to leave this one here as the value of calling the method separately as it was originally intended seemed to outweigh bringing in the Case entity just to call this method.
- In order to generate the filedBy, you need access to Case contacts. I'm including these in the Document constructor params, assuming they should not persist when converting back to a raw object. I could also delete them as a follow up step when calling the generateFiledBy method if that is cleaner ¯\_(ツ)_/¯ 