### PR TITLE
refactoring the interactor to not return disposition info

### DIFF
--- a/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
@@ -29,23 +29,9 @@ exports.getCalendaredCasesForTrialSessionInteractor = async ({
       trialSessionId,
     });
 
-  return cases.map(caseWithAdditionalProperties => {
-    // TODO: revisit this approach.  I think our persistence layer is returning more than it should?
-    const {
-      disposition,
-      isManuallyAdded,
-      removedFromTrial,
-      removedFromTrialDate,
-    } = caseWithAdditionalProperties;
-
-    return {
-      ...new Case(caseWithAdditionalProperties, { applicationContext })
-        .validate()
-        .toRawObject(),
-      disposition,
-      isManuallyAdded,
-      removedFromTrial,
-      removedFromTrialDate,
-    };
-  });
+  return cases.map(caseWithAdditionalProperties =>
+    new Case(caseWithAdditionalProperties, { applicationContext })
+      .validate()
+      .toRawObject(),
+  );
 };

--- a/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction.js
+++ b/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction.js
@@ -1,0 +1,20 @@
+import { state } from 'cerebral';
+
+/**
+ * combines the caseOrder of the state.trailSession onto the state.trialSession.calendaredCases
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.props the cerebral props object containing the props.calendaredCases
+ * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
+ */
+export const mergeCaseOrderIntoCalendaredCasesAction = ({ get, store }) => {
+  const { caseOrder } = get(state.trialSession);
+  const { calendaredCases } = get(state.trialSession);
+
+  for (const calendaredCase of calendaredCases) {
+    const order = caseOrder.find(o => o.caseId === calendaredCase.caseId);
+    Object.assign(calendaredCase, order);
+  }
+
+  store.set(state.trialSession.calendaredCases, calendaredCases);
+};

--- a/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction.js
+++ b/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction.js
@@ -8,8 +8,7 @@ import { state } from 'cerebral';
  * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
  */
 export const mergeCaseOrderIntoCalendaredCasesAction = ({ get, store }) => {
-  const { caseOrder } = get(state.trialSession);
-  const { calendaredCases } = get(state.trialSession);
+  const { calendaredCases, caseOrder } = get(state.trialSession);
 
   for (const calendaredCase of calendaredCases) {
     const order = caseOrder.find(o => o.caseId === calendaredCase.caseId);

--- a/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoEligibleCasesAction.js
+++ b/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoEligibleCasesAction.js
@@ -8,8 +8,7 @@ import { state } from 'cerebral';
  * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
  */
 export const mergeCaseOrderIntoEligibleCasesAction = ({ get, store }) => {
-  const { caseOrder } = get(state.trialSession);
-  const { eligibleCases } = get(state.trialSession);
+  const { caseOrder, eligibleCases } = get(state.trialSession);
 
   for (const eligibleCase of eligibleCases) {
     const order = caseOrder.find(o => o.caseId === eligibleCase.caseId);

--- a/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoEligibleCasesAction.js
+++ b/web-client/src/presenter/actions/TrialSession/mergeCaseOrderIntoEligibleCasesAction.js
@@ -1,0 +1,20 @@
+import { state } from 'cerebral';
+
+/**
+ * combines the caseOrder of the state.trailSession onto the state.trialSession.eligibleCases
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.props the cerebral props object containing the props.calendaredCases
+ * @param {object} providers.store the cerebral store used for setting the state.calendaredCases
+ */
+export const mergeCaseOrderIntoEligibleCasesAction = ({ get, store }) => {
+  const { caseOrder } = get(state.trialSession);
+  const { eligibleCases } = get(state.trialSession);
+
+  for (const eligibleCase of eligibleCases) {
+    const order = caseOrder.find(o => o.caseId === eligibleCase.caseId);
+    Object.assign(eligibleCase, order);
+  }
+
+  store.set(state.trialSession.eligibleCases, eligibleCases);
+};

--- a/web-client/src/presenter/actions/shouldRefreshCaseAction.js
+++ b/web-client/src/presenter/actions/shouldRefreshCaseAction.js
@@ -1,0 +1,20 @@
+import { state } from 'cerebral';
+
+/**
+ * returns yes if we should refresh the case after generating the notice pdf
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext the application context
+ * @param {Function} providers.path the cerebral path method
+ * @param {Function} providers.get the cerebral get method
+ * @param {object} providers.props the cerebral props object
+ * @returns {object} the list of section work items
+ */
+export const shouldRefreshCaseAction = async ({ get, path, props }) => {
+  const docketNumber = props.docketNumber || get(state.caseDetail.docketNumber);
+  if (docketNumber) {
+    return path.yes();
+  } else {
+    return path.no();
+  }
+};

--- a/web-client/src/presenter/actions/shouldRefreshCaseAction.js
+++ b/web-client/src/presenter/actions/shouldRefreshCaseAction.js
@@ -4,11 +4,10 @@ import { state } from 'cerebral';
  * returns yes if we should refresh the case after generating the notice pdf
  *
  * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
  * @param {Function} providers.path the cerebral path method
  * @param {Function} providers.get the cerebral get method
  * @param {object} providers.props the cerebral props object
- * @returns {object} the list of section work items
+ * @returns {object} the path yes or no depending on if the case needs to be refreshed
  */
 export const shouldRefreshCaseAction = async ({ get, path, props }) => {
   const docketNumber = props.docketNumber || get(state.caseDetail.docketNumber);

--- a/web-client/src/presenter/actions/shouldRefreshCaseAction.test.js
+++ b/web-client/src/presenter/actions/shouldRefreshCaseAction.test.js
@@ -1,0 +1,55 @@
+import { presenter } from '../presenter';
+import { runAction } from 'cerebral/test';
+import { shouldRefreshCaseAction } from './shouldRefreshCaseAction';
+
+describe('shouldRefreshCaseAction', () => {
+  let pathYesStub;
+  let pathNoStub;
+
+  beforeEach(() => {
+    pathYesStub = jest.fn();
+    pathNoStub = jest.fn();
+
+    presenter.providers.path = {
+      no: pathNoStub,
+      yes: pathYesStub,
+    };
+  });
+
+  it('returns the no path if no caseDetail already set', async () => {
+    runAction(shouldRefreshCaseAction, {
+      modules: {
+        presenter,
+      },
+      state: {},
+    });
+    expect(pathNoStub).toHaveBeenCalled();
+  });
+
+  it('returns the yes path if caseDetail is set', async () => {
+    runAction(shouldRefreshCaseAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        caseDetail: {
+          docketNumber: '101-19',
+        },
+      },
+    });
+    expect(pathYesStub).toHaveBeenCalled();
+  });
+
+  it('returns the yes path if caseDetail is set', async () => {
+    runAction(shouldRefreshCaseAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        docketNumber: '101-19',
+      },
+      state: {},
+    });
+    expect(pathYesStub).toHaveBeenCalled();
+  });
+});

--- a/web-client/src/presenter/sequences/gotoTrialSessionDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoTrialSessionDetailSequence.js
@@ -5,6 +5,8 @@ import { getTrialSessionDetailsAction } from '../actions/TrialSession/getTrialSe
 import { getUsersInSectionAction } from '../actions/getUsersInSectionAction';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { isTrialSessionCalendaredAction } from '../actions/TrialSession/isTrialSessionCalendaredAction';
+import { mergeCaseOrderIntoCalendaredCasesAction } from '../actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction';
+import { mergeCaseOrderIntoEligibleCasesAction } from '../actions/TrialSession/mergeCaseOrderIntoEligibleCasesAction';
 import { parallel } from 'cerebral/factories';
 import { redirectToCognitoAction } from '../actions/redirectToCognitoAction';
 import { setCalendaredCasesOnTrialSessionAction } from '../actions/TrialSession/setCalendaredCasesOnTrialSessionAction';
@@ -29,10 +31,12 @@ const gotoTrialSessionDetails = [
         no: [
           getEligibleCasesForTrialSessionAction,
           setEligibleCasesOnTrialSessionAction,
+          mergeCaseOrderIntoEligibleCasesAction,
         ],
         yes: [
           getCalendaredCasesForTrialSessionAction,
           setCalendaredCasesOnTrialSessionAction,
+          mergeCaseOrderIntoCalendaredCasesAction,
         ],
       },
     ],

--- a/web-client/src/presenter/sequences/gotoTrialSessionWorkingCopySequence.js
+++ b/web-client/src/presenter/sequences/gotoTrialSessionWorkingCopySequence.js
@@ -10,6 +10,7 @@ import { gotoTrialSessionDetailSequence } from './gotoTrialSessionDetailSequence
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { isTrialSessionCalendaredAction } from '../actions/TrialSession/isTrialSessionCalendaredAction';
 import { isUserAssociatedWithTrialSessionAction } from '../actions/TrialSession/isUserAssociatedWithTrialSessionAction';
+import { mergeCaseOrderIntoCalendaredCasesAction } from '../actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction';
 import { redirectToCognitoAction } from '../actions/redirectToCognitoAction';
 import { runPathForUserRoleAction } from '../actions/runPathForUserRoleAction';
 import { setBaseUrlAction } from '../actions/setBaseUrlAction';
@@ -38,6 +39,7 @@ const checkUserAssociationAndProceed = [
         yes: [
           getCalendaredCasesForTrialSessionAction,
           setCalendaredCasesOnTrialSessionAction,
+          mergeCaseOrderIntoCalendaredCasesAction,
           getUserCaseNoteForCasesAction,
           setCaseNotesOntoCalendaredCasesAction,
           extractUserNotesFromCalendaredCasesAction,

--- a/web-client/src/presenter/sequences/noticeGenerationCompleteSequence.js
+++ b/web-client/src/presenter/sequences/noticeGenerationCompleteSequence.js
@@ -2,20 +2,26 @@ import { clearModalAction } from '../actions/clearModalAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getNoticeGenerationSuccessMessageAction } from '../actions/TrialSession/getNoticeGenerationSuccessMessageAction';
+
 import { hasPaperAction } from '../actions/hasPaperAction';
 import { navigateToPdfPreviewAction } from '../actions/navigateToPdfPreviewAction';
 import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
 import { setAlertWarningAction } from '../actions/setAlertWarningAction';
-import { setAlternateBackLocationAction } from '../actions/setAlternateBackLocationAction';
 import { setCaseAction } from '../actions/setCaseAction';
+
+import { setAlternateBackLocationAction } from '../actions/setAlternateBackLocationAction';
 import { setPdfPreviewUrlSequence } from './setPdfPreviewUrlSequence';
 import { setTrialSessionCalendarAlertWarningAction } from '../actions/TrialSession/setTrialSessionCalendarAlertWarningAction';
+import { shouldRefreshCaseAction } from '../actions/shouldRefreshCaseAction';
 import { stopWebSocketConnectionAction } from '../actions/webSocketConnection/stopWebSocketConnectionAction';
 
 export const noticeGenerationCompleteSequence = [
   stopWebSocketConnectionAction,
-  getCaseAction,
-  setCaseAction,
+  shouldRefreshCaseAction,
+  {
+    no: [],
+    yes: [getCaseAction, setCaseAction],
+  },
   clearModalStateAction,
   clearModalAction,
   hasPaperAction,

--- a/web-client/src/presenter/sequences/setTrialSessionCalendarSequence.js
+++ b/web-client/src/presenter/sequences/setTrialSessionCalendarSequence.js
@@ -2,6 +2,7 @@ import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCalendaredCasesForTrialSessionAction } from '../actions/TrialSession/getCalendaredCasesForTrialSessionAction';
 import { getTrialSessionDetailsAction } from '../actions/TrialSession/getTrialSessionDetailsAction';
+import { mergeCaseOrderIntoCalendaredCasesAction } from '../actions/TrialSession/mergeCaseOrderIntoCalendaredCasesAction';
 import { setCalendaredCasesOnTrialSessionAction } from '../actions/TrialSession/setCalendaredCasesOnTrialSessionAction';
 import { setNoticesForCalendaredTrialSessionAction } from '../actions/TrialSession/setNoticesForCalendaredTrialSessionAction';
 import { setTrialSessionCalendarAction } from '../actions/TrialSession/setTrialSessionCalendarAction';
@@ -17,6 +18,7 @@ export const setTrialSessionCalendarSequence = showProgressSequenceDecorator([
   setTrialSessionDetailsAction,
   getCalendaredCasesForTrialSessionAction,
   setCalendaredCasesOnTrialSessionAction,
+  mergeCaseOrderIntoCalendaredCasesAction,
   startWebSocketConnectionAction,
   setNoticesForCalendaredTrialSessionAction,
 ]);


### PR DESCRIPTION
no longer returning disposition and some other fields on the getCalendaredCases endpoint; instead the UI is responsible for looking at the trial session's caseOrder property and looking up the metadata.