### PR TITLE
Bug Fix: after entering a new order user should not see the view orders needed link

### DIFF
--- a/web-client/src/presenter/computeds/documentDetailHelper.js
+++ b/web-client/src/presenter/computeds/documentDetailHelper.js
@@ -153,7 +153,8 @@ export const documentDetailHelper = (get, applicationContext) => {
   const showViewOrdersNeededButton =
     (document.status === 'served' ||
       caseDetail.status === STATUS_TYPES.batchedForIRS) &&
-    user.role === USER_ROLES.petitionsClerk;
+    user.role === USER_ROLES.petitionsClerk &&
+    formattedDocument.isPetition;
 
   const showPrintCaseConfirmationButton =
     document.status === 'served' && formattedDocument.isPetition === true;

--- a/web-client/src/presenter/computeds/documentDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/documentDetailHelper.test.js
@@ -1214,7 +1214,7 @@ describe('document detail helper', () => {
   });
 
   describe('showViewOrdersNeededButton', () => {
-    it("should show the 'view orders needed' link if a document has been served and user is petitionsclerk", () => {
+    it("should show the 'view orders needed' link if a document has been served and user is petitionsclerk and document is a petition", () => {
       const user = {
         role: User.ROLES.petitionsClerk,
         userId: '123',
@@ -1227,7 +1227,7 @@ describe('document detail helper', () => {
             documents: [
               {
                 documentId: 'abc',
-                documentType: 'Stipulated Decision',
+                documentType: 'Petition',
                 status: 'served',
               },
             ],


### PR DESCRIPTION
We should only show this button when viewing a petition.