### PR TITLE
Fixing Virus Scan Bug

### DIFF
--- a/web-api/src/documents/virusScanPdfLambda.js
+++ b/web-api/src/documents/virusScanPdfLambda.js
@@ -12,7 +12,7 @@ const {
  */
 exports.handler = event =>
   handle(event, async () => {
-    const { documentId } = event.pathParameters || {};
+    const { documentId } = event.pathParameters || event.path || {};
     const user = getUserFromAuthHeader(event);
     const applicationContext = createApplicationContext(user);
 


### PR DESCRIPTION
- since virusScan is an async method, that documentId will be on event.path