### PR TITLE
bugfix: clear alerts on case detail subnav

### DIFF
--- a/web-client/src/views/CaseDetail/CaseDetailSubnavTabs.jsx
+++ b/web-client/src/views/CaseDetail/CaseDetailSubnavTabs.jsx
@@ -1,47 +1,55 @@
 import { Tab, Tabs } from '../../ustc-ui/Tabs/Tabs';
 import { connect } from '@cerebral/react';
-import { state } from 'cerebral';
+import { sequences, state } from 'cerebral';
 import React from 'react';
 
 export const CaseDetailSubnavTabs = connect(
-  { caseDetailSubnavHelper: state.caseDetailSubnavHelper },
-  ({ caseDetailSubnavHelper }) => {
-    return (
-      <div className="case-detail-primary-tabs__container">
-        <div className="case-detail-primary-tabs__tabs">
-          <Tabs
-            bind="caseDetailPage.primaryTab"
-            className="container-tabs-dark"
-          >
-            <Tab
-              className="padding-left-2"
-              id="tab-docket-record"
-              tabName="docketRecord"
-              title="Docket Record"
-            />
-            {caseDetailSubnavHelper.showDeadlinesTab && (
-              <Tab id="tab-deadlines" tabName="deadlines" title="Deadlines" />
-            )}
-            {caseDetailSubnavHelper.showInProgressTab && (
-              <Tab
-                id="tab-in-progress"
-                tabName="inProgress"
-                title="In Progress"
-              />
-            )}
-            {caseDetailSubnavHelper.showCaseInformationTab && (
-              <Tab
-                id="tab-case-information"
-                tabName="caseInformation"
-                title="Case Information"
-              />
-            )}
-            {caseDetailSubnavHelper.showNotesTab && (
-              <Tab id="tab-notes" tabName="notes" title="Notes" />
-            )}
-          </Tabs>
-        </div>
-      </div>
-    );
-  },
-);
+         {
+           caseDetailSubnavHelper: state.caseDetailSubnavHelper,
+           clearAlertSequence: sequences.clearAlertSequence,
+         },
+         ({ caseDetailSubnavHelper, clearAlertSequence }) => {
+           return (
+             <div className="case-detail-primary-tabs__container">
+               <div className="case-detail-primary-tabs__tabs">
+                 <Tabs
+                   bind="caseDetailPage.primaryTab"
+                   className="container-tabs-dark"
+                   onSelect={() => clearAlertSequence()}
+                 >
+                   <Tab
+                     className="padding-left-2"
+                     id="tab-docket-record"
+                     tabName="docketRecord"
+                     title="Docket Record"
+                   />
+                   {caseDetailSubnavHelper.showDeadlinesTab && (
+                     <Tab
+                       id="tab-deadlines"
+                       tabName="deadlines"
+                       title="Deadlines"
+                     />
+                   )}
+                   {caseDetailSubnavHelper.showInProgressTab && (
+                     <Tab
+                       id="tab-in-progress"
+                       tabName="inProgress"
+                       title="In Progress"
+                     />
+                   )}
+                   {caseDetailSubnavHelper.showCaseInformationTab && (
+                     <Tab
+                       id="tab-case-information"
+                       tabName="caseInformation"
+                       title="Case Information"
+                     />
+                   )}
+                   {caseDetailSubnavHelper.showNotesTab && (
+                     <Tab id="tab-notes" tabName="notes" title="Notes" />
+                   )}
+                 </Tabs>
+               </div>
+             </div>
+           );
+         },
+       );

--- a/web-client/src/views/CaseDetail/CaseDetailSubnavTabs.jsx
+++ b/web-client/src/views/CaseDetail/CaseDetailSubnavTabs.jsx
@@ -4,52 +4,48 @@ import { sequences, state } from 'cerebral';
 import React from 'react';
 
 export const CaseDetailSubnavTabs = connect(
-         {
-           caseDetailSubnavHelper: state.caseDetailSubnavHelper,
-           clearAlertSequence: sequences.clearAlertSequence,
-         },
-         ({ caseDetailSubnavHelper, clearAlertSequence }) => {
-           return (
-             <div className="case-detail-primary-tabs__container">
-               <div className="case-detail-primary-tabs__tabs">
-                 <Tabs
-                   bind="caseDetailPage.primaryTab"
-                   className="container-tabs-dark"
-                   onSelect={() => clearAlertSequence()}
-                 >
-                   <Tab
-                     className="padding-left-2"
-                     id="tab-docket-record"
-                     tabName="docketRecord"
-                     title="Docket Record"
-                   />
-                   {caseDetailSubnavHelper.showDeadlinesTab && (
-                     <Tab
-                       id="tab-deadlines"
-                       tabName="deadlines"
-                       title="Deadlines"
-                     />
-                   )}
-                   {caseDetailSubnavHelper.showInProgressTab && (
-                     <Tab
-                       id="tab-in-progress"
-                       tabName="inProgress"
-                       title="In Progress"
-                     />
-                   )}
-                   {caseDetailSubnavHelper.showCaseInformationTab && (
-                     <Tab
-                       id="tab-case-information"
-                       tabName="caseInformation"
-                       title="Case Information"
-                     />
-                   )}
-                   {caseDetailSubnavHelper.showNotesTab && (
-                     <Tab id="tab-notes" tabName="notes" title="Notes" />
-                   )}
-                 </Tabs>
-               </div>
-             </div>
-           );
-         },
-       );
+  {
+    caseDetailSubnavHelper: state.caseDetailSubnavHelper,
+    clearAlertSequence: sequences.clearAlertSequence,
+  },
+  ({ caseDetailSubnavHelper, clearAlertSequence }) => {
+    return (
+      <div className="case-detail-primary-tabs__container">
+        <div className="case-detail-primary-tabs__tabs">
+          <Tabs
+            bind="caseDetailPage.primaryTab"
+            className="container-tabs-dark"
+            onSelect={() => clearAlertSequence()}
+          >
+            <Tab
+              className="padding-left-2"
+              id="tab-docket-record"
+              tabName="docketRecord"
+              title="Docket Record"
+            />
+            {caseDetailSubnavHelper.showDeadlinesTab && (
+              <Tab id="tab-deadlines" tabName="deadlines" title="Deadlines" />
+            )}
+            {caseDetailSubnavHelper.showInProgressTab && (
+              <Tab
+                id="tab-in-progress"
+                tabName="inProgress"
+                title="In Progress"
+              />
+            )}
+            {caseDetailSubnavHelper.showCaseInformationTab && (
+              <Tab
+                id="tab-case-information"
+                tabName="caseInformation"
+                title="Case Information"
+              />
+            )}
+            {caseDetailSubnavHelper.showNotesTab && (
+              <Tab id="tab-notes" tabName="notes" title="Notes" />
+            )}
+          </Tabs>
+        </div>
+      </div>
+    );
+  },
+);

--- a/web-client/src/views/TrialSessions/AddTrialSession.jsx
+++ b/web-client/src/views/TrialSessions/AddTrialSession.jsx
@@ -35,6 +35,10 @@ export const AddTrialSession = connect(
             aria-labelledby="start-case-header"
             className="usa-form maxw-none"
             role="form"
+            onSubmit={e => {
+              e.preventDefault();
+              submitTrialSessionSequence();
+            }}
           >
             {showModal === 'FormCancelModalDialog' && (
               <FormCancelModalDialog onCancelSequence="closeModalAndReturnToTrialSessionsSequence" />
@@ -72,14 +76,7 @@ export const AddTrialSession = connect(
               </div>
             </div>
 
-            <Button
-              type="button"
-              onClick={() => {
-                submitTrialSessionSequence();
-              }}
-            >
-              Add Session
-            </Button>
+            <Button type="submit">Add Session</Button>
             <Button
               link
               type="button"

--- a/web-client/src/views/TrialSessions/AddTrialSession.jsx
+++ b/web-client/src/views/TrialSessions/AddTrialSession.jsx
@@ -35,10 +35,6 @@ export const AddTrialSession = connect(
             aria-labelledby="start-case-header"
             className="usa-form maxw-none"
             role="form"
-            onSubmit={e => {
-              e.preventDefault();
-              submitTrialSessionSequence();
-            }}
           >
             {showModal === 'FormCancelModalDialog' && (
               <FormCancelModalDialog onCancelSequence="closeModalAndReturnToTrialSessionsSequence" />
@@ -76,9 +72,17 @@ export const AddTrialSession = connect(
               </div>
             </div>
 
-            <Button type="submit">Add Session</Button>
+            <Button
+              type="button"
+              onClick={() => {
+                submitTrialSessionSequence();
+              }}
+            >
+              Add Session
+            </Button>
             <Button
               link
+              type="button"
               onClick={() => {
                 formCancelToggleCancelSequence();
               }}


### PR DESCRIPTION
https://trello.com/c/DCINH95T/324-need-to-clear-success-and-error-messages-when-you-navigate-to-new-tab-on-case-detail-screen
Also fixing accidental submit:
https://trello.com/c/5TE6IPF1/308-add-trial-session-form-clerk-typing-in-address-fields-when-suddenly-the-app-navigated-back-to-trial-sessions-screen-and-had-save