### PR TITLE
1912: detail page updates

### DIFF
--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.js
@@ -53,7 +53,7 @@ exports.formattedTrialSessionDetails = ({
     trialSession.term
   } ${trialSession.termYear.substr(-2)}`;
 
-  const allCases = trialSession.caseOrder;
+  const allCases = trialSession.caseOrder || [];
   const inactiveCases = allCases.filter(
     sessionCase => sessionCase.removedFromTrial === true,
   );

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.js
@@ -1,4 +1,4 @@
-const { compact } = require('lodash');
+const { compact, isEmpty, isEqual } = require('lodash');
 
 exports.formatCase = ({ applicationContext, caseItem }) => {
   caseItem.docketNumberWithSuffix = `${
@@ -52,6 +52,19 @@ exports.formattedTrialSessionDetails = ({
   trialSession.formattedTerm = `${
     trialSession.term
   } ${trialSession.termYear.substr(-2)}`;
+
+  const allCases = trialSession.caseOrder;
+  const inactiveCases = allCases.filter(
+    sessionCase => sessionCase.removedFromTrial === true,
+  );
+
+  if (!isEmpty(allCases) && isEqual(allCases, inactiveCases)) {
+    trialSession.computedStatus = 'Closed';
+  } else if (trialSession.isCalendared) {
+    trialSession.computedStatus = 'Open';
+  } else {
+    trialSession.computedStatus = 'New';
+  }
 
   trialSession.formattedStartDate = applicationContext
     .getUtilities()

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
@@ -7,6 +7,7 @@ import { applicationContext } from '../../../../web-client/src/applicationContex
 
 describe('formattedTrialSessionDetails', () => {
   const TRIAL_SESSION = {
+    caseOrder: [],
     city: 'Hartford',
     courtReporter: 'Test Court Reporter',
     irsCalendarAdministrator: 'Test Calendar Admin',
@@ -255,5 +256,49 @@ describe('formattedTrialSessionDetails', () => {
       { docketNumber: '101-18' },
       { docketNumber: '102-19' },
     ]);
+  });
+
+  it('sets computedStatus to New if the session is not calendared', () => {
+    let result = formattedTrialSessionDetails({
+      applicationContext,
+      trialSession: {
+        ...TRIAL_SESSION,
+        isCalendared: false,
+      },
+    });
+    expect(result.computedStatus).toEqual('New');
+  });
+
+  it('sets computedStatus to Open if the session is calendared and caseOrder contains open cases', () => {
+    let result = formattedTrialSessionDetails({
+      applicationContext,
+      trialSession: {
+        ...TRIAL_SESSION,
+        caseOrder: [
+          {
+            caseId: MOCK_CASE.caseId,
+          },
+        ],
+        isCalendared: true,
+      },
+    });
+    expect(result.computedStatus).toEqual('Open');
+  });
+
+  it('sets computedStatus to Closed if the session is calendared and caseOrder contains only cases with removedFromTrial = true', () => {
+    let result = formattedTrialSessionDetails({
+      applicationContext,
+      trialSession: {
+        ...TRIAL_SESSION,
+        caseOrder: [
+          {
+            caseId: MOCK_CASE.caseId,
+            removedFromTrial: true,
+          },
+        ],
+        isCalendared: true,
+      },
+    });
+    expect(result.computedStatus).toEqual('Closed');
   });
 });

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
@@ -8,17 +8,24 @@ export const formattedTrialSessionDetails = (get, applicationContext) => {
       trialSession: get(state.trialSession),
     });
 
-  if (formattedTrialSession && formattedTrialSession.startDate) {
-    const trialDateFormatted = applicationContext
-      .getUtilities()
-      .formatDateString(formattedTrialSession.startDate, 'YYYYMMDD');
-    const nowDateFormatted = applicationContext
-      .getUtilities()
-      .formatNow('YYYYMMDD');
-    const trialDateInFuture = trialDateFormatted > nowDateFormatted;
-    formattedTrialSession.canDelete =
-      trialDateInFuture && !formattedTrialSession.isCalendared;
-    formattedTrialSession.canEdit = trialDateInFuture;
+  if (formattedTrialSession) {
+    formattedTrialSession.showOpenCases =
+      formattedTrialSession.computedStatus === 'Open';
+    formattedTrialSession.showOnlyClosedCases =
+      formattedTrialSession.computedStatus === 'Closed';
+
+    if (formattedTrialSession.startDate) {
+      const trialDateFormatted = applicationContext
+        .getUtilities()
+        .formatDateString(formattedTrialSession.startDate, 'YYYYMMDD');
+      const nowDateFormatted = applicationContext
+        .getUtilities()
+        .formatNow('YYYYMMDD');
+      const trialDateInFuture = trialDateFormatted > nowDateFormatted;
+      formattedTrialSession.canDelete =
+        trialDateInFuture && !formattedTrialSession.isCalendared;
+      formattedTrialSession.canEdit = trialDateInFuture;
+    }
   }
 
   return formattedTrialSession;

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
@@ -10,6 +10,7 @@ const formattedTrialSessionDetails = withAppContextDecorator(
 
 describe('formattedTrialSessionDetails', () => {
   const TRIAL_SESSION = {
+    caseOrder: [],
     city: 'Hartford',
     courtReporter: 'Test Court Reporter',
     irsCalendarAdministrator: 'Test Calendar Admin',
@@ -325,5 +326,36 @@ describe('formattedTrialSessionDetails', () => {
       { docketNumber: '101-18' },
       { docketNumber: '102-19' },
     ]);
+  });
+
+  it('should show open cases when the trial session is calendared and has open cases', () => {
+    let result = runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          caseOrder: [{ caseId: 'eaff20df-d86e-48ab-adc2-831b6ad7e039' }],
+          isCalendared: true,
+        },
+      },
+    });
+    expect(result.showOpenCases).toEqual(true);
+  });
+
+  it('should show only closed cases when the trial session is calendared and has no open cases', () => {
+    let result = runCompute(formattedTrialSessionDetails, {
+      state: {
+        trialSession: {
+          ...TRIAL_SESSION,
+          caseOrder: [
+            {
+              caseId: 'eaff20df-d86e-48ab-adc2-831b6ad7e039',
+              removedFromTrial: true,
+            },
+          ],
+          isCalendared: true,
+        },
+      },
+    });
+    expect(result.showOnlyClosedCases).toEqual(true);
   });
 });

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
@@ -61,7 +61,7 @@ export const TrialSessionDetail = connect(
           </Tabs>
         )}
         {showModal == 'SetCalendarModalDialog' && <SetCalendarModalDialog />}
-        {formattedTrialSessionDetails.isCalendared && (
+        {formattedTrialSessionDetails.showOpenCases && (
           <Tabs
             bind="trialSessionDetailsTab.calendaredCaseList"
             defaultActiveTab="OpenCases"
@@ -83,6 +83,18 @@ export const TrialSessionDetail = connect(
             <Tab id="all-cases-tab" tabName="AllCases" title="All Cases">
               <div id="all-cases-tab-content">
                 <AllCases />
+              </div>
+            </Tab>
+          </Tabs>
+        )}
+        {formattedTrialSessionDetails.showOnlyClosedCases && (
+          <Tabs
+            bind="trialSessionDetailsTab.calendaredCaseList"
+            defaultActiveTab="InactiveCases"
+          >
+            <Tab id="inactive-cases-tab" tabName="InactiveCases" title="Cases">
+              <div id="inactive-cases-tab-content">
+                <InactiveCases />
               </div>
             </Tab>
           </Tabs>

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetailHeader.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetailHeader.jsx
@@ -1,7 +1,6 @@
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
-import classNames from 'classnames';
 
 export const TrialSessionDetailHeader = connect(
   {
@@ -13,16 +12,10 @@ export const TrialSessionDetailHeader = connect(
         <div className="grid-container">
           <div className="margin-bottom-1">
             <h1 tabIndex="-1">{formattedTrialSessionDetails.trialLocation}</h1>
-            <span
-              className={classNames(
-                'usa-tag',
-                !formattedTrialSessionDetails.isCalendared &&
-                  'ustc-tag--yellow',
-              )}
-            >
+            <span className="usa-tag">
               <span aria-hidden="true">
                 {formattedTrialSessionDetails.formattedTerm}:{' '}
-                {formattedTrialSessionDetails.status}
+                {formattedTrialSessionDetails.computedStatus}
               </span>
             </span>
           </div>


### PR DESCRIPTION
* Updated label on trial session detail page to match new trial session statuses
* Only show the Cases (closed cases) tab on detail page for closed trial sessions