### PR TITLE
Icon tooltips & accessibility

### DIFF
--- a/web-client/src/ustc-ui/Icon/Icon.jsx
+++ b/web-client/src/ustc-ui/Icon/Icon.jsx
@@ -1,0 +1,21 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { cloneDeep } from 'lodash';
+import React from 'react';
+
+/**
+ * Icon component
+ * Useful for copying an aria-label on an icon to a tool-tip 'title' attribute,
+ * particularly when an icon is used without any accompanying on-screen text
+ * explanation
+ *
+ * @param {object} props the properties to be passed to the FontAwesomeIcon
+ * @returns {object} a react component
+ */
+export const Icon = props => {
+  let iconProps = cloneDeep(props);
+  if (iconProps['aria-label']) {
+    iconProps['aria-hidden'] = false;
+    iconProps.title = iconProps['aria-label'];
+  }
+  return <FontAwesomeIcon {...iconProps} />;
+};

--- a/web-client/src/views/CaseDetail/CaseDetailHeader.jsx
+++ b/web-client/src/views/CaseDetail/CaseDetailHeader.jsx
@@ -2,6 +2,7 @@ import { Button } from '../../ustc-ui/Button/Button';
 import { CaseDetailHeaderMenu } from './CaseDetailHeaderMenu';
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { Mobile, NonMobile } from '../../ustc-ui/Responsive/Responsive';
 import { connect } from '@cerebral/react';
 import { props, state } from 'cerebral';
@@ -25,7 +26,8 @@ export const CaseDetailHeader = connect(
         {caseDetailHeaderHelper.showSealedCaseBanner && (
           <div className="red-warning-header sealed-banner">
             <div className="grid-container text-bold">
-              <FontAwesomeIcon
+              <Icon
+                aria-label="sealed case"
                 className="margin-right-1 icon-sealed"
                 icon="lock"
                 size="1x"
@@ -41,7 +43,8 @@ export const CaseDetailHeader = connect(
                 <div className="margin-bottom-1">
                   <h1 className="heading-2 captioned" tabIndex="-1">
                     {caseDetailHeaderHelper.showConsolidatedCaseIcon && (
-                      <FontAwesomeIcon
+                      <Icon
+                        aria-label="consolidated case"
                         className="margin-right-1 icon-consolidated"
                         icon="copy"
                         size="1x"

--- a/web-client/src/views/WorkQueue/IndividualWorkQueueBatched.jsx
+++ b/web-client/src/views/WorkQueue/IndividualWorkQueueBatched.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -46,8 +46,7 @@ export const IndividualWorkQueueBatched = connect(
                 </td>
                 <td className="message-queue-row has-icon padding-right-0">
                   {item.showBatchedStatusIcon && (
-                    <FontAwesomeIcon
-                      aria-hidden="false"
+                    <Icon
                       aria-label="batched for IRS"
                       className="iconStatusBatched"
                       icon={['far', 'clock']}

--- a/web-client/src/views/WorkQueue/IndividualWorkQueueInbox.jsx
+++ b/web-client/src/views/WorkQueue/IndividualWorkQueueInbox.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -52,8 +52,7 @@ export const IndividualWorkQueueInbox = connect(
                   </td>
                   <td className="message-queue-row has-icon padding-right-0">
                     {item.showBatchedStatusIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="batched for IRS"
                         className="iconStatusBatched"
                         icon={['far', 'clock']}
@@ -61,8 +60,7 @@ export const IndividualWorkQueueInbox = connect(
                       />
                     )}
                     {item.showRecalledStatusIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="recalled from IRS"
                         className="iconStatusRecalled"
                         icon={['far', 'clock']}
@@ -70,8 +68,7 @@ export const IndividualWorkQueueInbox = connect(
                       />
                     )}
                     {item.showUnreadStatusIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="unread message"
                         className="iconStatusUnread"
                         icon={['fas', 'envelope']}
@@ -79,8 +76,7 @@ export const IndividualWorkQueueInbox = connect(
                       />
                     )}
                     {item.showHighPriorityIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="high priority"
                         className="iconHighPriority"
                         icon={['fas', 'exclamation-circle']}

--- a/web-client/src/views/WorkQueue/IndividualWorkQueueOutbox.jsx
+++ b/web-client/src/views/WorkQueue/IndividualWorkQueueOutbox.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -67,8 +67,7 @@ export const IndividualWorkQueueOutbox = connect(
                 </td>
                 <td className="message-queue-row has-icon padding-right-0">
                   {item.showBatchedStatusIcon && (
-                    <FontAwesomeIcon
-                      aria-hidden="false"
+                    <Icon
                       aria-label="batched for IRS"
                       className="iconStatusBatched"
                       icon={['far', 'clock']}

--- a/web-client/src/views/WorkQueue/SectionWorkQueueBatched.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueBatched.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -47,8 +47,7 @@ export const SectionWorkQueueBatched = connect(
                   </td>
                   <td className="message-queue-row has-icon padding-right-0">
                     {item.showBatchedStatusIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="batched for IRS"
                         className="iconStatusBatched"
                         icon={['far', 'clock']}

--- a/web-client/src/views/WorkQueue/SectionWorkQueueInProgress.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueInProgress.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -29,11 +29,8 @@ export const SectionWorkQueueInProgress = connect(
       <React.Fragment>
         {workQueueHelper.showSendToBar && (
           <div className="action-section">
-            <span
-              aria-label="selected work items count"
-              className="assign-work-item-count"
-            >
-              <FontAwesomeIcon icon="check" />
+            <span className="assign-work-item-count">
+              <Icon aria-label="selected work items count" icon="check" />
               {selectedWorkItems.length}
             </span>
             <select

--- a/web-client/src/views/WorkQueue/SectionWorkQueueInbox.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueInbox.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
@@ -29,15 +29,12 @@ export const SectionWorkQueueInbox = connect(
       <React.Fragment>
         {workQueueHelper.showSendToBar && (
           <div className="action-section">
-            <span
-              aria-label="selected work items count"
-              className="assign-work-item-count"
-            >
-              <FontAwesomeIcon icon="check" />
+            <span className="assign-work-item-count">
+              <Icon aria-label="selected work items count" icon="check" />
               {selectedWorkItems.length}
             </span>
             <select
-              aria-label="select a assignee"
+              aria-label="select an assignee"
               className="usa-select"
               id="options"
               name="options"
@@ -139,16 +136,15 @@ export const SectionWorkQueueInbox = connect(
                 {!workQueueHelper.hideIconColumn && (
                   <td className="message-queue-row has-icon padding-right-0">
                     {item.showBatchedStatusIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="true"
+                      <Icon
+                        aria-label="batched for IRS"
                         className="iconStatusBatched"
                         icon={['far', 'clock']}
                         size="lg"
                       />
                     )}
                     {item.showRecalledStatusIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="recalled from IRS"
                         className="iconStatusRecalled"
                         icon={['far', 'clock']}
@@ -156,16 +152,15 @@ export const SectionWorkQueueInbox = connect(
                       />
                     )}
                     {item.showUnassignedIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="true"
+                      <Icon
+                        aria-label="unassigned"
                         className="iconStatusUnassigned"
                         icon={['fas', 'question-circle']}
                         size="lg"
                       />
                     )}
                     {item.showHighPriorityIcon && (
-                      <FontAwesomeIcon
-                        aria-hidden="false"
+                      <Icon
                         aria-label="high priority"
                         className="iconHighPriority"
                         icon={['fas', 'exclamation-circle']}

--- a/web-client/src/views/WorkQueue/SectionWorkQueueOutbox.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueOutbox.jsx
@@ -1,5 +1,5 @@
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -62,8 +62,8 @@ export const SectionWorkQueueOutbox = connect(
                 </td>
                 <td className="message-queue-row has-icon padding-right-0">
                   {item.showBatchedStatusIcon && (
-                    <FontAwesomeIcon
-                      aria-hidden="true"
+                    <Icon
+                      aria-label="batched for IRS"
                       className="iconStatusBatched"
                       icon={['far', 'clock']}
                       size="lg"


### PR DESCRIPTION
Implemented an `Icon` component
A thin wrapper around FontAwesomeIcon, it uses any provided `aria-label` attribute to set `aria-hidden` to false and to add a `title` attribute to the FontAwesomeIcon, providing a tooltip.

Usage of this `Icon` class isn't always necessary, but is useful when the UI is displaying a stand-alone icon without accompanying on-screen text. Users can mouse-over the icon to get a tooltip which reveals the same text as that which is shown to voiceover users within the aria-label