### PR TITLE
40: display formatted docket record data in table

### DIFF
--- a/shared/src/business/entities/cases/PublicDocument.js
+++ b/shared/src/business/entities/cases/PublicDocument.js
@@ -11,13 +11,17 @@ const {
  */
 function PublicDocument(rawDocument) {
   this.caseId = rawDocument.caseId;
+  this.createdAt = rawDocument.createdAt;
   this.documentId = rawDocument.documentId;
+  this.documentType = rawDocument.documentType;
   this.eventCode = rawDocument.eventCode;
   this.filedBy = rawDocument.filedBy;
-  this.createdAt = rawDocument.createdAt;
-  this.receivedAt = rawDocument.receivedAt;
-  this.documentType = rawDocument.documentType;
+  this.isPaper = rawDocument.isPaper;
   this.processingStatus = rawDocument.processingStatus;
+  this.receivedAt = rawDocument.receivedAt;
+  this.servedAt = rawDocument.servedAt;
+  this.servedParties = rawDocument.servedParties;
+  this.status = rawDocument.status;
 }
 
 joiValidationDecorator(PublicDocument, joi.object(), undefined, {});

--- a/shared/src/business/entities/cases/PublicDocument.test.js
+++ b/shared/src/business/entities/cases/PublicDocument.test.js
@@ -9,8 +9,11 @@ describe('PublicDocument', () => {
       documentType: 'testing',
       eventCode: 'testing',
       filedBy: 'testing',
+      isPaper: true,
       processingStatus: 'testing',
       receivedAt: 'testing',
+      servedAt: '2019-03-01T21:40:46.415Z',
+      status: 'served',
     });
 
     expect(entity.toRawObject()).toEqual({
@@ -20,8 +23,11 @@ describe('PublicDocument', () => {
       documentType: 'testing',
       eventCode: 'testing',
       filedBy: 'testing',
+      isPaper: true,
       processingStatus: 'testing',
       receivedAt: 'testing',
+      servedAt: '2019-03-01T21:40:46.415Z',
+      status: 'served',
     });
   });
 });

--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -426,6 +426,8 @@ const getFormattedCaseDetail = ({
 module.exports = {
   formatCase,
   formatCaseDeadlines,
+  formatDocketRecord,
+  formatDocketRecordWithDocument,
   formatDocument,
   getFilingsAndProceedings,
   getFormattedCaseDetail,

--- a/web-client/src/applicationContextPublic.js
+++ b/web-client/src/applicationContextPublic.js
@@ -3,6 +3,10 @@ import { CaseSearch } from '../../shared/src/business/entities/cases/CaseSearch'
 import { ContactFactory } from '../../shared/src/business/entities/contacts/ContactFactory';
 import { casePublicSearchInteractor } from '../../shared/src/proxies/casePublicSearchProxy';
 import {
+  formatDocketRecord,
+  formatDocketRecordWithDocument,
+} from '../../shared/src/business/utilities/getFormattedCaseDetail';
+import {
   getCognitoLoginUrl,
   getPublicSiteUrl,
 } from '../../shared/src/sharedAppContext.js';
@@ -27,7 +31,6 @@ const applicationContextPublic = {
       COUNTRY_TYPES: ContactFactory.COUNTRY_TYPES,
       US_STATES: ContactFactory.US_STATES,
     }),
-
   getCurrentUserToken: () => null,
   getHttpClient: () => axios,
   getPublicSiteUrl,
@@ -40,6 +43,8 @@ const applicationContextPublic = {
     return {
       compareCasesByDocketNumber,
       formatDateString,
+      formatDocketRecord,
+      formatDocketRecordWithDocument,
     };
   },
 };

--- a/web-client/src/presenter/computeds/public/publicCaseDetailHelper.js
+++ b/web-client/src/presenter/computeds/public/publicCaseDetailHelper.js
@@ -1,17 +1,23 @@
 import { state } from 'cerebral';
 
-export const publicCaseDetailHelper = get => {
+export const publicCaseDetailHelper = (get, applicationContext) => {
   const publicCase = get(state.caseDetail);
 
-  const formatDocketRecord = docketRecord =>
-    docketRecord.map(entry => {
-      entry.showPaperIcon = !!(entry.document && entry.document.isPaper);
-      return entry;
-    });
   const formatCaseDetail = caseToFormat => caseToFormat;
 
-  const formattedDocketRecord = formatDocketRecord(publicCase.docketRecord);
+  const formattedDocketRecord = publicCase.docketRecord.map(d =>
+    applicationContext.getUtilities().formatDocketRecord(applicationContext, d),
+  );
+
+  const formattedDocketRecordWithDocument = applicationContext
+    .getUtilities()
+    .formatDocketRecordWithDocument(
+      applicationContext,
+      formattedDocketRecord,
+      publicCase.documents,
+    );
+
   const formattedCaseDetail = formatCaseDetail(publicCase);
 
-  return { formattedCaseDetail, formattedDocketRecord };
+  return { formattedCaseDetail, formattedDocketRecordWithDocument };
 };

--- a/web-client/src/presenter/computeds/public/publicCaseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/public/publicCaseDetailHelper.test.js
@@ -1,5 +1,12 @@
-import { publicCaseDetailHelper } from './publicCaseDetailHelper';
+import { applicationContextPublic } from '../../../applicationContextPublic';
+import { publicCaseDetailHelper as publicCaseDetailHelperComputed } from './publicCaseDetailHelper';
 import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../../withAppContext';
+
+const publicCaseDetailHelper = withAppContextDecorator(
+  publicCaseDetailHelperComputed,
+  applicationContextPublic,
+);
 
 let state;
 describe('publicCaseDetailHelper', () => {
@@ -12,33 +19,115 @@ describe('publicCaseDetailHelper', () => {
     };
   });
 
-  it('Should return the formatted docket record as an array', () => {
+  it('should return the formattedDocketRecordWithDocument as an array', () => {
     const result = runCompute(publicCaseDetailHelper, { state });
-    expect(Array.isArray(result.formattedDocketRecord)).toBeTruthy();
+    expect(
+      Array.isArray(result.formattedDocketRecordWithDocument),
+    ).toBeTruthy();
   });
 
-  it('Should show the paper icon for entries with a document filed by paper', () => {
+  it('should format docket record with document', () => {
     state.caseDetail.docketRecord = [
       {
-        document: {
-          isPaper: true,
-        },
+        description: 'first record',
+        documentId: '8675309b-18d0-43ec-bafb-654e83405411',
+        filingDate: '2018-03-01T00:01:00.000Z',
+        index: 4,
       },
       {
-        document: {},
+        description: 'second record',
+        documentId: '8675309b-28d0-43ec-bafb-654e83405412',
+        filingDate: '2018-03-01T00:02:00.000Z',
+        index: 2,
+      },
+      {
+        description: 'third record',
+        documentId: '8675309b-28d0-43ec-bafb-654e83405413',
+        filingDate: '2018-03-01T00:03:00.000Z',
+        index: 3,
+      },
+    ];
+    state.caseDetail.documents = [
+      {
+        createdAt: '2018-11-21T20:49:28.192Z',
+        documentId: '8675309b-18d0-43ec-bafb-654e83405411',
+        documentTitle: 'Petition',
+        documentType: 'Petition',
+        processingStatus: 'pending',
+      },
+      {
+        createdAt: '2018-11-21T20:49:28.192Z',
+        documentId: 'abc81f4d-1e47-423a-8caf-6d2fdc3d3859',
+        documentTitle: 'Statement of Taxpayer Identification',
+        documentType: 'Statement of Taxpayer Identification',
+        processingStatus: 'pending',
+      },
+      {
+        createdAt: '2018-11-21T20:49:28.192Z',
+        documentId: '8675309b-28d0-43ec-bafb-654e83405412',
+        documentTitle: 'Answer',
+        documentType: 'Answer',
+        eventCode: 'A',
+        processingStatus: 'pending',
+      },
+      {
+        createdAt: '2018-11-25T20:49:28.192Z',
+        documentId: '8675309b-28d0-43ec-bafb-654e83405413',
+        documentTitle: 'Order to do something',
+        documentType: 'O - Order',
+        eventCode: 'O',
+        processingStatus: 'pending',
+        servedAt: '2018-11-27T20:49:28.192Z',
+        status: 'served',
       },
     ];
     const result = runCompute(publicCaseDetailHelper, { state });
-    expect(result.formattedDocketRecord).toEqual([
+    expect(result.formattedDocketRecordWithDocument).toMatchObject([
       {
         document: {
-          isPaper: true,
+          createdAtFormatted: '11/21/18',
+          isCourtIssuedDocument: false,
+          isInProgress: false,
+          isNotServedCourtIssuedDocument: false,
+          isStatusServed: false,
+          showServedAt: false,
         },
-        showPaperIcon: true,
+        record: {
+          createdAtFormatted: '02/28/18',
+          description: 'first record',
+          filingsAndProceedings: '',
+        },
       },
       {
-        document: {},
-        showPaperIcon: false,
+        document: {
+          createdAtFormatted: '11/21/18',
+          isCourtIssuedDocument: false,
+          isInProgress: false,
+          isNotServedCourtIssuedDocument: false,
+          isStatusServed: false,
+          showServedAt: false,
+        },
+        record: {
+          createdAtFormatted: '02/28/18',
+          description: 'second record',
+          filingsAndProceedings: '',
+        },
+      },
+      {
+        document: {
+          createdAtFormatted: '11/25/18',
+          isCourtIssuedDocument: true,
+          isInProgress: false,
+          isNotServedCourtIssuedDocument: false,
+          isStatusServed: true,
+          servedAtFormatted: '11/27/18 03:49 pm',
+          showServedAt: true,
+        },
+        record: {
+          createdAtFormatted: '02/28/18',
+          description: 'third record',
+          filingsAndProceedings: '',
+        },
       },
     ]);
   });

--- a/web-client/src/presenter/sequences/public/gotoPublicCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/public/gotoPublicCaseDetailSequence.js
@@ -1,9 +1,11 @@
 import { getPublicCaseAction } from '../../actions/Public/getPublicCaseAction';
+import { setBaseUrlAction } from '../../actions/setBaseUrlAction';
 import { setCaseAction } from '../../actions/setCaseAction';
 import { setCurrentPageAction } from '../../actions/setCurrentPageAction';
 
 export const gotoPublicCaseDetailSequence = [
   getPublicCaseAction,
   setCaseAction,
+  setBaseUrlAction,
   setCurrentPageAction('PublicCaseDetail'),
 ];

--- a/web-client/src/views/Public/PublicDocketRecord.jsx
+++ b/web-client/src/views/Public/PublicDocketRecord.jsx
@@ -1,6 +1,6 @@
-import { FilingsAndProceedings } from '../DocketRecord/FilingsAndProceedings';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PublicDocketRecordHeader } from './PublicDocketRecordHeader';
+import { PublicFilingsAndProceedings } from './PublicFilingsAndProceedings';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -39,8 +39,8 @@ export const PublicDocketRecord = connect(
             </tr>
           </thead>
           <tbody>
-            {publicCaseDetailHelper.formattedDocketRecord.map(
-              ({ document, index, record, showPaperIcon }, arrayIndex) => {
+            {publicCaseDetailHelper.formattedDocketRecordWithDocument.map(
+              ({ document, index, record }) => {
                 return (
                   <tr key={index}>
                     <td className="center-column hide-on-mobile">{index}</td>
@@ -56,13 +56,12 @@ export const PublicDocketRecord = connect(
                       aria-hidden="true"
                       className="filing-type-icon hide-on-mobile"
                     >
-                      {showPaperIcon && (
+                      {document && document.isPaper && (
                         <FontAwesomeIcon icon={['fas', 'file-alt']} />
                       )}
                     </td>
                     <td>
-                      <FilingsAndProceedings
-                        arrayIndex={arrayIndex}
+                      <PublicFilingsAndProceedings
                         document={document}
                         record={record}
                       />

--- a/web-client/src/views/Public/PublicFilingsAndProceedings.jsx
+++ b/web-client/src/views/Public/PublicFilingsAndProceedings.jsx
@@ -1,0 +1,73 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { connect } from '@cerebral/react';
+import { props, state } from 'cerebral';
+import React from 'react';
+
+export const PublicFilingsAndProceedings = connect(
+  {
+    arrayIndex: props.arrayIndex,
+    baseUrl: state.baseUrl,
+    document: props.document,
+    record: props.record,
+  },
+  ({ baseUrl, document, record }) => {
+    const renderDocumentLink = (documentId, description, isPaper) => {
+      return (
+        <React.Fragment>
+          {!document.isInProgress && !document.isNotServedCourtIssuedDocument && (
+            <React.Fragment>
+              <a
+                aria-label={`View PDF: ${description}`}
+                href={`${baseUrl}/documents/${documentId}/document-download-url`}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                {isPaper && (
+                  <span className="filing-type-icon-mobile">
+                    <FontAwesomeIcon icon={['fas', 'file-alt']} />
+                  </span>
+                )}
+                {description}
+              </a>
+            </React.Fragment>
+          )}
+          {document.isInProgress && description}
+        </React.Fragment>
+      );
+    };
+
+    return (
+      <React.Fragment>
+        {document &&
+          document.processingStatus === 'complete' &&
+          document.isCourtIssuedDocument &&
+          !document.isNotServedCourtIssuedDocument &&
+          renderDocumentLink(
+            document.documentId,
+            record.description,
+            document.isPaper,
+          )}
+
+        {document &&
+          (!document.isCourtIssuedDocument ||
+            document.isNotServedCourtIssuedDocument) &&
+          (document.documentTitle || record.description)}
+
+        <span> {record.signatory}</span>
+
+        {!document && record.description}
+
+        <span className="filings-and-proceedings">
+          {document &&
+            document.documentTitle &&
+            document.additionalInfo &&
+            ` ${document.additionalInfo}`}
+          {record.filingsAndProceedings && ` ${record.filingsAndProceedings}`}
+          {document &&
+            document.additionalInfo2 &&
+            ` ${document.additionalInfo2}`}
+        </span>
+      </React.Fragment>
+    );
+  },
+);


### PR DESCRIPTION
This is just a first pass and I'm sure is missing things. Should "Not served" documents be shown on the table at all? The PDFs are not currently linking correctly. This will need to be reviewed with UX to find anything else we're missing, but I'm at least confident that this first pass shouldn't break anything.

<img width="1408" alt="Screen Shot 2019-12-03 at 3 50 24 PM" src="https://user-images.githubusercontent.com/43251054/70099771-aac53880-15e4-11ea-85a7-eed4c06d7a76.png">
