### PR TITLE
317: a11y &  modal placement

### DIFF
--- a/web-client/src/views/CaseDetail/AddEditProceduralNoteModal.jsx
+++ b/web-client/src/views/CaseDetail/AddEditProceduralNoteModal.jsx
@@ -23,7 +23,7 @@ export const AddEditProceduralNoteModal = connect(
         onConfirmSequence={onConfirmSequence}
       >
         <h5 className="margin-bottom-4">
-          Docket {modal.docketNumber}: {modal.caseCaptionNames}
+          {`Docket ${modal.docketNumber}: ${modal.caseCaptionNames}`}
         </h5>
         <FormGroup
           className="margin-bottom-2"

--- a/web-client/src/views/CaseDetail/CaseDetailInternal.jsx
+++ b/web-client/src/views/CaseDetail/CaseDetailInternal.jsx
@@ -1,3 +1,4 @@
+import { AddEditProceduralNoteModal } from './AddEditProceduralNoteModal';
 import { AddToTrialModal } from './AddToTrialModal';
 import { BlockFromTrialModal } from './BlockFromTrialModal';
 import { CaseDeadlinesInternal } from './CaseDeadlinesInternal';
@@ -153,6 +154,9 @@ export const CaseDetailInternal = connect(
         )}
         {showModal === 'DeleteCaseDeadlineModalDialog' && (
           <DeleteCaseDeadlineModalDialog />
+        )}
+        {showModal === 'AddEditProceduralNoteModal' && (
+          <AddEditProceduralNoteModal onConfirmSequence="updateProceduralNoteSequence" />
         )}
         {showModal === 'AddToTrialModal' && <AddToTrialModal />}
         {showModal === 'BlockFromTrialModal' && <BlockFromTrialModal />}

--- a/web-client/src/views/CaseDetail/CaseNotes.jsx
+++ b/web-client/src/views/CaseDetail/CaseNotes.jsx
@@ -1,5 +1,4 @@
 import { AddEditCaseNoteModal } from '../TrialSessionWorkingCopy/AddEditCaseNoteModal';
-import { AddEditProceduralNoteModal } from './AddEditProceduralNoteModal';
 import { Button } from '../../ustc-ui/Button/Button';
 import { DeleteCaseNoteConfirmModal } from '../TrialSessionWorkingCopy/DeleteCaseNoteConfirmModal';
 import { DeleteProceduralNoteConfirmModal } from './DeleteProceduralNoteConfirmModal';
@@ -155,9 +154,6 @@ export const CaseNotes = connect(
         )}
         {showModal === 'DeleteProceduralNoteConfirmModal' && (
           <DeleteProceduralNoteConfirmModal onConfirmSequence="deleteProceduralNoteSequence" />
-        )}
-        {showModal === 'AddEditProceduralNoteModal' && (
-          <AddEditProceduralNoteModal onConfirmSequence="updateProceduralNoteSequence" />
         )}
       </>
     );


### PR DESCRIPTION
string alteration on modal done for sake of voiceover playback (which formerly said "four items" because it had four text nodes).
Modal call moved to CaseDetailInternal so that when "Add Case Note" is selected from the actions menu, one need not be viewing "Notes" tab to utilize it.
<img width="1415" alt="Screen Shot 2019-12-18 at 11 20 27 AM" src="https://user-images.githubusercontent.com/2445917/71108298-6c08b400-2188-11ea-8db7-bd56a560d250.png">
