### PR TITLE
helper for wrapping set and unset of progress indicator

### DIFF
--- a/web-client/src/presenter/sequences/convertHtml2PdfSequence.js
+++ b/web-client/src/presenter/sequences/convertHtml2PdfSequence.js
@@ -4,14 +4,13 @@ import { getPdfFileAction } from '../actions/CourtIssuedOrder/getPdfFileAction';
 import { setMetadataAsPristineAction } from '../actions/setMetadataAsPristineAction';
 import { setPdfFileAction } from '../actions/CourtIssuedOrder/setPdfFileAction';
 import { setPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/setPdfPreviewUrlAction';
-import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
+import { showProgressSequenceDecorator } from '../utilities/sequenceHelpers';
 
-export const convertHtml2PdfSequence = [
-  setWaitingForResponseAction,
+export const convertHtml2PdfSequence = showProgressSequenceDecorator([
   createOrderAction,
   clearPdfPreviewUrlAction,
   getPdfFileAction,
   setPdfFileAction,
   setPdfPreviewUrlAction,
   setMetadataAsPristineAction,
-];
+]);

--- a/web-client/src/presenter/utilities/sequenceHelpers.js
+++ b/web-client/src/presenter/utilities/sequenceHelpers.js
@@ -1,7 +1,7 @@
 import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 
-const showProgressSequenceDecorator = actionsList => {
+export const showProgressSequenceDecorator = actionsList => {
   const wrappedActions = [
     setWaitingForResponseAction,
     ...actionsList,
@@ -9,5 +9,3 @@ const showProgressSequenceDecorator = actionsList => {
   ];
   return wrappedActions;
 };
-
-module.exports = { showProgressSequenceDecorator };

--- a/web-client/src/presenter/utilities/sequenceHelpers.js
+++ b/web-client/src/presenter/utilities/sequenceHelpers.js
@@ -1,0 +1,13 @@
+import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
+import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
+
+const showProgressSequenceDecorator = actionsList => {
+  const wrappedActions = [
+    setWaitingForResponseAction,
+    ...actionsList,
+    unsetWaitingForResponseAction,
+  ];
+  return wrappedActions;
+};
+
+module.exports = { showProgressSequenceDecorator };

--- a/web-client/src/presenter/utilities/sequenceHelpers.test.js
+++ b/web-client/src/presenter/utilities/sequenceHelpers.test.js
@@ -1,0 +1,16 @@
+import { showProgressSequenceDecorator } from './sequenceHelpers';
+
+describe('sequenceHelpers', () => {
+  describe('showProgressSequenceDecorator', () => {
+    it('should take an array of actions (functions) and return a new array with same elements plus a function at beginning and end', () => {
+      const mockActionsArray = [jest.fn(), jest.fn(), jest.fn()];
+      const result = showProgressSequenceDecorator(mockActionsArray);
+
+      expect(result).toMatchObject([
+        expect.any(Function),
+        ...mockActionsArray,
+        expect.any(Function),
+      ]);
+    });
+  });
+});

--- a/web-client/src/views/CreateOrder/CreateOrder.jsx
+++ b/web-client/src/views/CreateOrder/CreateOrder.jsx
@@ -1,7 +1,6 @@
 import { Button } from '../../ustc-ui/Button/Button';
 import { CaseDetailHeader } from '../CaseDetail/CaseDetailHeader';
 import { ErrorNotification } from '../ErrorNotification';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FormCancelModalDialog } from '../FormCancelModalDialog';
 import { PdfPreview } from '../../ustc-ui/PdfPreview/PdfPreview';
 import { SuccessNotification } from '../SuccessNotification';

--- a/web-client/src/views/CreateOrder/CreateOrder.jsx
+++ b/web-client/src/views/CreateOrder/CreateOrder.jsx
@@ -57,11 +57,11 @@ export const CreateOrder = connect(
                 <Button
                   link
                   className="margin-top-105 minw-10"
+                  icon="sync"
                   onClick={() => {
                     convertHtml2PdfSequence();
                   }}
                 >
-                  <FontAwesomeIcon icon="sync" size="sm" />
                   Refresh
                 </Button>
               </div>


### PR DESCRIPTION
Creates a utility for decorating sequences which adds the "set waiting indicator" at the beginning and "unset waiting indicator" at the successful conclusion.

Also addresses this bug: https://trello.com/c/e703l0DN/345-clicking-refresh-button-on-create-order-page-produces-a-spinner-and-a-console-error