### PR TITLE
4296: move Case Caption to Party Info tab

### DIFF
--- a/cypress/integration/edit-case-caption-via-case-edit.spec.js
+++ b/cypress/integration/edit-case-caption-via-case-edit.spec.js
@@ -1,4 +1,5 @@
 const {
+  getCaseInfoTab,
   getCaseTitleContaining,
   getCaseTitleTextArea,
   getReviewPetitionButton,
@@ -14,6 +15,7 @@ describe('change the case caption via the case edit page ', () => {
       '101-19',
       '1f1aa3f7-e2e3-43e6-885d-4ce341588c76',
     );
+    getCaseInfoTab().click();
     getCaseTitleTextArea()
       .clear()
       .type('hello world');

--- a/cypress/support/pages/document-detail.js
+++ b/cypress/support/pages/document-detail.js
@@ -10,6 +10,10 @@ exports.getInProgressTab = () => {
   return cy.get('button#tab-messages-in-progress');
 };
 
+exports.getCaseInfoTab = () => {
+  return cy.get('button#tab-case-info');
+};
+
 exports.getCreateMessageButton = () => {
   return cy.get('button#create-message-button');
 };

--- a/web-client/src/presenter/sequences/saveSavedCaseForLaterSequence.js
+++ b/web-client/src/presenter/sequences/saveSavedCaseForLaterSequence.js
@@ -4,8 +4,10 @@ import { computeIrsNoticeDateAction } from '../actions/StartCaseInternal/compute
 import { getFormCombinedWithCaseDetailAction } from '../actions/getFormCombinedWithCaseDetailAction';
 import { navigateToCaseDetailAction } from '../actions/navigateToCaseDetailAction';
 import { saveCaseDetailInternalEditAction } from '../actions/saveCaseDetailInternalEditAction';
+import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
 import { setCaseAction } from '../actions/setCaseAction';
 import { setCaseInProgressAction } from '../actions/StartCaseInternal/setCaseInProgressAction';
+import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { showProgressSequenceDecorator } from '../utilities/sequenceHelpers';
 
 export const saveSavedCaseForLaterSequence = showProgressSequenceDecorator([
@@ -16,5 +18,7 @@ export const saveSavedCaseForLaterSequence = showProgressSequenceDecorator([
   saveCaseDetailInternalEditAction,
   setCaseAction,
   assignPetitionToAuthenticatedUserAction,
+  setAlertSuccessAction,
+  setSaveAlertsForNavigationAction,
   navigateToCaseDetailAction,
 ]);

--- a/web-client/src/views/CaseDetailEdit/CaseInfo.jsx
+++ b/web-client/src/views/CaseDetailEdit/CaseInfo.jsx
@@ -12,6 +12,7 @@ export const CaseInfo = connect(
     caseDetail: state.caseDetail,
     caseDetailEditHelper: state.caseDetailEditHelper,
     caseDetailErrors: state.caseDetailErrors,
+    constants: state.constants,
     form: state.form,
     token: state.token,
     updateCaseValueSequence: sequences.updateCaseValueSequence,
@@ -23,6 +24,7 @@ export const CaseInfo = connect(
     caseDetail,
     caseDetailEditHelper,
     caseDetailErrors,
+    constants,
     form,
     token,
     updateCaseValueSequence,
@@ -31,6 +33,28 @@ export const CaseInfo = connect(
   }) => {
     return (
       <div className="blue-container">
+        <div className="subsection">
+          <div className="usa-form-group">
+            <label className="usa-label" htmlFor="case-caption">
+              Case caption
+            </label>
+            <textarea
+              className="usa-textarea"
+              id="case-caption"
+              name="caseCaption"
+              value={caseDetail.caseCaption}
+              onChange={e => {
+                updateCaseValueSequence({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+              }}
+            />
+            <span className="display-inline-block margin-top-1">
+              {constants.CASE_CAPTION_POSTFIX}
+            </span>
+          </div>
+        </div>
         {caseDetail.isPaper && (
           <>
             <DateInput

--- a/web-client/src/views/CaseDetailEdit/PartyInformation.jsx
+++ b/web-client/src/views/CaseDetailEdit/PartyInformation.jsx
@@ -9,7 +9,6 @@ export const PartyInformation = connect(
     baseUrl: state.baseUrl,
     caseDetail: state.caseDetail,
     caseDetailEditHelper: state.caseDetailEditHelper,
-    constants: state.constants,
     token: state.token,
     updateCasePartyTypeSequence: sequences.updateCasePartyTypeSequence,
     updateCaseValueSequence: sequences.updateCaseValueSequence,
@@ -18,35 +17,12 @@ export const PartyInformation = connect(
     baseUrl,
     caseDetail,
     caseDetailEditHelper,
-    constants,
     token,
     updateCasePartyTypeSequence,
     updateCaseValueSequence,
   }) => {
     return (
       <div className="blue-container document-detail-one-third">
-        <div className="subsection">
-          <div className="usa-form-group">
-            <label className="usa-label" htmlFor="case-caption">
-              Case caption
-            </label>
-            <textarea
-              className="usa-textarea"
-              id="case-caption"
-              name="caseCaption"
-              value={caseDetail.caseCaption}
-              onChange={e => {
-                updateCaseValueSequence({
-                  key: e.target.name,
-                  value: e.target.value,
-                });
-              }}
-            />
-            <span className="display-inline-block margin-top-1">
-              {constants.CASE_CAPTION_POSTFIX}
-            </span>
-          </div>
-        </div>
         <div className="subsection party-type">
           <div className="usa-form-group">
             <label className="usa-label" htmlFor="party-type">


### PR DESCRIPTION
also fixed so that "success" message shows after saving for later.
<img width="788" alt="Screen Shot 2020-03-03 at 12 00 04 PM" src="https://user-images.githubusercontent.com/2445917/75805385-5a768780-5d47-11ea-8e68-400feff33513.png">
<img width="736" alt="Screen Shot 2020-03-03 at 12 00 16 PM" src="https://user-images.githubusercontent.com/2445917/75805388-5cd8e180-5d47-11ea-813a-982faaeabcdd.png">

https://trello.com/c/9KJOorGf/589-efiled-document-case-caption-displaying-on-party-tab-it-should-be-under-case-info-tab#
