### PR TITLE
2839 - fixing the name of the stack

### DIFF
--- a/web-api/serverless-public-api.yml
+++ b/web-api/serverless-public-api.yml
@@ -1,4 +1,4 @@
-service: ef-cms
+service: ef-cms-public
 
 plugins:
   - serverless-domain-manager


### PR DESCRIPTION
the API stack is overwriting this stack because they have the same service name.