### PR TITLE
DevEx: correctly add route53:ListTagsForResource to policy

### DIFF
--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -16,7 +16,8 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "route53:GetHostedZone",
         "route53:ListResourceRecordSets",
         "route53:ListHostedZones",
-        "route53:ChangeResourceRecordSets"
+        "route53:ChangeResourceRecordSets",
+        "route53:ListTagsForResource"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
Note that this has to be run from the local machine of someone with Flexion AWS account access (I've already done it), and Waldo will need to make this update on the tax court's AWS account for the next sprint.