### PR TITLE
DevEx: lock down content-security-policy

### DIFF
--- a/shared/src/sharedAppContext.js
+++ b/shared/src/sharedAppContext.js
@@ -13,7 +13,7 @@ const getCognitoLoginUrl = () => {
 
 const getPublicSiteUrl = () => {
   if (process.env.USTC_ENV === 'prod') {
-    return 'https://https://ui-public-dev.ustc-case-mgmt.flexion.us/';
+    return 'https://ui-public-dev.ustc-case-mgmt.flexion.us/';
   } else {
     return process.env.PUBLIC_SITE_URL || 'http://localhost:5678/';
   }

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -31,7 +31,7 @@ exports.handler = (event, context, callback) => {
   headers['content-security-policy'] = [
     {
       key: 'Content-Security-Policy',
-      value: `default-src: https: https://${allowedDomainString}; style-src 'self' 'unsafe-inline'; object-src 'none'`,
+      value: `default-src 'self'; connect-src https://${allowedDomainString} https://*.auth.us-east-1.amazoncognito.com; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action https://${allowedDomainString}; require-trusted-types-for 'script';`,
     },
   ];
   headers['x-content-type-options'] = [


### PR DESCRIPTION
This is currently deployed to exp, with these results:

https://observatory.mozilla.org/analyze/ui-exp.ustc-case-mgmt.flexion.us

https://csp-evaluator.withgoogle.com/?csp=https://ui-exp.ustc-case-mgmt.flexion.us

