### PR TITLE
1624: exclude party details for public printable docket records

### DIFF
--- a/shared/src/business/useCases/generateDocketRecordPdfInteractor.js
+++ b/shared/src/business/useCases/generateDocketRecordPdfInteractor.js
@@ -11,6 +11,7 @@ exports.generateDocketRecordPdfInteractor = async ({
   applicationContext,
   caseId,
   docketRecordSort,
+  includePartyDetail = false,
 }) => {
   const { Case } = applicationContext.getEntityConstructors();
   const caseCaptionPostfix = Case.CASE_CAPTION_POSTFIX;
@@ -175,7 +176,7 @@ exports.generateDocketRecordPdfInteractor = async ({
 
   const getDocketRecordContent = detail => {
     let docketRecordContent = `
-      <table>
+      <table class="docket-record-table">
         <thead>
           <tr>
             <th>No.</th>
@@ -257,7 +258,9 @@ exports.generateDocketRecordPdfInteractor = async ({
       captionPostfix: caseCaptionPostfix,
       docketNumberWithSuffix: docketNumber + (docketNumberSuffix || ''),
       docketRecord: getDocketRecordContent(formattedCaseDetail),
-      partyInfo: getPartyInfoContent(formattedCaseDetail),
+      partyInfo: includePartyDetail
+        ? getPartyInfoContent(formattedCaseDetail)
+        : '',
     });
 
   return await applicationContext.getUseCases().generatePdfFromHtmlInteractor({

--- a/shared/src/business/useCases/generateDocketRecordPdfInteractor.test.js
+++ b/shared/src/business/useCases/generateDocketRecordPdfInteractor.test.js
@@ -108,6 +108,7 @@ describe('generateDocketRecordPdfInteractor', () => {
     const result = await generateDocketRecordPdfInteractor({
       applicationContext,
       caseDetail,
+      includePartyDetail: true,
     });
 
     expect(result.indexOf('<!DOCTYPE html>')).toBe(0);
@@ -135,9 +136,60 @@ describe('generateDocketRecordPdfInteractor', () => {
         }),
       },
       caseId: 'ca123',
+      includePartyDetail: true,
     });
 
     expect(result.indexOf('Test Secondary')).toBeGreaterThan(-1);
+  });
+
+  it('displays no party information if "includePartyDetail" flag is undefined or falsy', async () => {
+    let result = await generateDocketRecordPdfInteractor({
+      applicationContext: {
+        ...applicationContext,
+        getPersistenceGateway: () => ({
+          getCaseByCaseId: () => ({
+            ...caseDetail,
+            contactSecondary: {
+              address1: 'address 1',
+              city: 'City',
+              countryType: 'domestic',
+              name: 'Test Secondary',
+              phone: '123-123-1234',
+              postalCode: '12345',
+              state: 'ST',
+            },
+          }),
+        }),
+      },
+      caseId: 'ca123',
+      // includePartyDetail not provided, is undefined
+    });
+
+    expect(result.indexOf('Test Secondary')).toEqual(-1);
+
+    result = await generateDocketRecordPdfInteractor({
+      applicationContext: {
+        ...applicationContext,
+        getPersistenceGateway: () => ({
+          getCaseByCaseId: () => ({
+            ...caseDetail,
+            contactSecondary: {
+              address1: 'address 1',
+              city: 'City',
+              countryType: 'domestic',
+              name: 'Test Secondary',
+              phone: '123-123-1234',
+              postalCode: '12345',
+              state: 'ST',
+            },
+          }),
+        }),
+      },
+      caseId: 'ca123',
+      includePartyDetail: false,
+    });
+
+    expect(result.indexOf('Test Secondary')).toEqual(-1);
   });
 
   it('Displays practitioners associated with the case', async () => {
@@ -178,6 +230,7 @@ describe('generateDocketRecordPdfInteractor', () => {
         }),
       },
       caseId: 'ca-123',
+      includePartyDetail: true,
     });
 
     expect(result.indexOf('Test Practitioner')).toBeGreaterThan(-1);
@@ -205,6 +258,7 @@ describe('generateDocketRecordPdfInteractor', () => {
         }),
       },
       caseId: 'ca123',
+      includePartyDetail: true,
     });
 
     expect(result.indexOf('Respondent Counsel')).toBeGreaterThan(-1);
@@ -229,6 +283,7 @@ describe('generateDocketRecordPdfInteractor', () => {
         }),
       },
       caseId: 'ca-123',
+      includePartyDetail: true,
     });
 
     expect(result.indexOf('Test C/O')).toBeGreaterThan(-1);
@@ -241,6 +296,7 @@ describe('generateDocketRecordPdfInteractor', () => {
     const result = await generateDocketRecordPdfInteractor({
       applicationContext,
       caseDetail: { ...caseDetail },
+      includePartyDetail: true,
     });
 
     expect(result.indexOf(caseDetail.caseCaption)).toBeGreaterThan(-1);

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
@@ -126,6 +126,7 @@ const batchDownloadTrialSessionInteractor = async ({
         .generateDocketRecordPdfInteractor({
           applicationContext,
           caseId,
+          includePartyDetail: true,
         })
         .then(async result => {
           await onDocketRecordCreation(caseId);

--- a/shared/src/business/utilities/generateHTMLTemplateForPDF.js
+++ b/shared/src/business/utilities/generateHTMLTemplateForPDF.js
@@ -332,6 +332,10 @@ const generatePrintableDocketRecordTemplate = content => {
     .party-details {
       width: 25%;
     }
+
+    .docket-record-table {
+      margin-top: 30px;
+    }
   `;
 
   const templateContent = {

--- a/web-api/src/cases/generateDocketRecordPdfLambda.js
+++ b/web-api/src/cases/generateDocketRecordPdfLambda.js
@@ -22,6 +22,7 @@ exports.handler = event =>
           applicationContext,
           caseId,
           docketRecordSort,
+          includePartyDetail: true,
         });
       applicationContext.logger.info('User', user);
       applicationContext.logger.info('Case ID', caseId);

--- a/web-api/src/public-api/generatePublicDocketRecordPdfLambda.js
+++ b/web-api/src/public-api/generatePublicDocketRecordPdfLambda.js
@@ -20,6 +20,7 @@ exports.handler = event =>
           applicationContext,
           caseId,
           docketRecordSort,
+          includePartyDetail: false,
         });
       applicationContext.logger.info('Case ID', caseId);
       return result;

--- a/web-client/src/presenter/actions/generateDocketRecordPdfUrlAction.js
+++ b/web-client/src/presenter/actions/generateDocketRecordPdfUrlAction.js
@@ -22,6 +22,7 @@ export const generateDocketRecordPdfUrlAction = async ({
       applicationContext,
       caseId: caseDetail.caseId,
       docketRecordSort,
+      includePartyDetail: true,
     });
 
   const pdfFile = new Blob([docketRecordPdf], { type: 'application/pdf' });


### PR DESCRIPTION
![Screen Shot 2019-12-05 at 1 44 03 PM](https://user-images.githubusercontent.com/2445917/70268069-56959200-1765-11ea-94c3-7421c96b8c02.png)

Added explicit flag which must be included and must be set to true to enable inclusion of the party information.