### PR TITLE
Devex: move persistence private keys into app context

### DIFF
--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -969,6 +969,7 @@ module.exports = (appContextUser = {}) => {
         zipDocuments,
       };
     },
+    getPersistencePrivateKeys: () => ['pk', 'sk', 'gsi1pk'],
     getPug: () => {
       // Notice: this require is here to only have the lambdas that need it call it.
       // This dependency is only available on lambdas with the 'puppeteer' layer,

--- a/web-api/src/cases/getCaseLambda.js
+++ b/web-api/src/cases/getCaseLambda.js
@@ -8,23 +8,30 @@ const { handle } = require('../middleware/apiGatewayHelper');
  * @param {object} event the AWS event object
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
-exports.handler = event =>
-  handle(event, async () => {
-    const user = getUserFromAuthHeader(event);
-    const applicationContext = createApplicationContext(user);
-    try {
-      const results = await applicationContext.getUseCases().getCaseInteractor({
-        applicationContext,
-        caseId: event.pathParameters.caseId,
-      });
-      applicationContext.logger.info('User', user);
-      applicationContext.logger.info('Results', results);
-      return results;
-    } catch (e) {
-      // we don't want email alerts to be sent out just because someone searched for a non-existing case
-      if (!e.skipLogging) {
-        applicationContext.logger.error(e);
+exports.handler = event => {
+  const user = getUserFromAuthHeader(event);
+  const applicationContext = createApplicationContext(user);
+  return handle(
+    event,
+    async () => {
+      try {
+        const results = await applicationContext
+          .getUseCases()
+          .getCaseInteractor({
+            applicationContext,
+            caseId: event.pathParameters.caseId,
+          });
+        applicationContext.logger.info('User', user);
+        applicationContext.logger.info('Results', results);
+        return results;
+      } catch (e) {
+        // we don't want email alerts to be sent out just because someone searched for a non-existing case
+        if (!e.skipLogging) {
+          applicationContext.logger.error(e);
+        }
+        throw e;
       }
-      throw e;
-    }
-  });
+    },
+    applicationContext,
+  );
+};

--- a/web-api/src/middleware/apiGatewayHelper.test.js
+++ b/web-api/src/middleware/apiGatewayHelper.test.js
@@ -137,6 +137,28 @@ describe('handle', () => {
     });
   });
 
+  it('should return 200 status if response is undefined', async () => {
+    const response = await handle(
+      {},
+      async () => undefined,
+      applicationContext,
+    );
+    expect(response).toEqual({
+      body: undefined,
+      headers: EXPECTED_HEADERS,
+      statusCode: '200',
+    });
+  });
+
+  it('should return 200 status if response is an empty array', async () => {
+    const response = await handle({}, async () => [], applicationContext);
+    expect(response).toEqual({
+      body: JSON.stringify([]),
+      headers: EXPECTED_HEADERS,
+      statusCode: '200',
+    });
+  });
+
   it('should return an object representing 500 status if the function returns an unsanitized entity as an array (response contains private data as defined in app context)', async () => {
     const response = await handle(
       {},

--- a/web-api/src/middleware/apiGatewayHelper.test.js
+++ b/web-api/src/middleware/apiGatewayHelper.test.js
@@ -150,10 +150,14 @@ describe('handle', () => {
     });
   });
 
-  it('should return 200 status if response is an empty array', async () => {
-    const response = await handle({}, async () => [], applicationContext);
+  it('should return 200 status if response is an array with an undefined value', async () => {
+    const response = await handle(
+      {},
+      async () => [undefined],
+      applicationContext,
+    );
     expect(response).toEqual({
-      body: JSON.stringify([]),
+      body: JSON.stringify([undefined]),
       headers: EXPECTED_HEADERS,
       statusCode: '200',
     });

--- a/web-api/src/middleware/apiGatewayHelper.test.js
+++ b/web-api/src/middleware/apiGatewayHelper.test.js
@@ -107,6 +107,21 @@ describe('handle', () => {
     });
   });
 
+  it('should not throw an error for private keys if the applicationContext is not passed in', async () => {
+    const response = await handle({}, async () => ({
+      pk: 'also bad',
+      private: 'this is bad!',
+    }));
+    expect(response).toEqual({
+      body: JSON.stringify({
+        pk: 'also bad',
+        private: 'this is bad!',
+      }),
+      headers: EXPECTED_HEADERS,
+      statusCode: '200',
+    });
+  });
+
   it('should return an object representing 500 status if the function returns an unsanitized entity (response contains private data as defined in app context)', async () => {
     const response = await handle(
       {},

--- a/web-api/src/middleware/apiGatewayHelper.test.js
+++ b/web-api/src/middleware/apiGatewayHelper.test.js
@@ -17,6 +17,10 @@ const EXPECTED_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
 };
 
+const applicationContext = {
+  getPersistencePrivateKeys: () => ['private', 'keys'],
+};
+
 describe('handle', () => {
   it('should return warm up string if warm up source is passed in', async () => {
     const response = await handle(
@@ -103,10 +107,14 @@ describe('handle', () => {
     });
   });
 
-  it('should return an object representing 500 status if the function returns an unsanitized entity (response contains private data)', async () => {
-    const response = await handle({}, async () => ({
-      pk: 'this is bad!',
-    }));
+  it('should return an object representing 500 status if the function returns an unsanitized entity (response contains private data as defined in app context)', async () => {
+    const response = await handle(
+      {},
+      async () => ({
+        private: 'this is bad!',
+      }),
+      applicationContext,
+    );
     expect(response).toEqual({
       body: JSON.stringify('Unsanitized entity'),
       headers: EXPECTED_HEADERS,
@@ -114,12 +122,16 @@ describe('handle', () => {
     });
   });
 
-  it('should return an object representing 500 status if the function returns an unsanitized entity as an array (response contains private data)', async () => {
-    const response = await handle({}, async () => [
-      {
-        pk: 'this is bad!',
-      },
-    ]);
+  it('should return an object representing 500 status if the function returns an unsanitized entity as an array (response contains private data as defined in app context)', async () => {
+    const response = await handle(
+      {},
+      async () => [
+        {
+          private: 'this is bad!',
+        },
+      ],
+      applicationContext,
+    );
     expect(response).toEqual({
       body: JSON.stringify('Unsanitized entity'),
       headers: EXPECTED_HEADERS,


### PR DESCRIPTION
It seems like the definition of persistence private keys should be in the applicationContext, but our apiGateway handle function doesn’t currently have the applicationContext sent in. This change modifies our lambdas to create the applicationContext first and send it to the handle function. Another alternative would be for the handle function itself to create the applicationContext from the event that’s sent in - would that be a better approach?