### PR TITLE
linting whitespace issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
         allowChildren: false,
       },
     ],
+    'no-irregular-whitespace': [2, { skipStrings: false }],
     'sort-imports-es6-autofix/sort-imports-es6': [
       2,
       {


### PR DESCRIPTION
finds "irregular whitespace" such as non-printable unicode characters, even in strings, and alerts us to them.