### PR TITLE
1193 bug fixes

### DIFF
--- a/shared/src/business/entities/trialSessions/TrialSession.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.js
@@ -186,11 +186,23 @@ TrialSession.VALIDATION_ERROR_MESSAGES = {
 
 TrialSession.validationRules = {
   COMMON: {
-    address1: joi.string().optional(),
-    address2: joi.string().optional(),
-    city: joi.string().optional(),
+    address1: joi
+      .string()
+      .allow('')
+      .optional(),
+    address2: joi
+      .string()
+      .allow('')
+      .optional(),
+    city: joi
+      .string()
+      .allow('')
+      .optional(),
     courtReporter: joi.string().optional(),
-    courthouseName: joi.string().optional(),
+    courthouseName: joi
+      .string()
+      .allow('')
+      .optional(),
     createdAt: joi
       .date()
       .iso()
@@ -221,7 +233,10 @@ TrialSession.validationRules = {
       .iso()
       .required(),
     startTime: JoiValidationConstants.TWENTYFOUR_HOUR_MINUTES,
-    state: joi.string().optional(),
+    state: joi
+      .string()
+      .allow('')
+      .optional(),
     status: joi
       .string()
       .valid(

--- a/web-client/src/presenter/sequences/setTrialSessionCalendarSequence.js
+++ b/web-client/src/presenter/sequences/setTrialSessionCalendarSequence.js
@@ -1,4 +1,5 @@
 import { canSetTrialSessionToCalendarAction } from '../actions/TrialSession/canSetTrialSessionToCalendarAction';
+import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { getCalendaredCasesForTrialSessionAction } from '../actions/TrialSession/getCalendaredCasesForTrialSessionAction';
 import { getSetTrialSessionCalendarAlertSuccessAction } from '../actions/TrialSession/getSetTrialSessionCalendarAlertSuccessAction';
 import { getTrialSessionDetailsAction } from '../actions/TrialSession/getTrialSessionDetailsAction';
@@ -16,6 +17,7 @@ import { state } from 'cerebral';
 import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 
 export const setTrialSessionCalendarSequence = [
+  clearAlertsAction,
   setWaitingForResponseAction,
   canSetTrialSessionToCalendarAction,
   {


### PR DESCRIPTION
With regard to the `.allow('')`, this was added because `joi` will fail validation if the input is being set with an empty string despite having `optional()`.

<img width="763" alt="Screen Shot 2020-01-13 at 1 45 03 PM" src="https://user-images.githubusercontent.com/1891789/72291972-b5281880-360d-11ea-9a87-eefd105a7706.png">

It's getting the empty string from the input where the value is something like: 
```
<input
  value={someValue || ''}
/>
```

I actually saw this bug show up at one point during on-site user testing and think we either need to remove the default string value on the inputs or add `allow('')` to the validations in these cases. I'm leaning towards the latter since we do string operations on these fields sometimes (like in the case of the trial location, concatenating the city, state, and zip on a computed). This pattern is also present in the Document entity.
