### PR TITLE
Sprint 30: fix action menu down to 1024px

### DIFF
--- a/web-client/src/views/CaseDetail/CaseDetailHeaderMenu.jsx
+++ b/web-client/src/views/CaseDetail/CaseDetailHeaderMenu.jsx
@@ -86,7 +86,7 @@ export const CaseDetailHeaderMenu = connect(
           >
             <button
               aria-expanded={isCaseDetailMenuOpen}
-              className="usa-accordion__button usa-nav__link hidden-underline case-detail-menu__button"
+              className="usa-accordion__button usa-nav__link hidden-underline case-detail-menu__button text-no-wrap"
               id="case-detail-menu-button"
               onClick={() => {
                 toggleMenuSequence({ caseDetailMenu: 'CaseDetailMenu' });


### PR DESCRIPTION
At 1024px: 

<img width="1025" alt="Screen Shot 2020-01-03 at 8 17 21 AM" src="https://user-images.githubusercontent.com/43251054/71734891-d3b63480-2e01-11ea-8b16-a6b433cad2fb.png">

At 1023px:

<img width="1027" alt="Screen Shot 2020-01-03 at 8 17 28 AM" src="https://user-images.githubusercontent.com/43251054/71734897-da44ac00-2e01-11ea-8ad9-531bdc4737c0.png">
