### PR TITLE
Check for dynamo keys before updating records in migrations

### DIFF
--- a/web-api/migrations/00001-mailing-date.test.js
+++ b/web-api/migrations/00001-mailing-date.test.js
@@ -9,6 +9,9 @@ describe('mailing date migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     putStub = jest.fn().mockReturnValue({
       promise: async () => ({}),
     });

--- a/web-api/migrations/00002-qc-complete-for-trial.test.js
+++ b/web-api/migrations/00002-qc-complete-for-trial.test.js
@@ -9,6 +9,9 @@ describe('qc complete for trial migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     putStub = jest.fn().mockReturnValue({
       promise: async () => ({}),
     });

--- a/web-api/migrations/00003-event-code-docket-entry.test.js
+++ b/web-api/migrations/00003-event-code-docket-entry.test.js
@@ -9,6 +9,9 @@ describe('docket entry event code migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     putStub = jest.fn().mockReturnValue({
       promise: async () => ({}),
     });

--- a/web-api/migrations/00004-service-indicator.test.js
+++ b/web-api/migrations/00004-service-indicator.test.js
@@ -12,6 +12,9 @@ describe('service indicator migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     putStub = jest.fn().mockReturnValue({
       promise: async () => ({}),
     });

--- a/web-api/migrations/00005-service-indicator-respondents.test.js
+++ b/web-api/migrations/00005-service-indicator-respondents.test.js
@@ -12,6 +12,9 @@ describe('service indicator respondents migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     scanStub = jest.fn().mockReturnValue({
       promise: async () => ({
         Items: [MOCK_DOCUMENTS[0]],

--- a/web-api/migrations/00006-document-filing-date.test.js
+++ b/web-api/migrations/00006-document-filing-date.test.js
@@ -9,6 +9,9 @@ describe('document filing date migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     scanStub = jest.fn().mockReturnValue({
       promise: async () => ({
         Items: [MOCK_DOCUMENTS[0]],

--- a/web-api/migrations/00007-previous-document.test.js
+++ b/web-api/migrations/00007-previous-document.test.js
@@ -9,6 +9,9 @@ describe('previous document string to object migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     scanStub = jest.fn().mockReturnValue({
       promise: async () => ({
         Items: [MOCK_DOCUMENTS[0]],

--- a/web-api/migrations/00010-closed-date.test.js
+++ b/web-api/migrations/00010-closed-date.test.js
@@ -10,6 +10,9 @@ describe('closed date migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     scanStub = jest.fn().mockReturnValue({
       promise: async () => ({
         Items: [MOCK_DOCUMENTS[0]],

--- a/web-api/migrations/00012-case-status-in-progress.test.js
+++ b/web-api/migrations/00012-case-status-in-progress.test.js
@@ -9,6 +9,9 @@ describe('in progress case status migration', () => {
   let putStub;
 
   beforeEach(() => {
+    MOCK_CASE.pk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+    MOCK_CASE.sk = '3a45813b-8b4d-4a2e-bfc5-729e85c2332c';
+
     scanStub = jest.fn().mockReturnValue({
       promise: async () => ({
         Items: [MOCK_CASE],

--- a/web-api/migrations/utilities.js
+++ b/web-api/migrations/utilities.js
@@ -32,6 +32,9 @@ const upGenerator = mutateFunction => async (
   await forAllRecords(documentClient, tableName, async item => {
     const updatedItem = await mutateFunction(item, documentClient, tableName);
     if (updatedItem) {
+      if (!updatedItem.pk && !updatedItem.sk && !updatedItem.gsi1pk) {
+        throw new Error('data must contain pk, sk, or gsi1pk');
+      }
       await documentClient
         .put({
           Item: updatedItem,

--- a/web-api/migrations/utilities.test.js
+++ b/web-api/migrations/utilities.test.js
@@ -129,6 +129,8 @@ describe('utilities', () => {
     it('run migration if records were found with the mutator', async () => {
       let mutateFunctionStub = jest.fn().mockReturnValue({
         caseId: 'case-id-123',
+        pk: '123',
+        sk: '123',
       });
 
       await upGenerator(mutateFunctionStub)(
@@ -140,6 +142,23 @@ describe('utilities', () => {
       expect(scanStub).toHaveBeenCalled();
       expect(putStub).toHaveBeenCalled();
       expect(putStub.mock.calls.length).toBe(2);
+    });
+
+    it('throw an error and do not run migration if record returned from the mutator does not have dynamo keys', async () => {
+      let mutateFunctionStub = jest.fn().mockReturnValue({
+        caseId: 'case-id-123',
+      });
+
+      await expect(
+        upGenerator(mutateFunctionStub)(
+          documentClient,
+          'efcms-local',
+          forAllRecords,
+        ),
+      ).rejects.toThrow('data must contain pk, sk, or gsi1pk');
+
+      expect(scanStub).toHaveBeenCalled();
+      expect(putStub).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
If this error is thrown in a migration script that is returning an entity that has been created, the fix would be:
```
return {
    ...item,
    ...entityData,
};
```
This ensures that the dynamo fields that were stripped out when the entity was created are added back in. 