### PR TITLE
Devex: all interactors should instantiate their entities (part 2)

### DIFF
--- a/shared/src/business/useCases/blockCaseFromTrialInteractor.js
+++ b/shared/src/business/useCases/blockCaseFromTrialInteractor.js
@@ -42,8 +42,12 @@ exports.blockCaseFromTrialInteractor = async ({
       caseId,
     });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.js
+++ b/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.js
@@ -56,8 +56,12 @@ exports.deleteCounselFromCaseInteractor = async ({
     userId: userIdToDelete,
   });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.test.js
@@ -24,7 +24,7 @@ const mockPetitioners = [{ role: User.ROLES.petitioner, userId: '111' }];
 
 describe('deleteCounselFromCaseInteractor', () => {
   beforeEach(() => {
-    updateCaseMock = jest.fn();
+    updateCaseMock = jest.fn().mockImplementation(v => v.caseToUpdate);
     deleteUserFromCaseMock = jest.fn();
 
     applicationContext = {

--- a/shared/src/business/useCases/caseAssociation/updateCounselOnCaseInteractor.js
+++ b/shared/src/business/useCases/caseAssociation/updateCounselOnCaseInteractor.js
@@ -58,8 +58,12 @@ exports.updateCounselOnCaseInteractor = async ({
     throw new Error('User is not a practitioner or respondent');
   }
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/caseAssociation/updateCounselOnCaseInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociation/updateCounselOnCaseInteractor.test.js
@@ -23,7 +23,7 @@ const mockPetitioners = [{ role: User.ROLES.petitioner, userId: '111' }];
 
 describe('updateCounselOnCaseInteractor', () => {
   beforeEach(() => {
-    updateCaseMock = jest.fn();
+    updateCaseMock = jest.fn().mockImplementation(v => v.caseToUpdate);
 
     applicationContext = {
       getCurrentUser: () => ({

--- a/shared/src/business/useCases/caseConsolidation/addConsolidatedCaseInteractor.js
+++ b/shared/src/business/useCases/caseConsolidation/addConsolidatedCaseInteractor.js
@@ -90,5 +90,5 @@ exports.addConsolidatedCaseInteractor = async ({
     );
   });
 
-  return await Promise.all(updateCasePromises);
+  await Promise.all(updateCasePromises);
 };

--- a/shared/src/business/useCases/caseConsolidation/addConsolidatedCaseInteractor.test.js
+++ b/shared/src/business/useCases/caseConsolidation/addConsolidatedCaseInteractor.test.js
@@ -165,40 +165,40 @@ describe('addConsolidatedCaseInteractor', () => {
   });
 
   it('Should update both cases with the leadCaseId if neither have one', async () => {
-    const result = await addConsolidatedCaseInteractor({
+    await addConsolidatedCaseInteractor({
       applicationContext,
       caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb', // docketNumber: '519-19'
       caseIdToConsolidateWith: 'd44ba5a9-b37b-479d-9201-067ec6e335aa', // docketNumber: '319-19'
     });
 
     expect(updateCaseMock).toHaveBeenCalled();
-    expect(result[0].leadCaseId).toEqual(
+    expect(updateCaseMock.mock.calls[0][0].caseToUpdate.leadCaseId).toEqual(
       'd44ba5a9-b37b-479d-9201-067ec6e335aa', // docketNumber: '319-19'
     );
   });
 
   it('Should update all leadCaseId fields if the new case has the lower docket number', async () => {
-    const result = await addConsolidatedCaseInteractor({
+    await addConsolidatedCaseInteractor({
       applicationContext,
       caseId: '000ba5a9-b37b-479d-9201-067ec6e33000', // docketNumber: '219-19'
       caseIdToConsolidateWith: 'aaaba5a9-b37b-479d-9201-067ec6e33aaa', // docketNumber: '319-19'
     });
 
     expect(updateCaseMock).toHaveBeenCalledTimes(3);
-    expect(result[0].leadCaseId).toEqual(
+    expect(updateCaseMock.mock.calls[0][0].caseToUpdate.leadCaseId).toEqual(
       '000ba5a9-b37b-479d-9201-067ec6e33000', // docketNumber: '219-19'
     );
   });
 
   it('Should combine all cases when both the case and case to consolidate with are in separate consolidated sets', async () => {
-    const result = await addConsolidatedCaseInteractor({
+    await addConsolidatedCaseInteractor({
       applicationContext,
       caseId: 'bbbba5a9-b37b-479d-9201-067ec6e33bbb', // docketNumber: '219-19'
       caseIdToConsolidateWith: '111ba5a9-b37b-479d-9201-067ec6e33111', // docketNumber: '419-19'
     });
 
     expect(updateCaseMock).toHaveBeenCalledTimes(2);
-    expect(result[0].leadCaseId).toEqual(
+    expect(updateCaseMock.mock.calls[0][0].caseToUpdate.leadCaseId).toEqual(
       'bbbba5a9-b37b-479d-9201-067ec6e33bbb', // docketNumber: '219-19'
     );
   });

--- a/shared/src/business/useCases/caseConsolidation/removeConsolidatedCasesInteractor.js
+++ b/shared/src/business/useCases/caseConsolidation/removeConsolidatedCasesInteractor.js
@@ -98,5 +98,5 @@ exports.removeConsolidatedCasesInteractor = async ({
     );
   }
 
-  return await Promise.all(updateCasePromises);
+  await Promise.all(updateCasePromises);
 };

--- a/shared/src/business/useCases/caseDeadline/getCaseDeadlinesForCaseInteractor.js
+++ b/shared/src/business/useCases/caseDeadline/getCaseDeadlinesForCaseInteractor.js
@@ -1,3 +1,5 @@
+const { CaseDeadline } = require('../../entities/CaseDeadline');
+
 /**
  * getCaseDeadlinesForCaseInteractor
  *
@@ -10,10 +12,14 @@ exports.getCaseDeadlinesForCaseInteractor = async ({
   applicationContext,
   caseId,
 }) => {
-  return await applicationContext
+  const caseDeadlines = await applicationContext
     .getPersistenceGateway()
     .getCaseDeadlinesByCaseId({
       applicationContext,
       caseId,
     });
+
+  return CaseDeadline.validateRawCollection(caseDeadlines, {
+    applicationContext,
+  });
 };

--- a/shared/src/business/useCases/caseDeadline/getCaseDeadlinesForCaseInteractor.test.js
+++ b/shared/src/business/useCases/caseDeadline/getCaseDeadlinesForCaseInteractor.test.js
@@ -6,6 +6,14 @@ const { User } = require('../../entities/User');
 describe('getCaseDeadlinesForCaseInteractor', () => {
   let applicationContext;
 
+  const mockCaseDeadline = {
+    caseId: '6805d1ab-18d0-43ec-bafb-654e83405416',
+    caseTitle: 'My Case Title',
+    deadlineDate: '2019-03-01T21:42:29.073Z',
+    description: 'hello world',
+    docketNumber: '101-21',
+  };
+
   it('gets the case deadlines', async () => {
     applicationContext = {
       environment: { stage: 'local' },
@@ -16,8 +24,9 @@ describe('getCaseDeadlinesForCaseInteractor', () => {
           userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
         }),
       getPersistenceGateway: () => ({
-        getCaseDeadlinesByCaseId: v => v,
+        getCaseDeadlinesByCaseId: () => [mockCaseDeadline],
       }),
+      getUniqueId: () => '6ba578e7-5736-435b-a41b-2de3eec29fe7',
     };
 
     let error;

--- a/shared/src/business/useCases/caseNote/deleteCaseNoteInteractor.js
+++ b/shared/src/business/useCases/caseNote/deleteCaseNoteInteractor.js
@@ -37,5 +37,5 @@ exports.deleteCaseNoteInteractor = async ({ applicationContext, caseId }) => {
     applicationContext,
     caseToUpdate,
   });
-  return result;
+  return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/caseNote/deleteCaseNoteInteractor.test.js
+++ b/shared/src/business/useCases/caseNote/deleteCaseNoteInteractor.test.js
@@ -3,7 +3,7 @@ const { MOCK_CASE } = require('../../../test/mockCase');
 const { UnauthorizedError } = require('../../../errors/errors');
 const { User } = require('../../entities/User');
 
-const updateCaseMock = jest.fn().mockImplementation(async c => c);
+const updateCaseMock = jest.fn().mockImplementation(async c => c.caseToUpdate);
 const getCaseByCaseIdMock = jest
   .fn()
   .mockResolvedValue({ ...MOCK_CASE, caseNote: 'My Procedural Note' });
@@ -46,6 +46,7 @@ describe('deleteCaseNoteInteractor', () => {
         getCaseByCaseId: getCaseByCaseIdMock,
         updateCase: updateCaseMock,
       }),
+      getUniqueId: () => '09c66c94-7480-4915-8f10-2f2e6e0bf4ad',
     };
 
     let error;

--- a/shared/src/business/useCases/caseNote/saveCaseNoteInteractor.js
+++ b/shared/src/business/useCases/caseNote/saveCaseNoteInteractor.js
@@ -45,5 +45,5 @@ exports.saveCaseNoteInteractor = async ({
     caseToUpdate,
   });
 
-  return result;
+  return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/getConsolidatedCasesByCaseInteractor.js
+++ b/shared/src/business/useCases/getConsolidatedCasesByCaseInteractor.js
@@ -1,3 +1,5 @@
+const { Case } = require('../entities/cases/Case');
+
 /**
  * getConsolidatedCasesByCaseInteractor
  *
@@ -10,8 +12,12 @@ exports.getConsolidatedCasesByCaseInteractor = async ({
   applicationContext,
   caseId,
 }) => {
-  return await applicationContext.getPersistenceGateway().getCasesByLeadCaseId({
-    applicationContext,
-    leadCaseId: caseId,
-  });
+  const consolidatedCases = await applicationContext
+    .getPersistenceGateway()
+    .getCasesByLeadCaseId({
+      applicationContext,
+      leadCaseId: caseId,
+    });
+
+  return Case.validateRawCollection(consolidatedCases, { applicationContext });
 };

--- a/shared/src/business/useCases/getConsolidatedCasesByCaseInteractor.test.js
+++ b/shared/src/business/useCases/getConsolidatedCasesByCaseInteractor.test.js
@@ -1,4 +1,7 @@
-import { getConsolidatedCasesByCaseInteractor } from './getConsolidatedCasesByCaseInteractor';
+const {
+  getConsolidatedCasesByCaseInteractor,
+} = require('./getConsolidatedCasesByCaseInteractor');
+const { MOCK_CASE } = require('../../test/mockCase');
 
 describe('getConsolidatedCasesByCaseInteractor', () => {
   let applicationContext;
@@ -7,10 +10,12 @@ describe('getConsolidatedCasesByCaseInteractor', () => {
   beforeEach(() => {
     getCasesByLeadCaseIdStub = jest.fn().mockResolvedValue([
       {
+        ...MOCK_CASE,
         caseCaption: 'Guy Fieri vs. Bobby Flay',
         caseId: 'a0af9894-0390-463c-bf17-aae52c34c026',
       },
       {
+        ...MOCK_CASE,
         caseCaption: 'Guy Fieri vs. Gordon Ramsay',
         caseId: '976e0e9d-ffa7-4d56-ac6f-aea848a5dba1',
       },
@@ -30,7 +35,7 @@ describe('getConsolidatedCasesByCaseInteractor', () => {
     });
 
     expect(getCasesByLeadCaseIdStub).toHaveBeenCalled();
-    expect(cases).toEqual([
+    expect(cases).toMatchObject([
       {
         caseCaption: 'Guy Fieri vs. Bobby Flay',
         caseId: 'a0af9894-0390-463c-bf17-aae52c34c026',

--- a/shared/src/business/useCases/getConsolidatedCasesByCaseInteractor.test.js
+++ b/shared/src/business/useCases/getConsolidatedCasesByCaseInteractor.test.js
@@ -6,8 +6,14 @@ describe('getConsolidatedCasesByCaseInteractor', () => {
 
   beforeEach(() => {
     getCasesByLeadCaseIdStub = jest.fn().mockResolvedValue([
-      { caseCaption: 'Guy Fieri vs. Bobby Flay', caseId: 'abc-123' },
-      { caseCaption: 'Guy Fieri vs. Gordon Ramsay', caseId: 'def-321' },
+      {
+        caseCaption: 'Guy Fieri vs. Bobby Flay',
+        caseId: 'a0af9894-0390-463c-bf17-aae52c34c026',
+      },
+      {
+        caseCaption: 'Guy Fieri vs. Gordon Ramsay',
+        caseId: '976e0e9d-ffa7-4d56-ac6f-aea848a5dba1',
+      },
     ]);
 
     applicationContext = {
@@ -25,8 +31,14 @@ describe('getConsolidatedCasesByCaseInteractor', () => {
 
     expect(getCasesByLeadCaseIdStub).toHaveBeenCalled();
     expect(cases).toEqual([
-      { caseCaption: 'Guy Fieri vs. Bobby Flay', caseId: 'abc-123' },
-      { caseCaption: 'Guy Fieri vs. Gordon Ramsay', caseId: 'def-321' },
+      {
+        caseCaption: 'Guy Fieri vs. Bobby Flay',
+        caseId: 'a0af9894-0390-463c-bf17-aae52c34c026',
+      },
+      {
+        caseCaption: 'Guy Fieri vs. Gordon Ramsay',
+        caseId: '976e0e9d-ffa7-4d56-ac6f-aea848a5dba1',
+      },
     ]);
   });
 });

--- a/shared/src/business/useCases/prioritizeCaseInteractor.js
+++ b/shared/src/business/useCases/prioritizeCaseInteractor.js
@@ -51,8 +51,12 @@ exports.prioritizeCaseInteractor = async ({
       caseSortTags: caseEntity.generateTrialSortTags(),
     });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/sealCaseInteractor.js
+++ b/shared/src/business/useCases/sealCaseInteractor.js
@@ -28,8 +28,12 @@ exports.sealCaseInteractor = async ({ applicationContext, caseId }) => {
 
   newCase.setAsSealed();
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: newCase.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: newCase.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/sendPetitionToIRSHoldingQueueInteractor.js
+++ b/shared/src/business/useCases/sendPetitionToIRSHoldingQueueInteractor.js
@@ -81,12 +81,16 @@ exports.sendPetitionToIRSHoldingQueueInteractor = async ({
 
   await Promise.all(caseEntity.getWorkItems().map(processWorkItem));
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity
-      .updateCaseTitleDocketRecord()
-      .updateDocketNumberRecord()
-      .validate()
-      .toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity
+        .updateCaseTitleDocketRecord()
+        .updateDocketNumberRecord()
+        .validate()
+        .toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/trialSessions/addCaseToTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/addCaseToTrialSessionInteractor.js
@@ -81,8 +81,12 @@ exports.addCaseToTrialSessionInteractor = async ({
     trialSessionToUpdate: trialSessionEntity.validate().toRawObject(),
   });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/trialSessions/createTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/createTrialSessionInteractor.js
@@ -57,5 +57,7 @@ exports.createTrialSessionInteractor = async ({
       });
   }
 
-  return createdTrialSession;
+  return new TrialSession(createdTrialSession, { applicationContext })
+    .validate()
+    .toRawObject();
 };

--- a/shared/src/business/useCases/trialSessions/createTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/createTrialSessionInteractor.test.js
@@ -140,7 +140,7 @@ describe('createTrialSessionInteractor', () => {
         });
       },
       getPersistenceGateway: () => ({
-        createTrialSession: trial => trial,
+        createTrialSession: trial => trial.trialSession,
       }),
       getUniqueId: () => 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     };
@@ -153,7 +153,7 @@ describe('createTrialSessionInteractor', () => {
       },
     });
 
-    expect(result.trialSession.isCalendared).toEqual(true);
+    expect(result.isCalendared).toEqual(true);
   });
 
   it('sets the trial session as calendared if it is a Special session type', async () => {
@@ -166,7 +166,7 @@ describe('createTrialSessionInteractor', () => {
         });
       },
       getPersistenceGateway: () => ({
-        createTrialSession: trial => trial,
+        createTrialSession: trial => trial.trialSession,
       }),
       getUniqueId: () => 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     };
@@ -179,7 +179,7 @@ describe('createTrialSessionInteractor', () => {
       },
     });
 
-    expect(result.trialSession.isCalendared).toEqual(true);
+    expect(result.isCalendared).toEqual(true);
   });
 
   it('does not set the trial session as calendared if it is a Regular session type', async () => {
@@ -192,7 +192,7 @@ describe('createTrialSessionInteractor', () => {
         });
       },
       getPersistenceGateway: () => ({
-        createTrialSession: trial => trial,
+        createTrialSession: trial => trial.trialSession,
       }),
       getUniqueId: () => 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     };
@@ -202,6 +202,6 @@ describe('createTrialSessionInteractor', () => {
       trialSession: MOCK_TRIAL,
     });
 
-    expect(result.trialSession.isCalendared).toEqual(false);
+    expect(result.isCalendared).toEqual(false);
   });
 });

--- a/shared/src/business/useCases/trialSessions/removeCaseFromTrialInteractor.js
+++ b/shared/src/business/useCases/trialSessions/removeCaseFromTrialInteractor.js
@@ -74,8 +74,12 @@ exports.removeCaseFromTrialInteractor = async ({
       caseSortTags: caseEntity.generateTrialSortTags(),
     });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.js
+++ b/shared/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.js
@@ -144,8 +144,14 @@ exports.setTrialSessionCalendarInteractor = async ({
     ...eligibleCases.map(setTrialSessionCalendarForEligibleCase),
   ]);
 
-  return await applicationContext.getPersistenceGateway().updateTrialSession({
-    applicationContext,
-    trialSessionToUpdate: trialSessionEntity.validate().toRawObject(),
-  });
+  const updatedTrialSession = await applicationContext
+    .getPersistenceGateway()
+    .updateTrialSession({
+      applicationContext,
+      trialSessionToUpdate: trialSessionEntity.validate().toRawObject(),
+    });
+
+  return new TrialSession(updatedTrialSession, { applicationContext })
+    .validate()
+    .toRawObject();
 };

--- a/shared/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.test.js
@@ -1,4 +1,3 @@
-const sinon = require('sinon');
 const {
   setTrialSessionCalendarInteractor,
 } = require('./setTrialSessionCalendarInteractor');
@@ -52,8 +51,10 @@ describe('setTrialSessionCalendarInteractor', () => {
   });
 
   it('should set a trial session to "calendared" and calendar all cases that have been QCed', async () => {
-    let updateTrialSession = sinon.spy();
-    let updateCaseSpy = sinon.spy();
+    let updateTrialSession = jest
+      .fn()
+      .mockImplementation(v => v.trialSessionToUpdate);
+    let updateCaseSpy = jest.fn();
 
     applicationContext = {
       getCurrentUser: () => {
@@ -95,12 +96,14 @@ describe('setTrialSessionCalendarInteractor', () => {
       applicationContext,
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
-    expect(updateCaseSpy.called).toEqual(true);
+    expect(updateCaseSpy).toBeCalled();
   });
 
   it('should set a trial session to "calendared" but not calendar cases that have not been QCed', async () => {
-    let updateTrialSession = sinon.spy();
-    let updateCaseSpy = sinon.spy();
+    let updateTrialSession = jest
+      .fn()
+      .mockImplementation(v => v.trialSessionToUpdate);
+    let updateCaseSpy = jest.fn();
     applicationContext = {
       getCurrentUser: () => {
         return new User({
@@ -130,7 +133,7 @@ describe('setTrialSessionCalendarInteractor', () => {
           },
         ],
         getTrialSessionById: () => MOCK_TRIAL,
-        updateCase: () => {},
+        updateCase: updateCaseSpy,
         updateTrialSession,
       }),
       getUniqueId: () => 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
@@ -140,7 +143,7 @@ describe('setTrialSessionCalendarInteractor', () => {
       applicationContext,
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
-    expect(updateCaseSpy.called).toEqual(false);
+    expect(updateCaseSpy).not.toBeCalled();
   });
 
   it('should set work items as high priority for each case that is calendared', async () => {
@@ -177,7 +180,7 @@ describe('setTrialSessionCalendarInteractor', () => {
         getTrialSessionById: () => MOCK_TRIAL,
         setPriorityOnAllWorkItems: setPriorityOnAllWorkItemsSpy,
         updateCase: () => {},
-        updateTrialSession: () => {},
+        updateTrialSession: v => v.trialSessionToUpdate,
       }),
       getUniqueId: () => 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     };

--- a/shared/src/business/useCases/unblockCaseFromTrialInteractor.js
+++ b/shared/src/business/useCases/unblockCaseFromTrialInteractor.js
@@ -42,8 +42,12 @@ exports.unblockCaseFromTrialInteractor = async ({
       caseSortTags: caseEntity.generateTrialSortTags(),
     });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/unprioritizeCaseInteractor.js
+++ b/shared/src/business/useCases/unprioritizeCaseInteractor.js
@@ -48,8 +48,12 @@ exports.unprioritizeCaseInteractor = async ({ applicationContext, caseId }) => {
       });
   }
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: caseEntity.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/updateCaseContextInteractor.js
+++ b/shared/src/business/useCases/updateCaseContextInteractor.js
@@ -93,8 +93,12 @@ exports.updateCaseContextInteractor = async ({
     }
   }
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: newCase.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: newCase.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/updatePetitionDetailsInteractor.js
+++ b/shared/src/business/useCases/updatePetitionDetailsInteractor.js
@@ -71,8 +71,12 @@ exports.updatePetitionDetailsInteractor = async ({
     }
   }
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: newCase.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: newCase.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/updateQcCompleteForTrialInteractor.js
+++ b/shared/src/business/useCases/updateQcCompleteForTrialInteractor.js
@@ -35,8 +35,12 @@ exports.updateQcCompleteForTrialInteractor = async ({
 
   newCase.setQcCompleteForTrial({ qcCompleteForTrial, trialSessionId });
 
-  return await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: newCase.validate().toRawObject(),
-  });
+  const updatedCase = await applicationContext
+    .getPersistenceGateway()
+    .updateCase({
+      applicationContext,
+      caseToUpdate: newCase.validate().toRawObject(),
+    });
+
+  return new Case(updatedCase, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/users/createUserInteractor.js
+++ b/shared/src/business/useCases/users/createUserInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { User } = require('../../entities/User');
 
 /**
  * createUserInteractor
@@ -17,8 +18,14 @@ exports.createUserInteractor = async ({ applicationContext, user }) => {
   if (!isAuthorized(requestUser, ROLE_PERMISSIONS.CREATE_USER)) {
     throw new UnauthorizedError('Unauthorized');
   }
-  return await applicationContext.getPersistenceGateway().createUser({
-    applicationContext,
-    user,
-  });
+
+  const userEntity = new User(user, { applicationContext });
+  const createdUser = await applicationContext
+    .getPersistenceGateway()
+    .createUser({
+      applicationContext,
+      user: userEntity.validate().toRawObject(),
+    });
+
+  return new User(createdUser, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/users/createUserInteractor.test.js
+++ b/shared/src/business/useCases/users/createUserInteractor.test.js
@@ -28,7 +28,7 @@ describe('create user', () => {
     const userToCreate = { userId: 'petitionsclerk1@example.com' };
     const user = await createUserInteractor({
       applicationContext,
-      userToCreate,
+      user: userToCreate,
     });
     expect(user).not.toBeUndefined();
   });
@@ -58,7 +58,7 @@ describe('create user', () => {
     try {
       await createUserInteractor({
         applicationContext,
-        userToCreate,
+        user: userToCreate,
       });
     } catch (err) {
       error = err;

--- a/shared/src/business/useCases/users/getPractitionersBySearchKeyInteractor.js
+++ b/shared/src/business/useCases/users/getPractitionersBySearchKeyInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { User } = require('../../entities/User');
 
 /**
  * getPractitionersBySearchKeyInteractor
@@ -24,9 +25,13 @@ exports.getPractitionersBySearchKeyInteractor = async ({
     throw new UnauthorizedError('Unauthorized');
   }
 
-  return await applicationContext.getPersistenceGateway().getUsersBySearchKey({
-    applicationContext,
-    searchKey,
-    type: 'practitioner',
-  });
+  const users = await applicationContext
+    .getPersistenceGateway()
+    .getUsersBySearchKey({
+      applicationContext,
+      searchKey,
+      type: 'practitioner',
+    });
+
+  return User.validateRawCollection(users, { applicationContext });
 };

--- a/shared/src/business/useCases/users/getPractitionersBySearchKeyInteractor.test.js
+++ b/shared/src/business/useCases/users/getPractitionersBySearchKeyInteractor.test.js
@@ -43,7 +43,12 @@ describe('getPractitionersBySearchKeyInteractor', () => {
         };
       },
       getPersistenceGateway: () => ({
-        getUsersBySearchKey: async () => [{ name: 'Test Practitioner' }],
+        getUsersBySearchKey: async () => [
+          {
+            name: 'Test Practitioner',
+            userId: 'f3e91236-495b-4412-b684-1cffe59ed9d9',
+          },
+        ],
       }),
     };
 
@@ -52,6 +57,6 @@ describe('getPractitionersBySearchKeyInteractor', () => {
       searchKey: 'Test Practitioner',
     });
 
-    expect(result).toEqual([{ name: 'Test Practitioner' }]);
+    expect(result).toMatchObject([{ name: 'Test Practitioner' }]);
   });
 });

--- a/shared/src/business/useCases/users/getRespondentsBySearchKeyInteractor.js
+++ b/shared/src/business/useCases/users/getRespondentsBySearchKeyInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { User } = require('../../entities/User');
 
 /**
  * getRespondentsBySearchKeyInteractor
@@ -24,9 +25,13 @@ exports.getRespondentsBySearchKeyInteractor = async ({
     throw new UnauthorizedError('Unauthorized');
   }
 
-  return await applicationContext.getPersistenceGateway().getUsersBySearchKey({
-    applicationContext,
-    searchKey,
-    type: 'respondent',
-  });
+  const users = await applicationContext
+    .getPersistenceGateway()
+    .getUsersBySearchKey({
+      applicationContext,
+      searchKey,
+      type: 'respondent',
+    });
+
+  return User.validateRawCollection(users, { applicationContext });
 };

--- a/shared/src/business/useCases/users/getRespondentsBySearchKeyInteractor.test.js
+++ b/shared/src/business/useCases/users/getRespondentsBySearchKeyInteractor.test.js
@@ -43,7 +43,12 @@ describe('getRespondentsBySearchKeyInteractor', () => {
         };
       },
       getPersistenceGateway: () => ({
-        getUsersBySearchKey: async () => [{ name: 'Test Respondent' }],
+        getUsersBySearchKey: async () => [
+          {
+            name: 'Test Respondent',
+            userId: '7d9eca44-4d10-44f2-9210-e7eed047f3c5',
+          },
+        ],
       }),
     };
 
@@ -52,6 +57,6 @@ describe('getRespondentsBySearchKeyInteractor', () => {
       searchKey: 'Test Respondent',
     });
 
-    expect(result).toEqual([{ name: 'Test Respondent' }]);
+    expect(result).toMatchObject([{ name: 'Test Respondent' }]);
   });
 });

--- a/shared/src/business/useCases/workitems/getInboxMessagesForSectionInteractor.js
+++ b/shared/src/business/useCases/workitems/getInboxMessagesForSectionInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { WorkItem } = require('../../entities/WorkItem');
 
 /**
  * getInboxMessagesForSectionInteractor
@@ -29,5 +30,5 @@ exports.getInboxMessagesForSectionInteractor = async ({
       section,
     });
 
-  return workItems;
+  return WorkItem.validateRawCollection(workItems, { applicationContext });
 };

--- a/shared/src/business/useCases/workitems/getInboxMessagesForUserInteractor.js
+++ b/shared/src/business/useCases/workitems/getInboxMessagesForUserInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { WorkItem } = require('../../entities/WorkItem');
 
 /**
  * getInboxMessagesForUserInteractor
@@ -33,5 +34,11 @@ exports.getInboxMessagesForUserInteractor = async ({
       userId,
     });
 
-  return workItems.filter(workItem => workItem.section === user.section);
+  const filteredWorkItems = workItems.filter(
+    workItem => workItem.section === user.section,
+  );
+
+  return WorkItem.validateRawCollection(filteredWorkItems, {
+    applicationContext,
+  });
 };

--- a/shared/src/business/useCases/workitems/getSentMessagesForSectionInteractor.js
+++ b/shared/src/business/useCases/workitems/getSentMessagesForSectionInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { WorkItem } = require('../../entities/WorkItem');
 
 /**
  *
@@ -30,5 +31,5 @@ exports.getSentMessagesForSectionInteractor = async ({
       section,
     });
 
-  return workItems;
+  return WorkItem.validateRawCollection(workItems, { applicationContext });
 };

--- a/shared/src/business/useCases/workitems/getSentMessagesForUserInteractor.js
+++ b/shared/src/business/useCases/workitems/getSentMessagesForUserInteractor.js
@@ -3,6 +3,7 @@ const {
   ROLE_PERMISSIONS,
 } = require('../../../authorization/authorizationClientService');
 const { UnauthorizedError } = require('../../../errors/errors');
+const { WorkItem } = require('../../entities/WorkItem');
 
 /**
  *
@@ -30,5 +31,5 @@ exports.getSentMessagesForUserInteractor = async ({
       userId,
     });
 
-  return workItems;
+  return WorkItem.validateRawCollection(workItems, { applicationContext });
 };

--- a/shared/src/utilities/JoiValidationDecorator.js
+++ b/shared/src/utilities/JoiValidationDecorator.js
@@ -186,7 +186,7 @@ exports.joiValidationDecorator = function(
   entityConstructor.prototype.toRawObjectFromJoi = toRawObjectPrototype;
 
   entityConstructor.validateRawCollection = function(
-    collection,
+    collection = [],
     { applicationContext },
   ) {
     return collection.map(entity =>

--- a/web-api/src/middleware/apiGatewayHelper.js
+++ b/web-api/src/middleware/apiGatewayHelper.js
@@ -2,6 +2,7 @@ const jwt = require('jsonwebtoken');
 const {
   NotFoundError,
   UnauthorizedError,
+  UnsanitizedEntityError,
 } = require('../../../shared/src/errors/errors');
 const { pick } = require('lodash');
 const headers = {
@@ -27,19 +28,17 @@ exports.handle = async (event, fun) => {
   }
   try {
     let response = await fun();
-    // commenting this out for now so this can be done in stages
-    // if (Array.isArray(response)) {
-    //   response.forEach(item => {
-    //     if (item && (item.pk || item.sk || item.gsi1pk)) {
-    //       throw new UnsanitizedEntityError();
-    //     }
-    //   });
-    // } else {
-    //   if (response && (response.pk || response.sk || response.gsi1pk)) {
-    //     console.log(event);
-    //     throw new UnsanitizedEntityError();
-    //   }
-    // }
+    if (Array.isArray(response)) {
+      response.forEach(item => {
+        if (item && (item.pk || item.sk || item.gsi1pk)) {
+          throw new UnsanitizedEntityError();
+        }
+      });
+    } else {
+      if (response && (response.pk || response.sk || response.gsi1pk)) {
+        throw new UnsanitizedEntityError();
+      }
+    }
     if (event.queryStringParameters && event.queryStringParameters.fields) {
       const { fields } = event.queryStringParameters;
       const fieldsArr = fields.split(',');

--- a/web-api/src/middleware/apiGatewayHelper.test.js
+++ b/web-api/src/middleware/apiGatewayHelper.test.js
@@ -103,10 +103,23 @@ describe('handle', () => {
     });
   });
 
-  it('should return an object representing an 500 status if the function returns an unsanitized entity (response contains private data)', async () => {
+  it('should return an object representing 500 status if the function returns an unsanitized entity (response contains private data)', async () => {
     const response = await handle({}, async () => ({
       pk: 'this is bad!',
     }));
+    expect(response).toEqual({
+      body: JSON.stringify('Unsanitized entity'),
+      headers: EXPECTED_HEADERS,
+      statusCode: 500,
+    });
+  });
+
+  it('should return an object representing 500 status if the function returns an unsanitized entity as an array (response contains private data)', async () => {
+    const response = await handle({}, async () => [
+      {
+        pk: 'this is bad!',
+      },
+    ]);
     expect(response).toEqual({
       body: JSON.stringify('Unsanitized entity'),
       headers: EXPECTED_HEADERS,

--- a/web-api/src/middleware/apiGatewayHelper.test.js
+++ b/web-api/src/middleware/apiGatewayHelper.test.js
@@ -103,7 +103,7 @@ describe('handle', () => {
     });
   });
 
-  xit('should return an object representing an 500 status if the function returns an unsanitized entity (response contains private data)', async () => {
+  it('should return an object representing an 500 status if the function returns an unsanitized entity (response contains private data)', async () => {
     const response = await handle({}, async () => ({
       pk: 'this is bad!',
     }));

--- a/web-api/storage/fixtures/seed/104-19.json
+++ b/web-api/storage/fixtures/seed/104-19.json
@@ -237,6 +237,8 @@
   },
   {
     "createdAt": "2019-08-22T12:47:16.905Z",
+    "caseTitle": "Mufutau Wade",
+    "docketNumber": "104-19",
     "deadlineDate": "2019-08-25T04:00:00.000Z",
     "caseId": "5f6e8b8e-4fac-4fd7-bf3c-42f0d7c3ca05",
     "sk": "case-deadline-ff22fe63-4117-42ee-a66c-8cfd2062a057",
@@ -263,6 +265,8 @@
     "pk": "case-deadline-catalog"
   },
   {
+    "caseTitle": "Mufutau Wade",
+    "docketNumber": "104-19",
     "createdAt": "2019-08-22T12:46:01.052Z",
     "deadlineDate": "2019-08-22T04:00:00.000Z",
     "caseId": "5f6e8b8e-4fac-4fd7-bf3c-42f0d7c3ca05",

--- a/web-api/storage/fixtures/seed/106-19.json
+++ b/web-api/storage/fixtures/seed/106-19.json
@@ -881,6 +881,8 @@
     "updatedAt": "2019-08-08T14:23:51.565Z"
   },
   {
+    "caseTitle": "Denise Gould",
+    "docketNumber": "106-19",
     "createdAt": "2019-08-22T12:49:10.949Z",
     "deadlineDate": "2019-08-23T04:00:00.000Z",
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",

--- a/web-api/storage/fixtures/seed/107-19.json
+++ b/web-api/storage/fixtures/seed/107-19.json
@@ -450,6 +450,8 @@
     "pk": "107-19|case"
   },
   {
+    "caseTitle": "Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s) v. Commissioner of Internal Revenue, Respondent",
+    "docketNumber": "107-19",
     "createdAt": "2019-08-22T12:51:32.434Z",
     "deadlineDate": "2019-08-22T04:00:00.000Z",
     "caseId": "58c1f7a3-8062-42f0-a73e-8bd69b419878",

--- a/web-api/storage/fixtures/seed/109-19.json
+++ b/web-api/storage/fixtures/seed/109-19.json
@@ -151,6 +151,8 @@
     "associatedJudge": "Chief Judge"
   },
   {
+    "caseTitle": "Brett Osborne, Petitioner v. Commissioner of Internal Revenue, Respondent",
+    "docketNumber": "109-19",
     "createdAt": "2019-08-22T12:47:16.905Z",
     "deadlineDate": "2019-08-25T04:00:00.000Z",
     "caseId": "2fb2da8d-4328-4a20-a5d7-b76637e1dc02",

--- a/web-client/src/presenter/actions/caseConsolidation/removeConsolidatedCasesAction.js
+++ b/web-client/src/presenter/actions/caseConsolidation/removeConsolidatedCasesAction.js
@@ -18,13 +18,11 @@ export const removeConsolidatedCasesAction = async ({
     .filter(([, shouldRemove]) => shouldRemove)
     .map(([caseIdToRemove]) => caseIdToRemove);
 
-  const result = await applicationContext
-    .getUseCases()
-    .removeConsolidatedCasesInteractor({
-      applicationContext,
-      caseId,
-      caseIdsToRemove,
-    });
+  await applicationContext.getUseCases().removeConsolidatedCasesInteractor({
+    applicationContext,
+    caseId,
+    caseIdsToRemove,
+  });
 
   return {
     alertSuccess: {
@@ -32,6 +30,5 @@ export const removeConsolidatedCasesAction = async ({
         'You can view your updates to the consolidated cases below under Case Information',
       title: 'Your Changes Have Been Saved',
     },
-    result,
   };
 };


### PR DESCRIPTION
Continuation of #4423.

The reason this is important is so that we can ensure that private data from dynamo is not sent in our responses. Also, we need to make sure we are sending valid data back to the front end.