### PR TITLE
Bug: advanced search form docket number search clears state input

### DIFF
--- a/web-client/src/presenter/sequences/submitCaseDocketNumberSearchSequence.js
+++ b/web-client/src/presenter/sequences/submitCaseDocketNumberSearchSequence.js
@@ -4,6 +4,7 @@ import { clearSearchTermAction } from '../actions/clearSearchTermAction';
 import { navigateToCaseDetailAction } from '../actions/navigateToCaseDetailAction';
 import { set, unset } from 'cerebral/factories';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
+import { setDefaultCountryTypeOnAdvancedSearchFormAction } from '../actions/AdvancedSearch/setDefaultCountryTypeOnAdvancedSearchFormAction';
 import { setDocketNumberFromAdvancedSearchAction } from '../actions/AdvancedSearch/setDocketNumberFromAdvancedSearchAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { showProgressSequenceDecorator } from '../utilities/sequenceHelpers';
@@ -13,6 +14,7 @@ import { validateCaseDocketNumberSearchAction } from '../actions/AdvancedSearch/
 export const submitCaseDocketNumberSearchSequence = [
   clearSearchTermAction,
   clearAdvancedSearchFormAction,
+  setDefaultCountryTypeOnAdvancedSearchFormAction,
   validateCaseDocketNumberSearchAction,
   {
     error: [


### PR DESCRIPTION
https://trello.com/c/kfPq7vDb/379-advanced-search-state-field-in-search-by-name-disappears-when-clicking-on-search-button-in-search-by-docket-number