### PR TITLE
Bugs: spouse change of address, QC complete paper service modal

### DIFF
--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
@@ -68,7 +68,7 @@ exports.completeDocketEntryQCInteractor = async ({
   const updatedDocument = new Document(
     {
       ...entryMetadata,
-      createdAt: currentDocument.createdAt, // eslint-disable-line
+      createdAt: currentDocument.createdAt,
       documentId,
       documentType,
       relationship: 'primaryDocument',
@@ -194,6 +194,7 @@ exports.completeDocketEntryQCInteractor = async ({
 
   let servedParties = aggregatePartiesForService(caseEntity);
   let paperServicePdfUrl;
+  let paperServiceDocumentTitle;
 
   if (
     Document.CONTACT_CHANGE_DOCUMENT_TYPES.includes(
@@ -247,6 +248,7 @@ exports.completeDocketEntryQCInteractor = async ({
         });
 
       paperServicePdfUrl = url;
+      paperServiceDocumentTitle = updatedDocument.documentTitle;
     }
   } else if (needsNoticeOfDocketChange) {
     const noticeDocumentId = await generateNoticeOfDocketChangePdf({
@@ -342,6 +344,7 @@ exports.completeDocketEntryQCInteractor = async ({
         });
 
       paperServicePdfUrl = url;
+      paperServiceDocumentTitle = noticeUpdatedDocument.documentTitle;
     }
   }
 
@@ -360,6 +363,7 @@ exports.completeDocketEntryQCInteractor = async ({
 
   return {
     caseDetail: caseEntity.toRawObject(),
+    paperServiceDocumentTitle,
     paperServiceParties: servedParties.paper,
     paperServicePdfUrl,
   };

--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.js
@@ -51,7 +51,10 @@ exports.updatePetitionerInformationInteractor = async ({
     });
 
   const secondaryChange =
-    contactSecondary && contactSecondary.name
+    contactSecondary &&
+    contactSecondary.name &&
+    oldCase.contactSecondary &&
+    oldCase.contactSecondary.name
       ? applicationContext.getUtilities().getDocumentTypeForAddressChange({
           newData: contactSecondary,
           oldData: oldCase.contactSecondary || {},

--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.test.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.test.js
@@ -163,13 +163,49 @@ describe('update petitioner contact information on a case', () => {
     expect(sendServedPartiesEmailsMock).toHaveBeenCalled();
   });
 
-  it('updates petitioner contact when secondary contact info changes, serves the generated notice, and returns the download URL for the paper notice', async () => {
-    const result = await updatePetitionerInformationInteractor({
+  it('updates petitioner contact when secondary contact info changes and does not generate or serve a notice if the secondary contact was not previously present', async () => {
+    await updatePetitionerInformationInteractor({
       applicationContext,
       caseId: 'a805d1ab-18d0-43ec-bafb-654e83405416',
       contactPrimary: MOCK_CASE.contactPrimary,
       contactSecondary: {
         address1: '789 Division St',
+        city: 'Somewhere',
+        countryType: 'domestic',
+        name: 'Test Petitioner',
+        postalCode: '12345',
+        state: 'TN',
+        title: 'Executor',
+      },
+      partyType: ContactFactory.PARTY_TYPES.petitionerSpouse,
+    });
+    expect(updateCaseStub).toHaveBeenCalled();
+    expect(generateChangeOfAddressTemplateStub).not.toHaveBeenCalled();
+    expect(generatePdfFromHtmlInteractorStub).not.toHaveBeenCalled();
+    expect(sendServedPartiesEmailsMock).not.toHaveBeenCalled();
+  });
+
+  it('updates petitioner contact when secondary contact info changes, serves the generated notice, and returns the download URL for the paper notice if the contactSecondary was previously on the case', async () => {
+    persistenceGateway.getCaseByCaseId = () => ({
+      ...MOCK_CASE,
+      contactSecondary: {
+        address1: '789 Division St',
+        city: 'Somewhere',
+        countryType: 'domestic',
+        name: 'Test Petitioner',
+        postalCode: '12345',
+        state: 'TN',
+        title: 'Executor',
+      },
+      partyType: ContactFactory.PARTY_TYPES.petitionerSpouse,
+    });
+
+    const result = await updatePetitionerInformationInteractor({
+      applicationContext,
+      caseId: 'a805d1ab-18d0-43ec-bafb-654e83405416',
+      contactPrimary: MOCK_CASE.contactPrimary,
+      contactSecondary: {
+        address1: '789 Division St APT 123', //changed address1
         city: 'Somewhere',
         countryType: 'domestic',
         name: 'Test Petitioner',

--- a/web-client/src/presenter/actions/EditDocketRecord/completeDocketEntryQCAction.js
+++ b/web-client/src/presenter/actions/EditDocketRecord/completeDocketEntryQCAction.js
@@ -35,6 +35,7 @@ export const completeDocketEntryQCAction = async ({
 
   const {
     caseDetail,
+    paperServiceDocumentTitle,
     paperServiceParties,
     paperServicePdfUrl,
   } = await applicationContext.getUseCases().completeDocketEntryQCInteractor({
@@ -53,6 +54,7 @@ export const completeDocketEntryQCAction = async ({
     },
     caseDetail,
     caseId: docketNumber,
+    paperServiceDocumentTitle,
     paperServiceParties,
     pdfUrl: paperServicePdfUrl,
     updatedDocument,

--- a/web-client/src/presenter/actions/setPaperServicePartiesAction.js
+++ b/web-client/src/presenter/actions/setPaperServicePartiesAction.js
@@ -14,5 +14,6 @@ export const setPaperServicePartiesAction = ({ props, store }) => {
     props.paperServiceParties.length > 0
   ) {
     store.set(state.showModal, 'PaperServiceConfirmModal');
+    store.set(state.form.documentTitle, props.paperServiceDocumentTitle);
   }
 };


### PR DESCRIPTION
https://trello.com/c/WqJoFPwz/327-when-you-add-spouse-changing-party-type-system-is-generates-notice-of-change-of-address-automatically-which-does-not-need-to-be

https://trello.com/c/5UjvkYBe/316-on-qc-complete-the-paper-service-modal-should-not-be-displaying-for-externally-filed-document