### PR TITLE
Speeding up the Integration Tests

### DIFF
--- a/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
@@ -124,13 +124,11 @@ exports.serveCourtIssuedDocumentInteractor = async ({
     serviceStampText: `${serviceStampType} ${serviceStampDate}`,
   });
 
-  applicationContext.logger.time('Saving S3 Document');
   await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
     applicationContext,
     document: newPdfData,
     documentId,
   });
-  applicationContext.logger.timeEnd('Saving S3 Document');
 
   const workItemToUpdate = courtIssuedDocument.getQCWorkItem();
   await completeWorkItem({

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
@@ -231,14 +231,12 @@ exports.completeDocketEntryQCInteractor = async ({
 
       const paperServicePdfId = applicationContext.getUniqueId();
 
-      applicationContext.logger.time('Saving S3 Document');
       await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
         applicationContext,
         document: paperServicePdfData,
         documentId: paperServicePdfId,
         useTempBucket: true,
       });
-      applicationContext.logger.timeEnd('Saving S3 Document');
 
       const {
         url,
@@ -295,13 +293,11 @@ exports.completeDocketEntryQCInteractor = async ({
       serviceStampText: `Served ${serviceStampDate}`,
     });
 
-    applicationContext.logger.time('Saving S3 Document');
     await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
       applicationContext,
       document: newPdfData,
       documentId: noticeUpdatedDocument.documentId,
     });
-    applicationContext.logger.timeEnd('Saving S3 Document');
 
     await applicationContext.getUseCaseHelpers().sendServedPartiesEmails({
       applicationContext,
@@ -327,14 +323,12 @@ exports.completeDocketEntryQCInteractor = async ({
       const paperServicePdfData = await newPdfDoc.save();
       const paperServicePdfId = applicationContext.getUniqueId();
 
-      applicationContext.logger.time('Saving S3 Document');
       await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
         applicationContext,
         document: paperServicePdfData,
         documentId: paperServicePdfId,
         useTempBucket: true,
       });
-      applicationContext.logger.timeEnd('Saving S3 Document');
 
       const {
         url,

--- a/shared/src/business/useCases/generatePdfFromHtmlInteractor.js
+++ b/shared/src/business/useCases/generatePdfFromHtmlInteractor.js
@@ -21,7 +21,6 @@ exports.generatePdfFromHtmlInteractor = async ({
   let result = null;
 
   try {
-    applicationContext.logger.time('Generating PDF From HTML');
     browser = await applicationContext.getChromiumBrowser();
     let page = await browser.newPage();
 
@@ -81,6 +80,5 @@ exports.generatePdfFromHtmlInteractor = async ({
       await browser.close();
     }
   }
-  applicationContext.logger.timeEnd('Generating PDF From HTML');
   return result;
 };

--- a/shared/src/business/useCases/pdf/validatePdfInteractor.js
+++ b/shared/src/business/useCases/pdf/validatePdfInteractor.js
@@ -9,7 +9,6 @@ const { StringDecoder } = require('string_decoder');
  * @returns {object} errors (null if no errors)
  */
 exports.validatePdfInteractor = async ({ applicationContext, documentId }) => {
-  applicationContext.logger.time(`Fetching S3 File for Validate ${documentId}`);
   let { Body: pdfData } = await applicationContext
     .getStorageClient()
     .getObject({
@@ -17,9 +16,6 @@ exports.validatePdfInteractor = async ({ applicationContext, documentId }) => {
       Key: documentId,
     })
     .promise();
-  applicationContext.logger.timeEnd(
-    `Fetching S3 File for Validate ${documentId}`,
-  );
 
   const stringDecoder = new StringDecoder('utf8');
   const pdfHeaderBytes = pdfData.slice(0, 5);

--- a/shared/src/business/useCases/pdf/virusScanPdfInteractor.js
+++ b/shared/src/business/useCases/pdf/virusScanPdfInteractor.js
@@ -10,9 +10,6 @@ const tmp = require('tmp');
  * @returns {object} errors (null if no errors)
  */
 exports.virusScanPdfInteractor = async ({ applicationContext, documentId }) => {
-  applicationContext.logger.time(
-    `Fetching S3 File for Virus Scan ${documentId}`,
-  );
   let { Body: pdfData } = await applicationContext
     .getStorageClient()
     .getObject({
@@ -20,18 +17,13 @@ exports.virusScanPdfInteractor = async ({ applicationContext, documentId }) => {
       Key: documentId,
     })
     .promise();
-  applicationContext.logger.timeEnd(
-    `Fetching S3 File for Virus Scan ${documentId}`,
-  );
 
   const inputPdf = tmp.fileSync();
   fs.writeSync(inputPdf.fd, Buffer.from(pdfData));
   fs.closeSync(inputPdf.fd);
 
   try {
-    applicationContext.logger.time('Running Clamscan');
     await applicationContext.runVirusScan({ filePath: inputPdf.name });
-    applicationContext.logger.timeEnd('Running Clamscan');
     applicationContext.getStorageClient().putObjectTagging({
       Bucket: applicationContext.environment.documentsBucketName,
       Key: documentId,

--- a/shared/src/business/useCases/saveSignedDocumentInteractor.js
+++ b/shared/src/business/useCases/saveSignedDocumentInteractor.js
@@ -19,7 +19,6 @@ exports.saveSignedDocumentInteractor = async ({
 }) => {
   const user = applicationContext.getCurrentUser();
 
-  applicationContext.logger.time('Fetching the Case');
   const caseRecord = await applicationContext
     .getPersistenceGateway()
     .getCaseByCaseId({
@@ -28,7 +27,6 @@ exports.saveSignedDocumentInteractor = async ({
     });
 
   const caseEntity = new Case(caseRecord, { applicationContext });
-  applicationContext.logger.timeEnd('Fetching the Case');
 
   const originalDocumentEntity = caseEntity.documents.find(
     document => document.documentId === originalDocumentId,
@@ -73,14 +71,10 @@ exports.saveSignedDocumentInteractor = async ({
     caseEntity.updateDocument(signedDocumentEntity);
   }
 
-  applicationContext.logger.time('Updating case with signed document');
-
   await applicationContext.getPersistenceGateway().updateCase({
     applicationContext,
     caseToUpdate: caseEntity.validate().toRawObject(),
   });
-
-  applicationContext.logger.timeEnd('Updating case with signed document');
 
   return caseEntity;
 };

--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.js
@@ -200,14 +200,12 @@ exports.updatePetitionerInformationInteractor = async ({
 
     const paperServicePdfData = await fullDocument.save();
     const paperServicePdfId = applicationContext.getUniqueId();
-    applicationContext.logger.time('Saving S3 Document');
     await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
       applicationContext,
       document: paperServicePdfData,
       documentId: paperServicePdfId,
       useTempBucket: true,
     });
-    applicationContext.logger.timeEnd('Saving S3 Document');
 
     const {
       url,

--- a/web-client/integration-tests-public/unauthedUserSearchesForSealedCase.test.js
+++ b/web-client/integration-tests-public/unauthedUserSearchesForSealedCase.test.js
@@ -27,8 +27,9 @@ describe('Petitioner creates cases to search for', () => {
     jest.setTimeout(10000);
   });
 
+  loginAs(testClient, 'petitioner');
+
   it('Create case', async () => {
-    await loginAs(testClient, 'petitioner');
     const caseDetail = await uploadPetition(testClient, {
       contactSecondary: {
         address1: '734 Cowley Parkway',

--- a/web-client/integration-tests/adcSignsProposedStipDecision.test.js
+++ b/web-client/integration-tests/adcSignsProposedStipDecision.test.js
@@ -31,7 +31,6 @@ import adcSignsOut from './journey/adcSignsOut';
 import adcVerifiesStipulatedDecisionDoesNotExistInInbox from './journey/adcVerifiesStipulatedDecisionDoesNotExistInInbox';
 import adcVerifiesStipulatedDecisionExistsInOutbox from './journey/adcVerifiesStipulatedDecisionExistsInOutbox';
 import adcViewsStipulatedDecisionForSigning from './journey/adcViewsStipulatedDecisionForSigning';
-//
 const test = setupTest({
   useCases: {
     loadPDFForSigningInteractor: () => Promise.resolve(null),

--- a/web-client/integration-tests/adcSignsProposedStipDecision.test.js
+++ b/web-client/integration-tests/adcSignsProposedStipDecision.test.js
@@ -31,7 +31,7 @@ import adcSignsOut from './journey/adcSignsOut';
 import adcVerifiesStipulatedDecisionDoesNotExistInInbox from './journey/adcVerifiesStipulatedDecisionDoesNotExistInInbox';
 import adcVerifiesStipulatedDecisionExistsInOutbox from './journey/adcVerifiesStipulatedDecisionExistsInOutbox';
 import adcViewsStipulatedDecisionForSigning from './journey/adcViewsStipulatedDecisionForSigning';
-
+//
 const test = setupTest({
   useCases: {
     loadPDFForSigningInteractor: () => Promise.resolve(null),

--- a/web-client/integration-tests/createAWorkItem.test.js
+++ b/web-client/integration-tests/createAWorkItem.test.js
@@ -1,76 +1,7 @@
-import { ContactFactory } from '../../shared/src/business/entities/contacts/ContactFactory';
-import { fakeFile, setupTest, wait, waitForRouter } from './helpers';
+import { loginAs, setupTest, uploadPetition } from './helpers';
 
 const DOCKET_CLERK_1_ID = '2805d1ab-18d0-43ec-bafb-654e83405416';
 const MESSAGE = 'new test message';
-
-/**
- * logs a user in for testing with the given persona
- *
- * @param {string} user username to log in with
- * @returns {void} runs submitLoginSequence
- */
-async function loginAs(user) {
-  await test.runSequence('updateFormValueSequence', {
-    key: 'name',
-    value: user,
-  });
-  await test.runSequence('submitLoginSequence');
-  await wait(2000);
-}
-
-/**
- * logs a user in for testing with the given persona
- *
- * @param {object} test the current test object
- * @returns {void} creates and persists a new case
- */
-async function createCase(test) {
-  test.setState('form', {
-    caseType: 'CDP (Lien/Levy)',
-    contactPrimary: {
-      address1: '734 Cowley Parkway',
-      address2: 'Cum aut velit volupt',
-      address3: 'Et sunt veritatis ei',
-      city: 'Et id aut est velit',
-      countryType: 'domestic',
-      name: 'Mona Schultz',
-      phone: '+1 (884) 358-9729',
-      postalCode: '77546',
-      state: 'CT',
-    },
-    contactSecondary: {},
-    filingType: 'Myself',
-    hasIrsNotice: false,
-    partyType: ContactFactory.PARTY_TYPES.petitioner,
-    preferredTrialCity: 'Lubbock, Texas',
-    procedureType: 'Regular',
-    signature: true,
-  });
-
-  await test.runSequence('updateStartCaseFormValueSequence', {
-    key: 'petitionFile',
-    value: fakeFile,
-  });
-
-  await test.runSequence('updateStartCaseFormValueSequence', {
-    key: 'petitionFileSize',
-    value: 1,
-  });
-
-  await test.runSequence('updateStartCaseFormValueSequence', {
-    key: 'stinFile',
-    value: fakeFile,
-  });
-
-  await test.runSequence('updateStartCaseFormValueSequence', {
-    key: 'stinFileSize',
-    value: 1,
-  });
-
-  await test.runSequence('submitFilePetitionSequence');
-  return await waitForRouter();
-}
 
 /**
  * returns a document on the test object based on the given documentType
@@ -157,9 +88,8 @@ describe('Create a work item', () => {
   let petitionDocument;
 
   it('create the case for this test', async () => {
-    await loginAs('petitioner');
-    await waitForRouter();
-    await createCase(test);
+    await loginAs(test, 'petitioner');
+    await uploadPetition(test);
   });
 
   it('keep track of the docketNumber and petitionDocument', () => {
@@ -168,8 +98,7 @@ describe('Create a work item', () => {
   });
 
   it('login as a petitionsclerk and create a new work item on the petition document', async () => {
-    await loginAs('petitionsclerk');
-    await waitForRouter();
+    await loginAs(test, 'petitionsclerk');
 
     await test.runSequence('gotoDocumentDetailSequence', {
       docketNumber: docketNumber,
@@ -202,8 +131,7 @@ describe('Create a work item', () => {
   });
 
   it('login as the docketclerk1 (who we created the new work item for)', async () => {
-    await loginAs('docketclerk1');
-    await waitForRouter();
+    await loginAs(test, 'docketclerk1');
   });
 
   it('verify the work item exists on the docket section inbox', async () => {

--- a/web-client/integration-tests/createAWorkItem.test.js
+++ b/web-client/integration-tests/createAWorkItem.test.js
@@ -87,8 +87,9 @@ describe('Create a work item', () => {
   let docketNumber;
   let petitionDocument;
 
+  loginAs(test, 'petitioner');
+
   it('create the case for this test', async () => {
-    await loginAs(test, 'petitioner');
     await uploadPetition(test);
   });
 
@@ -97,9 +98,9 @@ describe('Create a work item', () => {
     petitionDocument = findByDocumentType(test, 'Petition');
   });
 
-  it('login as a petitionsclerk and create a new work item on the petition document', async () => {
-    await loginAs(test, 'petitionsclerk');
+  loginAs(test, 'petitionsclerk');
 
+  it('login as a petitionsclerk and create a new work item on the petition document', async () => {
     await test.runSequence('gotoDocumentDetailSequence', {
       docketNumber: docketNumber,
       documentId: petitionDocument.documentId,
@@ -130,9 +131,7 @@ describe('Create a work item', () => {
     expect(workItemFromSectionOutbox).toBeDefined();
   });
 
-  it('login as the docketclerk1 (who we created the new work item for)', async () => {
-    await loginAs(test, 'docketclerk1');
-  });
+  loginAs(test, 'docketclerk1');
 
   it('verify the work item exists on the docket section inbox', async () => {
     const workItemFromSectionInbox = await findWorkItemInWorkQueue({

--- a/web-client/integration-tests/docketClerkConsolidatesCases.test.js
+++ b/web-client/integration-tests/docketClerkConsolidatesCases.test.js
@@ -27,8 +27,9 @@ describe('Case Consolidation Journey', () => {
     jest.setTimeout(30000);
   });
 
+  loginAs(test, 'petitioner');
+
   it('login as a petitioner and create the lead case', async () => {
-    await loginAs(test, 'petitioner');
     const caseDetail = await uploadPetition(test, overrides);
     test.caseId = test.leadCaseId = caseDetail.caseId;
     test.docketNumber = test.leadDocketNumber = caseDetail.docketNumber;
@@ -38,8 +39,9 @@ describe('Case Consolidation Journey', () => {
   docketClerkUpdatesCaseStatusToReadyForTrial(test);
   docketClerkSignsOut(test);
 
+  loginAs(test, 'petitioner');
+
   it('login as a petitioner and create the case to consolidate with', async () => {
-    await loginAs(test, 'petitioner');
     const caseDetail = await uploadPetition(test, overrides);
     test.caseId = caseDetail.caseId;
     test.docketNumber = caseDetail.docketNumber;

--- a/web-client/integration-tests/docketClerkCreateMessageWorkflow.test.js
+++ b/web-client/integration-tests/docketClerkCreateMessageWorkflow.test.js
@@ -27,9 +27,9 @@ describe('a docketclerk user creates a new message for another docketclerk user'
   let myCountBefore;
   let myInboxWorkItem;
 
-  it('login as the docketclerk and cache the initial inbox counts', async () => {
-    await loginAs(test, 'docketclerk1');
+  loginAs(test, 'docketclerk1');
 
+  it('login as the docketclerk and cache the initial inbox counts', async () => {
     await getFormattedDocumentQCSectionInbox(test);
     qcSectionInboxCountBefore = getInboxCount(test);
 
@@ -39,8 +39,9 @@ describe('a docketclerk user creates a new message for another docketclerk user'
     notificationsBefore = getNotifications(test);
   });
 
+  loginAs(test, 'petitioner');
+
   it('login as a tax payer and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test);
   });
 
@@ -48,8 +49,9 @@ describe('a docketclerk user creates a new message for another docketclerk user'
     await uploadExternalDecisionDocument(test);
   });
 
+  loginAs(test, 'docketclerk');
+
   it('login as the docketclerk and verify there is a message in the qc section inbox entries', async () => {
-    await loginAs(test, 'docketclerk');
     const documentQCSectionInbox = await getFormattedDocumentQCSectionInbox(
       test,
     );
@@ -127,8 +129,9 @@ describe('a docketclerk user creates a new message for another docketclerk user'
     });
   });
 
+  loginAs(test, 'docketclerk1');
+
   it('login as docketclerk1 and verify we have a message in my inbox', async () => {
-    await loginAs(test, 'docketclerk1');
     const myInbox = await getFormattedMyInbox(test);
     myInboxWorkItem = myInbox.find(
       workItem => workItem.caseId === caseDetail.caseId,

--- a/web-client/integration-tests/docketClerkEditsPetitionPaymentFee.test.js
+++ b/web-client/integration-tests/docketClerkEditsPetitionPaymentFee.test.js
@@ -11,14 +11,15 @@ describe('docket clerk edits a petition payment fee', () => {
 
   let caseDetail;
 
+  loginAs(test, 'petitioner');
+
   it('login as a tax payer and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test);
   });
 
-  it('login as the docketclerk and edit the case petition payment fee', async () => {
-    await loginAs(test, 'docketclerk');
+  loginAs(test, 'docketclerk');
 
+  it('login as the docketclerk and edit the case petition payment fee', async () => {
     await test.runSequence('gotoEditPetitionDetailsSequence', {
       docketNumber: caseDetail.docketNumber,
     });

--- a/web-client/integration-tests/docketClerkEditsPetitionerInformation.test.js
+++ b/web-client/integration-tests/docketClerkEditsPetitionerInformation.test.js
@@ -10,8 +10,9 @@ describe('docket clerk edits the petitioner information', () => {
 
   let caseDetail;
 
+  loginAs(test, 'petitioner');
+
   it('login as a tax payer and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test, {
       contactSecondary: {
         address1: '734 Cowley Parkway',
@@ -27,9 +28,9 @@ describe('docket clerk edits the petitioner information', () => {
     test.docketNumber = caseDetail.docketNumber;
   });
 
-  it('login as the docketclerk and edit the case contact information', async () => {
-    await loginAs(test, 'docketclerk');
+  loginAs(test, 'docketclerk');
 
+  it('login as the docketclerk and edit the case contact information', async () => {
     await test.runSequence('gotoEditPetitionerInformationSequence', {
       docketNumber: caseDetail.docketNumber,
     });

--- a/web-client/integration-tests/docketClerkEditsServiceIndicators.test.js
+++ b/web-client/integration-tests/docketClerkEditsServiceIndicators.test.js
@@ -27,8 +27,9 @@ describe('Docket Clerk edits service indicators for petitioner, practitioner, an
     jest.setTimeout(30000);
   });
 
+  loginAs(test, 'petitioner');
+
   it('login as a petitioner and create a case', async () => {
-    await loginAs(test, 'petitioner');
     const caseDetail = await uploadPetition(test);
     test.docketNumber = caseDetail.docketNumber;
   });

--- a/web-client/integration-tests/docketClerkExternalDocumentQCWorkflow.test.js
+++ b/web-client/integration-tests/docketClerkExternalDocumentQCWorkflow.test.js
@@ -26,9 +26,9 @@ describe('Create a work item', () => {
   let notificationsBefore;
   let decisionWorkItem;
 
-  it('login as the docketclerk and cache the initial inbox counts', async () => {
-    await loginAs(test, 'docketclerk');
+  loginAs(test, 'docketclerk');
 
+  it('login as the docketclerk and cache the initial inbox counts', async () => {
     await getFormattedDocumentQCMyInbox(test);
     qcMyInboxCountBefore = getInboxCount(test);
 
@@ -38,8 +38,8 @@ describe('Create a work item', () => {
     notificationsBefore = getNotifications(test);
   });
 
+  loginAs(test, 'petitioner');
   it('login as a tax payer and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test, {
       contactSecondary: {
         address1: '734 Cowley Parkway',
@@ -60,9 +60,8 @@ describe('Create a work item', () => {
     await uploadExternalDecisionDocument(test);
   });
 
+  loginAs(test, 'docketclerk');
   it('login as the docketclerk and verify there are 3 document qc section inbox entries', async () => {
-    await loginAs(test, 'docketclerk');
-
     const documentQCSectionInbox = await getFormattedDocumentQCSectionInbox(
       test,
     );

--- a/web-client/integration-tests/docketClerkSealsCase.test.js
+++ b/web-client/integration-tests/docketClerkSealsCase.test.js
@@ -28,8 +28,8 @@ describe('Docket Clerk seals a case', () => {
     jest.setTimeout(30000);
   });
 
+  loginAs(test, 'petitioner');
   it('login as a petitioner and create a case', async () => {
-    await loginAs(test, 'petitioner');
     const caseDetail = await uploadPetition(test, {
       contactSecondary: {
         address1: '734 Cowley Parkway',

--- a/web-client/integration-tests/docketClerkUpdateCaseJourney.test.js
+++ b/web-client/integration-tests/docketClerkUpdateCaseJourney.test.js
@@ -8,6 +8,7 @@ import docketClerkViewsEligibleCasesForTrialSession from './journey/docketClerkV
 import docketClerkViewsInactiveCasesForTrialSession from './journey/docketClerkViewsInactiveCasesForTrialSession';
 import docketClerkViewsTrialSessionList from './journey/docketClerkViewsTrialSessionList';
 import markAllCasesAsQCed from './journey/markAllCasesAsQCed';
+import petitionerLogIn from './journey/petitionerLogIn';
 import petitionsClerkLogIn from './journey/petitionsClerkLogIn';
 import petitionsClerkSetsATrialSessionsSchedule from './journey/petitionsClerkSetsATrialSessionsSchedule';
 import userSignsOut from './journey/petitionerSignsOut';
@@ -30,8 +31,9 @@ describe('docket clerk update case journey', () => {
     test.closeSocket();
   });
 
-  it('login as a petitioner and create a case', async () => {
-    await loginAs(test, 'petitioner');
+  loginAs(test, 'petitioner');
+
+  it('create a case', async () => {
     const caseDetail = await uploadPetition(test, overrides);
     test.caseId = caseDetail.caseId;
     test.docketNumber = caseDetail.docketNumber;

--- a/web-client/integration-tests/docketClerkViewsAPendingItem.test.js
+++ b/web-client/integration-tests/docketClerkViewsAPendingItem.test.js
@@ -33,14 +33,14 @@ describe('a docket clerk uploads a pending item and sees that it is pending', ()
   let caseDetail;
   let pendingItemsCount;
 
+  loginAs(test, 'petitioner');
   it('login as a petitioner and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test);
     ({ docketNumber } = caseDetail.docketNumber);
   });
 
+  loginAs(test, 'docketclerk');
   it('login as a docket clerk and check pending items count', async () => {
-    await loginAs(test, 'docketclerk');
     await test.runSequence('gotoCaseDetailSequence', {
       docketNumber,
     });
@@ -54,8 +54,8 @@ describe('a docket clerk uploads a pending item and sees that it is pending', ()
     expect(formatted.pendingItemsDocketEntries.length).toEqual(0);
   });
 
+  loginAs(test, 'respondent');
   it('respondent uploads a proposed stipulated decision', async () => {
-    await loginAs(test, 'respondent');
     await viewCaseDetail({
       docketNumber: caseDetail.docketNumber,
       test,
@@ -63,8 +63,8 @@ describe('a docket clerk uploads a pending item and sees that it is pending', ()
     await uploadProposedStipulatedDecision(test);
   });
 
+  loginAs(test, 'docketclerk');
   it('login as a docket clerk and check pending items count has increased', async () => {
-    await loginAs(test, 'docketclerk');
     await viewCaseDetail({
       docketNumber: caseDetail.docketNumber,
       test,

--- a/web-client/integration-tests/docketClerkViewsCaseDetailMessagesInProgress.test.js
+++ b/web-client/integration-tests/docketClerkViewsCaseDetailMessagesInProgress.test.js
@@ -29,8 +29,8 @@ describe('a docket clerk views case detail messages in progress with a message o
     jest.setTimeout(30000);
   });
 
+  loginAs(test, 'petitioner');
   it('login as a petitioner and create a case', async () => {
-    await loginAs(test, 'petitioner');
     const caseDetail = await uploadPetition(test);
     test.docketNumber = caseDetail.docketNumber;
   });

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -335,12 +335,14 @@ exports.uploadPetition = async (test, overrides = {}) => {
   return test.getState('caseDetail');
 };
 
-exports.loginAs = async (test, user) => {
-  await test.runSequence('updateFormValueSequence', {
-    key: 'name',
-    value: user,
+exports.loginAs = (test, user) => {
+  return it(`login as ${user}`, async () => {
+    await test.runSequence('updateFormValueSequence', {
+      key: 'name',
+      value: user,
+    });
+    await test.runSequence('submitLoginSequence');
   });
-  await test.runSequence('submitLoginSequence');
 };
 
 exports.setupTest = ({ useCases = {} } = {}) => {
@@ -352,7 +354,6 @@ exports.setupTest = ({ useCases = {} } = {}) => {
   };
   global.WebSocket = require('websocket').w3cwebsocket;
   presenter.providers.applicationContext = applicationContext;
-
   const { initialize: initializeSocketProvider, start, stop } = socketProvider({
     socketRouter,
   });
@@ -436,6 +437,8 @@ exports.setupTest = ({ useCases = {} } = {}) => {
   test = CerebralTest(presenter);
   test.getSequence = name => obj => test.runSequence(name, obj);
   test.closeSocket = stop;
+  test.applicationContext = applicationContext;
+
   initializeSocketProvider(test);
 
   global.window = {

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -341,7 +341,6 @@ exports.loginAs = async (test, user) => {
     value: user,
   });
   await test.runSequence('submitLoginSequence');
-  await exports.wait(2000);
 };
 
 exports.setupTest = ({ useCases = {} } = {}) => {

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -332,7 +332,7 @@ exports.uploadPetition = async (test, overrides = {}) => {
   });
 
   await test.runSequence('submitFilePetitionSequence');
-  await exports.wait(4000);
+  // await exports.wait(500);
   return test.getState('caseDetail');
 };
 

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -508,21 +508,6 @@ exports.viewDocumentDetailMessage = async ({
   });
 };
 
-/**
- * This is needed because some sequences run router.route which runs another test.runSequence which
- * adds a new entry on the node event loop and causes the tests to continue running even though the sequence is
- * not yet done.
- *
- * @returns {Promise} resolves when the setImmediate is done
- */
-exports.waitForRouter = () => {
-  return new Promise(resolve => {
-    setImmediate(() => resolve(true));
-  });
-};
-
-exports.flushPromises = () => new Promise(resolve => setImmediate(resolve));
-
 exports.wait = time => {
   return new Promise(resolve => {
     setTimeout(resolve, time);

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -332,7 +332,6 @@ exports.uploadPetition = async (test, overrides = {}) => {
   });
 
   await test.runSequence('submitFilePetitionSequence');
-  // await exports.wait(500);
   return test.getState('caseDetail');
 };
 

--- a/web-client/integration-tests/journey/adcLogIn.js
+++ b/web-client/integration-tests/journey/adcLogIn.js
@@ -7,6 +7,5 @@ export default test => {
       value: 'adc',
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/adcLogIn.js
+++ b/web-client/integration-tests/journey/adcLogIn.js
@@ -7,6 +7,6 @@ export default test => {
       value: 'adc',
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/chambersLogin.js
+++ b/web-client/integration-tests/journey/chambersLogin.js
@@ -9,7 +9,7 @@ export default (test, token = 'armensChambers') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
     expect(test.getState('user.userId')).toEqual(userMap[token].userId);
     expect(applicationContext.getCurrentUser()).toBeDefined();
     expect(applicationContext.getCurrentUser().userId).toEqual(

--- a/web-client/integration-tests/journey/chambersLogin.js
+++ b/web-client/integration-tests/journey/chambersLogin.js
@@ -9,7 +9,6 @@ export default (test, token = 'armensChambers') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
     expect(test.getState('user.userId')).toEqual(userMap[token].userId);
     expect(applicationContext.getCurrentUser()).toBeDefined();
     expect(applicationContext.getCurrentUser().userId).toEqual(

--- a/web-client/integration-tests/journey/docketClerkLogIn.js
+++ b/web-client/integration-tests/journey/docketClerkLogIn.js
@@ -9,7 +9,7 @@ export default (test, token = 'docketclerk') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
     expect(test.getState('user.userId')).toEqual(userMap[token].userId);
     expect(applicationContext.getCurrentUser()).toBeDefined();
     expect(applicationContext.getCurrentUser().userId).toEqual(

--- a/web-client/integration-tests/journey/docketClerkLogIn.js
+++ b/web-client/integration-tests/journey/docketClerkLogIn.js
@@ -9,7 +9,6 @@ export default (test, token = 'docketclerk') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
     expect(test.getState('user.userId')).toEqual(userMap[token].userId);
     expect(applicationContext.getCurrentUser()).toBeDefined();
     expect(applicationContext.getCurrentUser().userId).toEqual(

--- a/web-client/integration-tests/journey/docketClerkNavigatesToEditDocketEntryMeta.js
+++ b/web-client/integration-tests/journey/docketClerkNavigatesToEditDocketEntryMeta.js
@@ -1,13 +1,9 @@
-import { waitForRouter } from '../helpers';
-
 export default (test, docketRecordIndex = 1) => {
   it('the docketclerk navigates to page to edit docket entry meta', async () => {
     await test.runSequence('gotoEditDocketEntryMetaSequence', {
       docketNumber: test.docketNumber,
       docketRecordIndex,
     });
-
-    await waitForRouter();
 
     expect(test.getState('currentPage')).toEqual('EditDocketEntryMeta');
     expect(test.getState('screenMetadata.editType')).toEqual('Document');

--- a/web-client/integration-tests/journey/docketClerkServesOrderWithPaperService.js
+++ b/web-client/integration-tests/journey/docketClerkServesOrderWithPaperService.js
@@ -1,7 +1,6 @@
 import { confirmInitiateServiceModalHelper } from '../../src/presenter/computeds/confirmInitiateServiceModalHelper';
 import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
 import { runCompute } from 'cerebral/test';
-import { waitForRouter } from '../helpers';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 export default (test, draftOrderIndex) => {
@@ -44,8 +43,6 @@ export default (test, draftOrderIndex) => {
       { name: 'Test Person, Petitioner' },
     ]);
     await test.runSequence('serveCourtIssuedDocumentSequence');
-
-    await waitForRouter();
 
     expect(test.getState('currentPage')).toEqual('PrintPreview');
     expect(test.getState('pdfPreviewUrl')).toBeDefined();

--- a/web-client/integration-tests/journey/judgeLogIn.js
+++ b/web-client/integration-tests/journey/judgeLogIn.js
@@ -7,6 +7,6 @@ export default (test, name = 'judgeArmen') => {
       value: name,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/judgeLogIn.js
+++ b/web-client/integration-tests/journey/judgeLogIn.js
@@ -7,6 +7,5 @@ export default (test, name = 'judgeArmen') => {
       value: name,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/petitionerLogIn.js
+++ b/web-client/integration-tests/journey/petitionerLogIn.js
@@ -8,7 +8,7 @@ export default test => {
       value: 'petitioner',
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
     expect(test.getState('user.userId')).toEqual(
       '7805d1ab-18d0-43ec-bafb-654e83405416',
     );

--- a/web-client/integration-tests/journey/petitionerLogIn.js
+++ b/web-client/integration-tests/journey/petitionerLogIn.js
@@ -1,5 +1,4 @@
 import { applicationContext } from '../../src/applicationContext';
-import { wait } from '../helpers';
 
 export default test => {
   return it('petitioner logs in', async () => {

--- a/web-client/integration-tests/journey/petitionerLogIn.js
+++ b/web-client/integration-tests/journey/petitionerLogIn.js
@@ -8,7 +8,6 @@ export default test => {
       value: 'petitioner',
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
     expect(test.getState('user.userId')).toEqual(
       '7805d1ab-18d0-43ec-bafb-654e83405416',
     );

--- a/web-client/integration-tests/journey/petitionsClerkCompletesAndSetsTrialSession.js
+++ b/web-client/integration-tests/journey/petitionsClerkCompletesAndSetsTrialSession.js
@@ -51,7 +51,7 @@ export default (test, overrides = {}) => {
     expect(test.getState('currentPage')).toEqual('TrialSessionDetail');
 
     await test.runSequence('setTrialSessionCalendarSequence');
-    await wait(5000);
+    await wait(1000); // we need to wait for some reason
 
     if (overrides.hasPaper) {
       expect(test.getState('currentPage')).toEqual('SimplePdfPreviewPage');

--- a/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
@@ -1,5 +1,4 @@
 import { Case } from '../../../shared/src/business/entities/cases/Case';
-import { waitForRouter } from '../helpers';
 
 const { VALIDATION_ERROR_MESSAGES } = Case;
 
@@ -162,6 +161,7 @@ export default (test, fakeFile, trialLocation = 'Birmingham, Alabama') => {
     expect(test.getState('validationErrors')).toEqual({});
 
     await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+
     await test.runSequence('gotoReviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');

--- a/web-client/integration-tests/journey/petitionsClerkLogIn.js
+++ b/web-client/integration-tests/journey/petitionsClerkLogIn.js
@@ -7,6 +7,6 @@ export default (test, role = 'petitionsclerk') => {
       value: role,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkLogIn.js
+++ b/web-client/integration-tests/journey/petitionsClerkLogIn.js
@@ -7,6 +7,5 @@ export default (test, role = 'petitionsclerk') => {
       value: role,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkManuallyAddsCaseToCalendaredTrialSession.js
+++ b/web-client/integration-tests/journey/petitionsClerkManuallyAddsCaseToCalendaredTrialSession.js
@@ -21,7 +21,7 @@ export default (test, createdCasesIndex) => {
     });
 
     await test.runSequence('addCaseToTrialSessionSequence');
-    await wait(5000);
+    await wait(1000);
 
     expect(test.getState('caseDetail.trialDate')).toBeDefined();
   });

--- a/web-client/integration-tests/journey/petitionsClerkManuallyAddsCaseToTrial.js
+++ b/web-client/integration-tests/journey/petitionsClerkManuallyAddsCaseToTrial.js
@@ -45,6 +45,6 @@ export default test => {
     expect(modalHelper.showSessionNotSetAlert).toEqual(true);
 
     await test.runSequence('addCaseToTrialSessionSequence');
-    await wait(5000);
+    await wait(1000);
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkSetsATrialSessionsSchedule.js
+++ b/web-client/integration-tests/journey/petitionsClerkSetsATrialSessionsSchedule.js
@@ -6,6 +6,6 @@ export default test => {
       trialSessionId: test.trialSessionId,
     });
     await test.runSequence('setTrialSessionCalendarSequence');
-    await wait(5000);
+    await wait(1000);
   });
 };

--- a/web-client/integration-tests/journey/practitionerLogIn.js
+++ b/web-client/integration-tests/journey/practitionerLogIn.js
@@ -7,6 +7,6 @@ export default (test, token = 'practitioner') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/practitionerLogIn.js
+++ b/web-client/integration-tests/journey/practitionerLogIn.js
@@ -7,6 +7,5 @@ export default (test, token = 'practitioner') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/respondentLogIn.js
+++ b/web-client/integration-tests/journey/respondentLogIn.js
@@ -8,6 +8,5 @@ export default (test, token = 'respondent') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/respondentLogIn.js
+++ b/web-client/integration-tests/journey/respondentLogIn.js
@@ -8,6 +8,6 @@ export default (test, token = 'respondent') => {
       value: token,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/trialClerkLogIn.js
+++ b/web-client/integration-tests/journey/trialClerkLogIn.js
@@ -7,6 +7,6 @@ export default (test, name = 'trialclerk') => {
       value: name,
     });
     await test.runSequence('submitLoginSequence');
-    await wait(2000);
+    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/trialClerkLogIn.js
+++ b/web-client/integration-tests/journey/trialClerkLogIn.js
@@ -7,6 +7,5 @@ export default (test, name = 'trialclerk') => {
       value: name,
     });
     await test.runSequence('submitLoginSequence');
-    // await wait(2000);
   });
 };

--- a/web-client/integration-tests/journey/trialClerkViewsNotesFromCaseDetail.js
+++ b/web-client/integration-tests/journey/trialClerkViewsNotesFromCaseDetail.js
@@ -1,12 +1,8 @@
-import { waitForRouter } from '../helpers';
-
 export default test => {
   return it('Trial Clerk views added notes from case detail', async () => {
     await test.runSequence('gotoCaseDetailSequence', {
       docketNumber: test.docketNumber,
     });
-
-    await waitForRouter();
 
     expect(test.getState('currentPage')).toEqual('CaseDetailInternal');
     expect(test.getState('caseDetail.judgesNote.notes')).toEqual(undefined); // judge (user) notes should not be present

--- a/web-client/integration-tests/judgeAndADCDocumentQC.test.js
+++ b/web-client/integration-tests/judgeAndADCDocumentQC.test.js
@@ -33,14 +33,14 @@ describe('JUDGE and ADC DOC QC: Work Item Filtering', () => {
   let judgeDocketSectionQCInboxCountBefore;
   let adcDocketSectionQCInboxCountBefore;
 
+  loginAs(test, 'judgeCohen');
   it("Get judge's document qc section inbox before", async () => {
-    await loginAs(test, 'judgeCohen');
     await getFormattedDocumentQCSectionInbox(test);
     judgeDocketSectionQCInboxCountBefore = getInboxCount(test);
   });
 
+  loginAs(test, 'adc');
   it("Get adc's document qc section inbox before", async () => {
-    await loginAs(test, 'adc');
     await getFormattedDocumentQCSectionInbox(test);
     adcDocketSectionQCInboxCountBefore = getInboxCount(test);
   });
@@ -66,8 +66,8 @@ describe('JUDGE and ADC DOC QC: Work Item Filtering', () => {
   petitionsClerkManuallyAddsCaseToCalendaredTrialSession(test, 1);
   petitionsClerkSignsOut(test);
 
+  loginAs(test, 'judgeCohen');
   it("Get judge's document qc section inbox after", async () => {
-    await loginAs(test, 'judgeCohen');
     await getFormattedDocumentQCSectionInbox(test);
     const judgeDocketSectionQCInboxCountAfter = getInboxCount(test);
     expect(judgeDocketSectionQCInboxCountAfter).toBe(
@@ -75,8 +75,8 @@ describe('JUDGE and ADC DOC QC: Work Item Filtering', () => {
     );
   });
 
+  loginAs(test, 'adc');
   it("Get adc's document qc section inbox after", async () => {
-    await loginAs(test, 'adc');
     await getFormattedDocumentQCSectionInbox(test);
     const adcDocketSectionQCInboxCountAfter = getInboxCount(test);
     expect(adcDocketSectionQCInboxCountAfter).toBe(

--- a/web-client/integration-tests/modifyContactInfo.test.js
+++ b/web-client/integration-tests/modifyContactInfo.test.js
@@ -25,8 +25,8 @@ describe('Modify Petitioner Contact Information', () => {
 
   let caseDetail;
 
+  loginAs(test, 'petitioner');
   it('login as a tax payer and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test, {
       contactSecondary: {
         address1: '734 Cowley Parkway',

--- a/web-client/integration-tests/modifyPractitionerContactInfo.test.js
+++ b/web-client/integration-tests/modifyPractitionerContactInfo.test.js
@@ -14,8 +14,8 @@ describe('Modify Practitioner Contact Information', () => {
   test.createdDocketNumbers = [];
 
   for (let i = 0; i < 3; i++) {
+    loginAs(test, 'practitioner');
     it(`login as a practitioner and create case #${i}`, async () => {
-      await loginAs(test, 'practitioner');
       caseDetail = await uploadPetition(test);
       test.createdDocketNumbers.push(caseDetail.docketNumber);
     });

--- a/web-client/integration-tests/modifyRespondentContactInfo.test.js
+++ b/web-client/integration-tests/modifyRespondentContactInfo.test.js
@@ -18,7 +18,6 @@ describe('Modify Respondent Contact Information', () => {
     it(`create case #${i} and associate a respondent`, async () => {
       await loginAs(test, 'petitioner');
       caseDetail = await uploadPetition(test);
-      // await wait(1000);
       test.createdDocketNumbers.push(caseDetail.docketNumber);
       await loginAs(test, 'petitionsclerk');
       await test.runSequence('gotoCaseDetailSequence', {

--- a/web-client/integration-tests/modifyRespondentContactInfo.test.js
+++ b/web-client/integration-tests/modifyRespondentContactInfo.test.js
@@ -18,7 +18,7 @@ describe('Modify Respondent Contact Information', () => {
     it(`create case #${i} and associate a respondent`, async () => {
       await loginAs(test, 'petitioner');
       caseDetail = await uploadPetition(test);
-      await wait(1000);
+      // await wait(1000);
       test.createdDocketNumbers.push(caseDetail.docketNumber);
       await loginAs(test, 'petitionsclerk');
       await test.runSequence('gotoCaseDetailSequence', {

--- a/web-client/integration-tests/modifyRespondentContactInfo.test.js
+++ b/web-client/integration-tests/modifyRespondentContactInfo.test.js
@@ -15,11 +15,16 @@ describe('Modify Respondent Contact Information', () => {
   test.createdDocketNumbers = [];
 
   for (let i = 0; i < 3; i++) {
+    loginAs(test, 'petitioner');
+
     it(`create case #${i} and associate a respondent`, async () => {
-      await loginAs(test, 'petitioner');
       caseDetail = await uploadPetition(test);
       test.createdDocketNumbers.push(caseDetail.docketNumber);
-      await loginAs(test, 'petitionsclerk');
+    });
+
+    loginAs(test, 'petitionsclerk');
+
+    it('associates a respondent', async () => {
       await test.runSequence('gotoCaseDetailSequence', {
         docketNumber: test.createdDocketNumbers[i],
       });

--- a/web-client/integration-tests/noticeOfTrialSessionWithElectronicService.test.js
+++ b/web-client/integration-tests/noticeOfTrialSessionWithElectronicService.test.js
@@ -74,7 +74,7 @@ describe('Generate Notices of Trial Session with Electronically Service', () => 
   markAllCasesAsQCed(test, () => {
     return [createdCases[0], createdCases[1]];
   });
-  petitionsClerkCompletesAndSetsTrialSession(test);
+  petitionsClerkCompletesAndSetsTrialSession(test); //
   petitionsClerkViewsDocketRecordAfterSettingTrial(test, {
     documentTitle: 'Standing Pretrial Order', // this is the default, but setting so it's more explicit
   });

--- a/web-client/integration-tests/noticeOfTrialSessionWithElectronicService.test.js
+++ b/web-client/integration-tests/noticeOfTrialSessionWithElectronicService.test.js
@@ -74,7 +74,7 @@ describe('Generate Notices of Trial Session with Electronically Service', () => 
   markAllCasesAsQCed(test, () => {
     return [createdCases[0], createdCases[1]];
   });
-  petitionsClerkCompletesAndSetsTrialSession(test); //
+  petitionsClerkCompletesAndSetsTrialSession(test);
   petitionsClerkViewsDocketRecordAfterSettingTrial(test, {
     documentTitle: 'Standing Pretrial Order', // this is the default, but setting so it's more explicit
   });

--- a/web-client/integration-tests/noticeOfTrialSessionWithPaperService.test.js
+++ b/web-client/integration-tests/noticeOfTrialSessionWithPaperService.test.js
@@ -87,7 +87,7 @@ describe('Generate Notices of Trial Session with Paper Service', () => {
   markAllCasesAsQCed(test, () => {
     return [createdCases[0], createdCases[1]];
   });
-  petitionsClerkCompletesAndSetsTrialSession(test, overrides); //
+  petitionsClerkCompletesAndSetsTrialSession(test, overrides);
   petitionsClerkViewsDocketRecordAfterSettingTrial(test, {
     documentTitle: 'Standing Pretrial Notice',
   });

--- a/web-client/integration-tests/noticeOfTrialSessionWithPaperService.test.js
+++ b/web-client/integration-tests/noticeOfTrialSessionWithPaperService.test.js
@@ -87,7 +87,7 @@ describe('Generate Notices of Trial Session with Paper Service', () => {
   markAllCasesAsQCed(test, () => {
     return [createdCases[0], createdCases[1]];
   });
-  petitionsClerkCompletesAndSetsTrialSession(test, overrides);
+  petitionsClerkCompletesAndSetsTrialSession(test, overrides); //
   petitionsClerkViewsDocketRecordAfterSettingTrial(test, {
     documentTitle: 'Standing Pretrial Notice',
   });

--- a/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
+++ b/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
@@ -48,7 +48,7 @@ describe('petitioner files document', () => {
     });
 
     await test.runSequence('addCaseToTrialSessionSequence');
-    // await wait(5000);
+    await wait(1000);
   });
   userSignsOut(test);
 

--- a/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
+++ b/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
@@ -24,41 +24,43 @@ describe('petitioner files document', () => {
   });
 
   petitionerLogIn(test);
+  it('a', () => console.time('uploadPetition'));
   it('Create case', async () => {
     const caseDetail = await uploadPetition(test);
     test.docketNumber = caseDetail.docketNumber;
   });
+  it('a', () => console.timeEnd('uploadPetition'));
   userSignsOut(test);
 
-  docketClerkLogIn(test);
-  docketClerkCreatesATrialSession(test);
-  docketClerkViewsTrialSessionList(test);
-  userSignsOut(test);
+  // docketClerkLogIn(test);
+  // docketClerkCreatesATrialSession(test);
+  // docketClerkViewsTrialSessionList(test);
+  // userSignsOut(test);
 
-  petitionsClerkLogIn(test);
-  petitionsClerkSetsATrialSessionsSchedule(test);
-  it('manually add the case to the session', async () => {
-    await test.runSequence('gotoCaseDetailSequence', {
-      docketNumber: test.docketNumber,
-    });
-    await test.runSequence('openAddToTrialModalSequence');
-    await test.runSequence('updateModalValueSequence', {
-      key: 'trialSessionId',
-      value: test.trialSessionId,
-    });
+  // petitionsClerkLogIn(test);
+  // petitionsClerkSetsATrialSessionsSchedule(test);
+  // it('manually add the case to the session', async () => {
+  //   await test.runSequence('gotoCaseDetailSequence', {
+  //     docketNumber: test.docketNumber,
+  //   });
+  //   await test.runSequence('openAddToTrialModalSequence');
+  //   await test.runSequence('updateModalValueSequence', {
+  //     key: 'trialSessionId',
+  //     value: test.trialSessionId,
+  //   });
 
-    await test.runSequence('addCaseToTrialSessionSequence');
-    await wait(5000);
-  });
-  userSignsOut(test);
+  //   await test.runSequence('addCaseToTrialSessionSequence');
+  //   await wait(5000);
+  // });
+  // userSignsOut(test);
 
-  petitionerLogIn(test);
-  petitionerFilesDocumentForCase(test, fakeFile);
-  userSignsOut(test);
-
-  docketClerkLogIn(test);
-  docketClerkViewsSectionInboxHighPriority(test);
-  docketClerkRemovesCaseFromTrial(test);
-  docketClerkViewsSectionInboxNotHighPriority(test);
-  userSignsOut(test);
+  // petitionerLogIn(test);
+  // petitionerFilesDocumentForCase(test, fakeFile);
+  // userSignsOut(test);
+  // //
+  // docketClerkLogIn(test);
+  // docketClerkViewsSectionInboxHighPriority(test);
+  // docketClerkRemovesCaseFromTrial(test);
+  // docketClerkViewsSectionInboxNotHighPriority(test);
+  // userSignsOut(test);
 });

--- a/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
+++ b/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
@@ -24,43 +24,41 @@ describe('petitioner files document', () => {
   });
 
   petitionerLogIn(test);
-  it('a', () => console.time('uploadPetition'));
   it('Create case', async () => {
     const caseDetail = await uploadPetition(test);
     test.docketNumber = caseDetail.docketNumber;
   });
-  it('a', () => console.timeEnd('uploadPetition'));
   userSignsOut(test);
 
-  // docketClerkLogIn(test);
-  // docketClerkCreatesATrialSession(test);
-  // docketClerkViewsTrialSessionList(test);
-  // userSignsOut(test);
+  docketClerkLogIn(test);
+  docketClerkCreatesATrialSession(test);
+  docketClerkViewsTrialSessionList(test);
+  userSignsOut(test);
 
-  // petitionsClerkLogIn(test);
-  // petitionsClerkSetsATrialSessionsSchedule(test);
-  // it('manually add the case to the session', async () => {
-  //   await test.runSequence('gotoCaseDetailSequence', {
-  //     docketNumber: test.docketNumber,
-  //   });
-  //   await test.runSequence('openAddToTrialModalSequence');
-  //   await test.runSequence('updateModalValueSequence', {
-  //     key: 'trialSessionId',
-  //     value: test.trialSessionId,
-  //   });
+  petitionsClerkLogIn(test);
+  petitionsClerkSetsATrialSessionsSchedule(test);
+  it('manually add the case to the session', async () => {
+    await test.runSequence('gotoCaseDetailSequence', {
+      docketNumber: test.docketNumber,
+    });
+    await test.runSequence('openAddToTrialModalSequence');
+    await test.runSequence('updateModalValueSequence', {
+      key: 'trialSessionId',
+      value: test.trialSessionId,
+    });
 
-  //   await test.runSequence('addCaseToTrialSessionSequence');
-  //   await wait(5000);
-  // });
-  // userSignsOut(test);
+    await test.runSequence('addCaseToTrialSessionSequence');
+    await wait(5000);
+  });
+  userSignsOut(test);
 
-  // petitionerLogIn(test);
-  // petitionerFilesDocumentForCase(test, fakeFile);
-  // userSignsOut(test);
-  // //
-  // docketClerkLogIn(test);
-  // docketClerkViewsSectionInboxHighPriority(test);
-  // docketClerkRemovesCaseFromTrial(test);
-  // docketClerkViewsSectionInboxNotHighPriority(test);
-  // userSignsOut(test);
+  petitionerLogIn(test);
+  petitionerFilesDocumentForCase(test, fakeFile);
+  userSignsOut(test);
+  //
+  docketClerkLogIn(test);
+  docketClerkViewsSectionInboxHighPriority(test);
+  docketClerkRemovesCaseFromTrial(test);
+  docketClerkViewsSectionInboxNotHighPriority(test);
+  userSignsOut(test);
 });

--- a/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
+++ b/web-client/integration-tests/petitionerFilesADocumentForCalendaredCase.test.js
@@ -48,14 +48,13 @@ describe('petitioner files document', () => {
     });
 
     await test.runSequence('addCaseToTrialSessionSequence');
-    await wait(5000);
+    // await wait(5000);
   });
   userSignsOut(test);
 
   petitionerLogIn(test);
   petitionerFilesDocumentForCase(test, fakeFile);
   userSignsOut(test);
-  //
   docketClerkLogIn(test);
   docketClerkViewsSectionInboxHighPriority(test);
   docketClerkRemovesCaseFromTrial(test);

--- a/web-client/integration-tests/petitionsClerkBlockCase.test.js
+++ b/web-client/integration-tests/petitionsClerkBlockCase.test.js
@@ -168,14 +168,11 @@ describe('Blocking a Case', () => {
     });
 
     await test.runSequence('addCaseToTrialSessionSequence');
-    // await wait(1000);
+    await wait(1000);
   });
 
   petitionsClerkCreatesACaseDeadline(test);
   it('petitions clerk views blocked report with no blocked cases', async () => {
-    // we need to wait for elasticsearch to get updated by the processing stream lambda
-    // await wait(10000);
-
     await test.runSequence('gotoBlockedCasesReportSequence');
 
     await test.runSequence('getBlockedCasesByTrialLocationSequence', {
@@ -191,9 +188,6 @@ describe('Blocking a Case', () => {
 
   petitionsClerkCreatesACaseDeadline(test);
   it('petitions clerk views blocked report with no blocked cases', async () => {
-    // we need to wait for elasticsearch to get updated by the processing stream lambda
-    // await wait(10000);
-
     await test.runSequence('gotoBlockedCasesReportSequence');
 
     await test.runSequence('getBlockedCasesByTrialLocationSequence', {

--- a/web-client/integration-tests/petitionsClerkBlockCase.test.js
+++ b/web-client/integration-tests/petitionsClerkBlockCase.test.js
@@ -168,13 +168,13 @@ describe('Blocking a Case', () => {
     });
 
     await test.runSequence('addCaseToTrialSessionSequence');
-    await wait(5000);
+    // await wait(1000);
   });
 
   petitionsClerkCreatesACaseDeadline(test);
   it('petitions clerk views blocked report with no blocked cases', async () => {
     // we need to wait for elasticsearch to get updated by the processing stream lambda
-    await wait(10000);
+    // await wait(10000);
 
     await test.runSequence('gotoBlockedCasesReportSequence');
 
@@ -192,7 +192,7 @@ describe('Blocking a Case', () => {
   petitionsClerkCreatesACaseDeadline(test);
   it('petitions clerk views blocked report with no blocked cases', async () => {
     // we need to wait for elasticsearch to get updated by the processing stream lambda
-    await wait(10000);
+    // await wait(10000);
 
     await test.runSequence('gotoBlockedCasesReportSequence');
 

--- a/web-client/integration-tests/petitionsClerkBlockCase.test.js
+++ b/web-client/integration-tests/petitionsClerkBlockCase.test.js
@@ -87,8 +87,9 @@ describe('Blocking a Case', () => {
   petitionsClerkSignsOut(test);
 
   //automatic block with a pending item
+  loginAs(test, 'respondent');
+
   it('respondent uploads a proposed stipulated decision (pending item)', async () => {
-    await loginAs(test, 'respondent');
     await viewCaseDetail({
       docketNumber: setupTest.docketNumber,
       test,

--- a/web-client/integration-tests/sentWorkItemsExpireAfter7Days.test.js
+++ b/web-client/integration-tests/sentWorkItemsExpireAfter7Days.test.js
@@ -23,8 +23,11 @@ describe('verify old sent work items do not show up in the outbox', () => {
 
   beforeEach(async () => {
     jest.setTimeout(30000);
+  });
 
-    await loginAs(test, 'petitioner');
+  loginAs(test, 'petitioner');
+
+  it('creates the case', async () => {
     caseDetail = await uploadPetition(test);
 
     const applicationContext = applicationContextFactory({
@@ -108,9 +111,9 @@ describe('verify old sent work items do not show up in the outbox', () => {
     });
   });
 
-  it('the petitionsclerk user should have the expected work items equal to or new than 7 days', async () => {
-    await loginAs(test, 'petitionsclerk');
+  loginAs(test, 'petitionsclerk');
 
+  it('the petitionsclerk user should have the expected work items equal to or new than 7 days', async () => {
     const myOutbox = (await getFormattedMyOutbox(test)).filter(
       item => item.docketNumber === caseDetail.docketNumber,
     );

--- a/web-client/integration-tests/servedWorkItemsExpireAfter7Days.test.js
+++ b/web-client/integration-tests/servedWorkItemsExpireAfter7Days.test.js
@@ -24,8 +24,11 @@ describe('verify old served work items do not show up in the outbox', () => {
 
   beforeEach(async () => {
     jest.setTimeout(300000);
+  });
 
-    await loginAs(test, 'petitioner');
+  loginAs(test, 'petitioner');
+
+  it('creates a case', async () => {
     caseDetail = await uploadPetition(test);
 
     const applicationContext = applicationContextFactory({
@@ -111,9 +114,9 @@ describe('verify old served work items do not show up in the outbox', () => {
     });
   });
 
-  it('the petitionsclerk user should have the expected work items equal to or new than 7 days', async () => {
-    await loginAs(test, 'petitionsclerk');
+  loginAs(test, 'petitionsclerk');
 
+  it('the petitionsclerk user should have the expected work items equal to or new than 7 days', async () => {
     const myOutbox = (await getFormattedDocumentQCMyOutbox(test)).filter(
       item => item.docketNumber === caseDetail.docketNumber,
     );
@@ -125,9 +128,9 @@ describe('verify old served work items do not show up in the outbox', () => {
       myOutbox.find(item => item.workItemId === workItemId7),
     ).toBeDefined();
 
-    const sectionOutbox = (await getFormattedDocumentQCSectionOutbox(
-      test,
-    )).filter(item => item.docketNumber === caseDetail.docketNumber);
+    const sectionOutbox = (
+      await getFormattedDocumentQCSectionOutbox(test)
+    ).filter(item => item.docketNumber === caseDetail.docketNumber);
     expect(sectionOutbox.length).toEqual(2);
     expect(
       sectionOutbox.find(item => item.workItemId === workItemId6),

--- a/web-client/integration-tests/signAndServeStipulatedDecision.test.js
+++ b/web-client/integration-tests/signAndServeStipulatedDecision.test.js
@@ -42,14 +42,16 @@ describe('a user signs and serves a stipulated decision', () => {
   let signedDocumentId = null;
   let caseDetail;
 
+  loginAs(test, 'petitioner');
+
   it('login as a petitioner and create a case', async () => {
-    await loginAs(test, 'petitioner');
     caseDetail = await uploadPetition(test);
     ({ docketNumber } = caseDetail.docketNumber);
   });
 
+  loginAs(test, 'respondent');
+
   it('respondent uploads a proposed stipulated decision', async () => {
-    await loginAs(test, 'respondent');
     await viewCaseDetail({
       docketNumber: caseDetail.docketNumber,
       test,
@@ -57,8 +59,8 @@ describe('a user signs and serves a stipulated decision', () => {
     await uploadProposedStipulatedDecision(test);
   });
 
+  loginAs(test, 'docketclerk');
   it('docketclerk assigns the stipulated decision to the adc', async () => {
-    await loginAs(test, 'docketclerk');
     const documentQCSectionInbox = await getFormattedDocumentQCSectionInbox(
       test,
     );
@@ -79,8 +81,8 @@ describe('a user signs and serves a stipulated decision', () => {
     });
   });
 
+  loginAs(test, 'adc');
   it('adc signs the proposed stipulated decision', async () => {
-    await loginAs(test, 'adc');
     const inbox = await getFormattedMyInbox(test);
     const stipulatedDecision = inbox.find(
       item =>
@@ -90,8 +92,9 @@ describe('a user signs and serves a stipulated decision', () => {
     await signProposedStipulatedDecision(test, stipulatedDecision);
   });
 
+  loginAs(test, 'docketclerk');
+
   it('docketclerk creates a docket entry for the signed stipulated decision', async () => {
-    await loginAs(test, 'docketclerk');
     const inbox = await getFormattedMyInbox(test);
     const signedStipulatedDecision = inbox.find(
       item =>
@@ -106,8 +109,9 @@ describe('a user signs and serves a stipulated decision', () => {
     });
   });
 
+  loginAs(test, 'docketclerk');
+
   it('docketclerk serves the signed stipulated decision', async () => {
-    await loginAs(test, 'docketclerk');
     caseDetail = test.getState('caseDetail');
     const signedDocument = caseDetail.documents.find(
       d => d.documentId === signedDocumentId,

--- a/web-client/integration-tests/trialSessionEligibleCasesJourney.test.js
+++ b/web-client/integration-tests/trialSessionEligibleCasesJourney.test.js
@@ -409,7 +409,7 @@ describe('Trial Session Eligible Cases Journey', () => {
       test.setState('modal.trialSessionId', test.trialSessionId);
 
       await test.runSequence('addCaseToTrialSessionSequence');
-      await wait(5000);
+      await wait(1000); // we need to wait for some reason
 
       await test.runSequence('gotoCaseDetailSequence', {
         docketNumber: createdDocketNumbers[0],

--- a/web-client/integration-tests/trialSessionEligibleCasesJourney.test.js
+++ b/web-client/integration-tests/trialSessionEligibleCasesJourney.test.js
@@ -401,6 +401,7 @@ describe('Trial Session Eligible Cases Journey', () => {
       expect(test.getState('caseDetail.status')).not.toEqual('Calendared');
 
       await test.runSequence('addCaseToTrialSessionSequence');
+      await wait(1000);
 
       expect(test.getState('validationErrors')).toEqual({
         trialSessionId: 'Select a Trial Session',


### PR DESCRIPTION
Removing `await wait()` and `await waitForRouter()` and refactoring how we call loginAs throughout the tests because there is some strange race condition that occurs if you login and uploadPetition in the same it statement.