### PR TITLE
devex - creating the sns subscriptions using cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,9 @@ jobs:
           name: 'Deploy - Web API - Terraform'
           command: docker run -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "COGNITO_SUFFIX=${COGNITO_SUFFIX}" -e "EFCMS_DOMAIN=${EFCMS_DOMAIN}" -e "SES_DMARC_EMAIL=${SES_DMARC_EMAIL}" -e "POST_CONFIRMATION_ROLE_ARN=${POST_CONFIRMATION_ROLE_ARN}" -e "CLOUDWATCH_ROLE_ARN=${CLOUDWATCH_ROLE_ARN}" -e "ES_INSTANCE_COUNT=${ES_INSTANCE_COUNT}" --rm efcms /bin/sh -c "cd web-api/terraform/main && ../bin/deploy-app.sh ${ENV}"
       - run:
+          name: 'Setup SNS Subscription'
+          command: docker run -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "COGNITO_SUFFIX=${COGNITO_SUFFIX}" -e "AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID}" -e "EFCMS_DOMAIN=${EFCMS_DOMAIN}" -e "SES_DMARC_EMAIL=${SES_DMARC_EMAIL}" -e "POST_CONFIRMATION_ROLE_ARN=${POST_CONFIRMATION_ROLE_ARN}" -e "CLOUDWATCH_ROLE_ARN=${CLOUDWATCH_ROLE_ARN}" -e "ES_INSTANCE_COUNT=${ES_INSTANCE_COUNT}" --rm efcms /bin/sh -c "cd web-api && ./setup-sns-subscriptions.sh ${ENV}"
+      - run:
           name: Setup Elasticsearch Index Settings
           command: docker run -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "EFCMS_DOMAIN=${EFCMS_DOMAIN}" --rm efcms /bin/sh -c "./web-api/setup-elasticsearch-index.sh ${ENV}"
       - run:

--- a/web-api/serverless-api.yml
+++ b/web-api/serverless-api.yml
@@ -50,9 +50,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-case-deadlines.yml
+++ b/web-api/serverless-case-deadlines.yml
@@ -48,9 +48,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-case-documents.yml
+++ b/web-api/serverless-case-documents.yml
@@ -48,9 +48,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-case-notes.yml
+++ b/web-api/serverless-case-notes.yml
@@ -48,9 +48,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-case-parties.yml
+++ b/web-api/serverless-case-parties.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-cases.yml
+++ b/web-api/serverless-cases.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-documents.yml
+++ b/web-api/serverless-documents.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-notifications.yml
+++ b/web-api/serverless-notifications.yml
@@ -47,9 +47,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}-ws.${opt:domain}

--- a/web-api/serverless-public-api.yml
+++ b/web-api/serverless-public-api.yml
@@ -45,9 +45,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-sections.yml
+++ b/web-api/serverless-sections.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-streams.yml
+++ b/web-api/serverless-streams.yml
@@ -55,9 +55,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-trial-sessions.yml
+++ b/web-api/serverless-trial-sessions.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-users.yml
+++ b/web-api/serverless-users.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/serverless-work-items.yml
+++ b/web-api/serverless-work-items.yml
@@ -49,9 +49,6 @@ custom:
     topics:
       alarm:
         topic: arn:aws:sns:${opt:region}:${opt:accountId}:serverless-alerts-topic-${self:provider.stage}
-        notifications:
-          - protocol: email
-            endpoint: ustaxcourt@flexion.us
 
   customDomain:
     domainName: efcms-${self:provider.stage}.${opt:domain}

--- a/web-api/setup-sns-subscriptions.sh
+++ b/web-api/setup-sns-subscriptions.sh
@@ -1,0 +1,25 @@
+#!/bin/bash 
+ENV=$1
+
+subscriptions=$(aws sns list-subscriptions-by-topic \
+  --topic-arn="arn:aws:sns:us-east-1:$AWS_ACCOUNT_ID:serverless-alerts-topic-$ENV" \
+  --region us-east-1 | grep "ustaxcourt@flexion.us")
+code=$?
+
+if [ "${code}" -ne "0" ]; then
+  echo "no subscription found, creating a subscription"
+
+  aws sns subscribe \
+      --topic-arn="arn:aws:sns:us-east-1:$AWS_ACCOUNT_ID:serverless-alerts-topic-$ENV" \
+      --protocol email \
+      --notification-endpoint="ustaxcourt@flexion.us" \
+      --region us-east-1
+
+  aws sns subscribe \
+      --topic-arn="arn:aws:sns:us-west-1:$AWS_ACCOUNT_ID:serverless-alerts-topic-$ENV" \
+      --protocol email \
+      --notification-endpoint="ustaxcourt@flexion.us" \
+      --region us-west-1
+else
+  echo "subscription exists; skipping"
+fi


### PR DESCRIPTION
so... we moved the sns topic to terraform, but you can't create SNS email subscriptions in terraform.  The serverless plugin we uses won't create the subscription if you provide an ARN, SO, I'm just running a .sh script to setup the subscription if it doesn't already exist.