### PR TITLE
3917: default Notice document title

### DIFF
--- a/web-client/src/presenter/actions/CourtIssuedOrder/updateCreateOrderModalFormValueAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/updateCreateOrderModalFormValueAction.js
@@ -25,8 +25,10 @@ export const updateCreateOrderModalFormValueAction = ({
         return item.eventCode === eventCode;
       });
       store.set(state.form.documentType, entry.documentType);
-      if (eventCode !== 'O') {
+      if (eventCode !== 'O' && eventCode !== 'NOT') {
         store.set(state.form.documentTitle, entry.documentTitle);
+      } else if (eventCode === 'NOT') {
+        store.set(state.form.documentTitle, 'Notice');
       } else {
         store.unset(state.form.documentTitle);
       }

--- a/web-client/src/presenter/actions/CourtIssuedOrder/updateCreateOrderModalFormValueAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/updateCreateOrderModalFormValueAction.test.js
@@ -40,6 +40,21 @@ describe('updateCreateOrderModalFormValueAction', () => {
     expect(result.state.form.documentType).toEqual('Order');
   });
 
+  it('sets state.form values correctly if a generic notice event code is passed in', async () => {
+    const result = await runAction(updateCreateOrderModalFormValueAction, {
+      modules: {
+        presenter,
+      },
+      props: { key: 'eventCode', value: 'NOT' },
+      state: {
+        form: {},
+      },
+    });
+    expect(result.state.form.eventCode).toEqual('NOT');
+    expect(result.state.form.documentTitle).toEqual('Notice');
+    expect(result.state.form.documentType).toEqual('Notice');
+  });
+
   it('unsets state.form values if event code is empty', async () => {
     const params = {
       modules: {

--- a/web-client/src/views/CreateOrder/CreateOrderChooseTypeModal.jsx
+++ b/web-client/src/views/CreateOrder/CreateOrderChooseTypeModal.jsx
@@ -9,6 +9,7 @@ export const CreateOrderChooseTypeModal = connect(
   {
     cancelSequence: sequences.dismissModalSequence,
     confirmSequence: sequences.submitCreateOrderModalSequence,
+    form: state.form,
     orderTypesHelper: state.orderTypesHelper,
     updateFormValue: sequences.updateCreateOrderModalFormValueSequence,
     validateSequence: sequences.validateOrderWithoutBodySequence,
@@ -17,6 +18,7 @@ export const CreateOrderChooseTypeModal = connect(
   ({
     cancelSequence,
     confirmSequence,
+    form,
     orderTypesHelper,
     updateFormValue,
     validateSequence,
@@ -70,6 +72,7 @@ export const CreateOrderChooseTypeModal = connect(
                 id="documentTitle"
                 name="documentTitle"
                 type="text"
+                value={form.documentTitle || ''}
                 onChange={e => {
                   updateFormValue({
                     key: e.target.name,


### PR DESCRIPTION
Added "Notice" text to the notice title input box by default, so it's clear to users that they should include the full document title. Per UX, this does not need to be done for generic Orders.
<img width="526" alt="Screen Shot 2020-01-14 at 9 47 54 AM" src="https://user-images.githubusercontent.com/43251054/72368462-00483700-36b3-11ea-8695-2fcd5e332434.png">
