### PR TITLE
3917: UX fixes 

### DIFF
--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.js
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.js
@@ -37,7 +37,15 @@ export const addCourtIssuedDocketEntryNonstandardHelper = (
       break;
   }
 
+  let freeTextLabel;
+  if (selectedEventCode === 'O') {
+    freeTextLabel = 'What is this order for?';
+  } else if (selectedEventCode === 'NOT') {
+    freeTextLabel = 'What is this notice for?';
+  }
+
   return {
+    freeTextLabel,
     showDate,
     showDocketNumbers,
     showFreeText,

--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.test.js
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.test.js
@@ -88,4 +88,26 @@ describe('addCourtIssuedDocketEntryNonstandardHelper', () => {
       showJudge: false,
     });
   });
+
+  it('returns freeTextLabel for an order if the selected eventCode is O', () => {
+    let testState = { ...state, form: { eventCode: 'O' } };
+
+    const result = runCompute(addCourtIssuedDocketEntryNonstandardHelper, {
+      state: testState,
+    });
+    expect(result).toMatchObject({
+      freeTextLabel: 'What is this order for?',
+    });
+  });
+
+  it('returns freeTextLabel for a notice if the selected eventCode is NOT', () => {
+    let testState = { ...state, form: { eventCode: 'NOT' } };
+
+    const result = runCompute(addCourtIssuedDocketEntryNonstandardHelper, {
+      state: testState,
+    });
+    expect(result).toMatchObject({
+      freeTextLabel: 'What is this notice for?',
+    });
+  });
 });

--- a/web-client/src/presenter/computeds/documentDetailHelper.js
+++ b/web-client/src/presenter/computeds/documentDetailHelper.js
@@ -190,9 +190,10 @@ export const documentDetailHelper = (get, applicationContext) => {
       !formattedDocument.isCourtIssuedDocument,
     showPrintCaseConfirmationButton,
     showRecallButton,
-    showRemoveSignature: isOrder && isSigned,
+    showRemoveSignature: isOrder && document.eventCode !== 'NOT' && isSigned,
     showServeToIrsButton,
     showSignDocumentButton,
+    showSignedAt: isOrder && isSigned,
     showViewOrdersNeededButton,
   };
 };

--- a/web-client/src/presenter/computeds/documentDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/documentDetailHelper.test.js
@@ -1332,8 +1332,8 @@ describe('document detail helper', () => {
     });
   });
 
-  describe('showConfirmEditOrder and showRemoveSignature', () => {
-    it('should show confirm edit order and remove signature', () => {
+  describe('showConfirmEditOrder, showSignedAt, and showRemoveSignature', () => {
+    it('should show confirm edit order, signed at, and remove signature for a signed order', () => {
       const user = {
         role: User.ROLES.petitionsClerk,
         userId: '123',
@@ -1359,7 +1359,39 @@ describe('document detail helper', () => {
       });
 
       expect(result.showConfirmEditOrder).toEqual(true);
+      expect(result.showSignedAt).toEqual(true);
       expect(result.showRemoveSignature).toEqual(true);
+    });
+
+    it('should show confirm edit order, signed at, but NOT remove signature for a signed notice', () => {
+      const user = {
+        role: User.ROLES.petitionsClerk,
+        userId: '123',
+      };
+      const result = runCompute(documentDetailHelper, {
+        state: {
+          ...getBaseState(user),
+          caseDetail: {
+            docketRecord: [],
+            documents: [
+              {
+                documentId: '123-abc',
+                documentType: 'Notice',
+                eventCode: 'NOT',
+                signedAt: getDateISO(),
+              },
+            ],
+          },
+          documentId: '123-abc',
+          user: {
+            role: User.ROLES.petitionsClerk,
+          },
+        },
+      });
+
+      expect(result.showConfirmEditOrder).toEqual(true);
+      expect(result.showSignedAt).toEqual(true);
+      expect(result.showRemoveSignature).toEqual(false);
     });
 
     it('should NOT show confirm edit order OR remove signature when the documentType is not an order', () => {
@@ -1388,6 +1420,7 @@ describe('document detail helper', () => {
       });
 
       expect(result.showConfirmEditOrder).toEqual(false);
+      expect(result.showSignedAt).toEqual(false);
       expect(result.showRemoveSignature).toEqual(false);
     });
 
@@ -1417,6 +1450,7 @@ describe('document detail helper', () => {
       });
 
       expect(result.showConfirmEditOrder).toEqual(false);
+      expect(result.showSignedAt).toEqual(false);
       expect(result.showRemoveSignature).toEqual(false);
     });
   });

--- a/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.jsx
+++ b/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.jsx
@@ -135,7 +135,7 @@ export const CourtIssuedNonstandardForm = connect(
               htmlFor="free-text"
               id="free-text-label"
             >
-              What is this order for?
+              {addCourtIssuedDocketEntryNonstandardHelper.freeTextLabel}
             </label>
 
             <input

--- a/web-client/src/views/DocumentDetail/DocumentDetail.jsx
+++ b/web-client/src/views/DocumentDetail/DocumentDetail.jsx
@@ -120,24 +120,26 @@ export const DocumentDetail = connect(
                     Apply Signature
                   </Button>
                 )}
-                {documentDetailHelper.showRemoveSignature && (
+                {documentDetailHelper.showSignedAt && (
                   <>
                     Signed{' '}
                     {documentDetailHelper.formattedDocument.signedAtFormattedTZ}
-                    <Button
-                      link
-                      className="margin-left-2 no-wrap"
-                      icon="trash"
-                      onClick={() =>
-                        removeSignatureFromOrderSequence({
-                          caseDetail,
-                          documentIdToEdit:
-                            documentDetailHelper.formattedDocument.documentId,
-                        })
-                      }
-                    >
-                      Delete Signature
-                    </Button>
+                    {documentDetailHelper.showRemoveSignature && (
+                      <Button
+                        link
+                        className="margin-left-2 no-wrap"
+                        icon="trash"
+                        onClick={() =>
+                          removeSignatureFromOrderSequence({
+                            caseDetail,
+                            documentIdToEdit:
+                              documentDetailHelper.formattedDocument.documentId,
+                          })
+                        }
+                      >
+                        Delete Signature
+                      </Button>
+                    )}
                   </>
                 )}
               </div>


### PR DESCRIPTION
* when "NOT" is selected on Add Docket Entry, update free text field label to "What is this notice for?"
* Remove option to "Delete Signature" from Draft Notice screen