### PR TITLE
Bug: docket entry save and serve button should validate before opening modal

### DIFF
--- a/web-client/pa11y/pa11y-docketclerk.js
+++ b/web-client/pa11y/pa11y-docketclerk.js
@@ -89,13 +89,17 @@ module.exports = [
   'http://localhost:1234/mock-login?token=docketclerk&path=/case-detail/110-19/documents/25100ec6-eeeb-4e88-872f-c99fad1fe6c7/add-court-issued-docket-entry',
   {
     actions: [
+      'wait for #judge to be visible',
+      'set field #judge to Judge Armen',
+      'check field #judge',
+      'set field #free-text to Anything',
       'wait for #serve-to-parties-btn to be visible',
       'click element #serve-to-parties-btn',
       'wait for .confirm-initiate-service-modal to be visible',
     ],
     notes: 'checks a11y of confirm-initiate-service-modal dialog',
     url:
-      'http://localhost:1234/mock-login?token=docketclerk&path=/case-detail/101-19/documents/25100ec6-eeeb-4e88-872f-c99fad1fe6c7/add-court-issued-docket-entry',
+      'http://localhost:1234/mock-login?token=docketclerk&path=/case-detail/101-19/documents/25100ec6-eeeb-4e88-872f-c99fad1fe6c7/add-court-issued-docket-entry&info=initiate-service-modal',
   },
   'http://localhost:1234/mock-login?token=docketclerk&path=/print-preview/110-19/',
   'http://localhost:1234/mock-login?token=docketclerk&path=/case-detail/105-19/edit-petitioner-information',

--- a/web-client/src/presenter/sequences/openConfirmInitiateServiceModalSequence.js
+++ b/web-client/src/presenter/sequences/openConfirmInitiateServiceModalSequence.js
@@ -1,7 +1,20 @@
+import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction';
+import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
+import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
+import { startShowValidationAction } from '../actions/startShowValidationAction';
+import { validateCourtIssuedDocketEntryAction } from '../actions/CourtIssuedDocketEntry/validateCourtIssuedDocketEntryAction';
 
 export const openConfirmInitiateServiceModalSequence = [
-  clearModalStateAction,
-  setShowModalFactoryAction('ConfirmInitiateServiceModal'),
+  clearAlertsAction,
+  startShowValidationAction,
+  validateCourtIssuedDocketEntryAction,
+  {
+    error: [setValidationErrorsAction, setValidationAlertErrorsAction],
+    success: [
+      clearModalStateAction,
+      setShowModalFactoryAction('ConfirmInitiateServiceModal'),
+    ],
+  },
 ];


### PR DESCRIPTION
https://trello.com/c/ksXvRUgw/377-add-docket-entry-save-and-serve-button-does-not-trigger-field-validation-errors