### PR TITLE
hard-code local AWS credentials

### DIFF
--- a/web-api/storage/scripts/seedLocalDatabase.js
+++ b/web-api/storage/scripts/seedLocalDatabase.js
@@ -2,6 +2,11 @@ const AWS = require('aws-sdk');
 const seedEntries = require('../fixtures/seed');
 const { createUsers } = require('./createUsers');
 
+AWS.config = new AWS.Config();
+AWS.config.accessKeyId = 'noop';
+AWS.config.secretAccessKey = 'noop';
+AWS.config.region = 'us-east-1';
+
 const client = new AWS.DynamoDB.DocumentClient({
   credentials: {
     accessKeyId: 'noop',


### PR DESCRIPTION
prevent local environment AWS credentials from polluting process which seeds local dynamo.  Provided this is working properly, there will be no functional change in seeding the database except that developers who may have existing AWS credentials in their environment won't bump into problems when running the `seed:db` task.

I'd appreciate it if an additional developer could pull down this branch and ensure that `start:api` continues to run as expected.  