### PR TITLE
move icon to the right

### DIFF
--- a/web-client/src/ustc-ui/Button/Button.jsx
+++ b/web-client/src/ustc-ui/Button/Button.jsx
@@ -9,13 +9,12 @@ export const Button = props => {
     className,
     icon,
     iconColor, // e.g. blue
+    iconRight = false,
     link,
+    marginDirection = 'right',
     secondary,
     ...remainingProps
   } = props;
-
-  let { marginDirection } = props;
-  marginDirection = marginDirection || 'right';
 
   const Element = href ? 'a' : 'button';
 
@@ -28,16 +27,19 @@ export const Button = props => {
   );
 
   const iconClasses = classNames(
-    'margin-right-05',
+    iconRight ? 'margin-left-05' : 'margin-right-05',
     iconColor && `fa-icon-${iconColor}`,
   );
 
   return (
     <Element className={classes} {...remainingProps}>
-      {icon && (
+      {icon && !iconRight && (
         <FontAwesomeIcon className={iconClasses} icon={icon} size="1x" />
       )}
       {children}
+      {icon && iconRight && (
+        <FontAwesomeIcon className={iconClasses} icon={icon} size="1x" />
+      )}
     </Element>
   );
 };

--- a/web-client/src/views/SuccessNotification.jsx
+++ b/web-client/src/views/SuccessNotification.jsx
@@ -63,6 +63,7 @@ export const SuccessNotification = connect(
                       link
                       className="no-underline padding-0"
                       icon="times-circle"
+                      iconRight={true}
                       onClick={() => dismissAlertSequence()}
                     >
                       Dismiss

--- a/web-client/src/views/WarningNotification.jsx
+++ b/web-client/src/views/WarningNotification.jsx
@@ -63,6 +63,7 @@ export const WarningNotification = connect(
                       link
                       className="no-underline padding-0"
                       icon="times-circle"
+                      iconRight={true}
                       onClick={() => dismissAlertSequence()}
                     >
                       Dismiss


### PR DESCRIPTION

![Screen Shot 2020-02-06 at 3 59 48 PM](https://user-images.githubusercontent.com/2445917/73982596-264fa880-48fa-11ea-9795-d7d6c8e8689a.png)
move icon to the right of text when a "dismiss" button on a success or warning message