### PR TITLE
Fix createUserInteractor entity validation issue

### DIFF
--- a/shared/src/business/useCases/users/createUserInteractor.js
+++ b/shared/src/business/useCases/users/createUserInteractor.js
@@ -19,12 +19,11 @@ exports.createUserInteractor = async ({ applicationContext, user }) => {
     throw new UnauthorizedError('Unauthorized');
   }
 
-  const userEntity = new User(user, { applicationContext });
   const createdUser = await applicationContext
     .getPersistenceGateway()
     .createUser({
       applicationContext,
-      user: userEntity.validate().toRawObject(),
+      user,
     });
 
   return new User(createdUser, { applicationContext }).validate().toRawObject();


### PR DESCRIPTION
The user data sent to `createUserInteractor` is not valid until `createUser` is called (missing the userId). `createUser` calls Cognito, which sends back the userId, so the user can be validated after this is called. 