### PR TITLE
Bug: order margins are incorrect locally

### DIFF
--- a/web-client/src/views/CreateOrder/orderTemplate.html
+++ b/web-client/src/views/CreateOrder/orderTemplate.html
@@ -5,13 +5,19 @@
     <meta charset="utf-8" />
     <style type="text/css">
       /* STYLES_PLACEHOLDER */
-      @page {
-        margin: 2.25cm 2cm 6cm;
-        size: 8.5in 11in;
-      }
       @page :first {
         margin-top: 1cm;
+        margin-right: 2cm;
         margin-bottom: 2cm;
+        margin-left: 2cm;
+        size: 8.5in 11in;
+      }
+      @page {
+        margin-top: 2.25cm;
+        margin-right: 2cm;
+        margin-bottom: 2cm;
+        margin-left: 2cm;
+        size: 8.5in 11in;
       }
       body {
         font-family: 'nimbus_roman', serif;


### PR DESCRIPTION
This ends up being basically the same CSS rules, but for some reason this is the only way it will work locally. 

<img width="450" alt="Screen Shot 2020-02-10 at 10 57 55 AM" src="https://user-images.githubusercontent.com/43251054/74184481-b8f28f00-4bfb-11ea-9f7c-0f78712c4fc6.png">
