### PR TITLE
4296: Set Create Paper Case tab to partyInfo by default

### DIFF
--- a/web-client/src/presenter/actions/StartCaseInternal/setStartInternalCaseDefaultTabAction.js
+++ b/web-client/src/presenter/actions/StartCaseInternal/setStartInternalCaseDefaultTabAction.js
@@ -7,6 +7,6 @@ import { state } from 'cerebral';
  * @param {Function} providers.props the cerebral props object used for passing in props.caseCaption
  * @param {Function} providers.store the cerebral store used for setting the state.form.caseCaption
  */
-export const setStartInternalCaseTabAction = ({ props, store }) => {
-  store.set(state.startCaseInternal.tab, props.tab);
+export const setStartInternalCaseDefaultTabAction = ({ store }) => {
+  store.set(state.startCaseInternal.tab, 'partyInfo');
 };

--- a/web-client/src/presenter/actions/StartCaseInternal/setStartInternalCaseDefaultTabAction.test.js
+++ b/web-client/src/presenter/actions/StartCaseInternal/setStartInternalCaseDefaultTabAction.test.js
@@ -1,0 +1,10 @@
+import { runAction } from 'cerebral/test';
+import { setStartInternalCaseDefaultTabAction } from './setStartInternalCaseDefaultTabAction';
+
+describe('setStartInternalCaseDefaultTabAction', () => {
+  it('should set startInternalCase tab to partyInfo by default', async () => {
+    const result = await runAction(setStartInternalCaseDefaultTabAction, {});
+
+    expect(result.state.startCaseInternal.tab).toEqual('partyInfo');
+  });
+});

--- a/web-client/src/presenter/actions/StartCaseInternal/setStartInternalCaseTabAction.test.js
+++ b/web-client/src/presenter/actions/StartCaseInternal/setStartInternalCaseTabAction.test.js
@@ -7,6 +7,6 @@ describe('setStartInternalCaseTabAction', () => {
       props: { tab: 'caseInfo' },
     });
 
-    expect(result.state.startInternalCase.tab).toEqual('caseInfo');
+    expect(result.state.startCaseInternal.tab).toEqual('caseInfo');
   });
 });

--- a/web-client/src/presenter/sequences/gotoStartCaseWizardSequence.js
+++ b/web-client/src/presenter/sequences/gotoStartCaseWizardSequence.js
@@ -11,10 +11,12 @@ import { setCaseTypesAction } from '../actions/setCaseTypesAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setFilingTypesAction } from '../actions/setFilingTypesAction';
 import { setProcedureTypesAction } from '../actions/setProcedureTypesAction';
+import { setStartInternalCaseDefaultTabAction } from '../actions/StartCaseInternal/setStartInternalCaseDefaultTabAction';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
 import { takePathForRoles } from './takePathForRoles';
 
 const gotoStartCaseInternal = [
+  setStartInternalCaseDefaultTabAction,
   set(state.documentUploadMode, 'scan'),
   set(state.documentSelectedForScan, 'petitionFile'),
   setCurrentPageAction('StartCaseInternal'),


### PR DESCRIPTION
- also fixes tab not being set properly after `edit` button is clicked on the review paper petition page (non-saved)