### PR TITLE
Docket date sort

### DIFF
--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -408,8 +408,16 @@ const formatCase = (applicationContext, caseDetail) => {
 
 const getDocketRecordSortFunc = sortBy => {
   const byIndex = (a, b) => a.index - b.index;
-  const byDate = (a, b) =>
-    dateStringsCompared(a.record.filingDate, b.record.filingDate);
+  const byDate = (a, b) => {
+    const compared = dateStringsCompared(
+      a.record.filingDate,
+      b.record.filingDate,
+    );
+    if (compared === 0) {
+      return byIndex(a, b);
+    }
+    return compared;
+  };
 
   switch (sortBy) {
     case 'byIndex': // fall-through

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -803,6 +803,46 @@ describe('sortDocketRecords', () => {
     expect(result[0].index).toEqual('1');
   });
 
+  it('should evaluate sort items by index if sorted by date and item dates match', () => {
+    const result = sortDocketRecords(
+      [
+        {
+          index: '2',
+          record: {
+            filingDate: '2019-08-03',
+          },
+        },
+        {
+          index: '1',
+          record: {
+            filingDate: '2019-08-03',
+          },
+        },
+        {
+          index: '4',
+          record: {
+            filingDate: '2019-08-03',
+          },
+        },
+        {
+          index: '3',
+          record: {
+            filingDate: '2019-08-03T00:06:44.000Z',
+          },
+        },
+        {
+          index: '5',
+          record: {
+            filingDate: '2019-09-01T00:01:12.025Z',
+          },
+        },
+      ],
+      'byDate',
+    );
+
+    expect(result[0].index).toEqual('1');
+  });
+
   it('should sort docket records by index when sortBy is byIndex', () => {
     const result = sortDocketRecords(
       [


### PR DESCRIPTION
In cases where multiple items in the docket record have the same filing date, the items could become out of order when sorting by date. This uses the entry's index as a secondary sort param if the date's match to ensure they are displayed sequentially.