### PR TITLE
dont rely on serverless layer retention, prune layers with plugin

### DIFF
--- a/web-api/serverless-clamav.yml
+++ b/web-api/serverless-clamav.yml
@@ -10,6 +10,7 @@ custom:
   prune:
     automatic: true
     number: 3
+    includeLayers: true
   jetpack:
     mode: yarn
 
@@ -31,4 +32,3 @@ layers:
     package:
       exclude:
         - clamav_lambda_layer.tar.gz
-    retain: true

--- a/web-api/serverless-puppeteer.yml
+++ b/web-api/serverless-puppeteer.yml
@@ -9,6 +9,7 @@ custom:
   prune:
     automatic: true
     number: 3
+    includeLayers: true
 
 provider:
   name: aws
@@ -29,4 +30,3 @@ layers:
     package:
       exclude:
         - puppeteer_lambda_layer.tar.gz
-    retain: true


### PR DESCRIPTION
For some reason, Serverless's `retain` policy isn't working as it should (or we misunderstood it?). Going to solely rely on pruning with `includeLayers` via `serverless-plugin-prune`.