### PR TITLE
Add admin to valid user roles

### DIFF
--- a/shared/src/business/entities/User.js
+++ b/shared/src/business/entities/User.js
@@ -9,6 +9,7 @@ const { ContactFactory } = require('../entities/contacts/ContactFactory');
 
 User.ROLES = {
   adc: 'adc',
+  admin: 'admin',
   admissionsClerk: 'admissionsclerk',
   calendarClerk: 'calendarclerk',
   chambers: 'chambers',


### PR DESCRIPTION
When the admin user is created when our Cognito scripts are run with each deploy, it throws an error because admin isn't a valid role.