### PR TITLE
3121: increase margin within sticky footer content

### DIFF
--- a/web-client/src/views/TrialSessionWorkingCopy/BatchDownloadProgress.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/BatchDownloadProgress.jsx
@@ -27,7 +27,7 @@ export const BatchDownloadProgress = connect(
       <div>
         <div className="sticky-footer sticky-footer--space" />
         <div className="sticky-footer sticky-footer--container">
-          <div className="usa-section grid-container padding-bottom-0">
+          <div className="usa-section grid-container padding-bottom-0 margin-top-1">
             <div aria-live="polite" className="progress-batch-download">
               <h3>Compressing Case Files</h3>
               <span className="progress-text">


### PR DESCRIPTION
Slightly increased space between the text "Compressing Case Files" and the grey border seen just above it per request of @alsmith1 

![Screen Shot 2019-12-03 at 5 05 07 PM](https://user-images.githubusercontent.com/2445917/70097538-42c81f80-15ef-11ea-9a5c-4848ed387518.png)
