### PR TITLE
480: script to create practitioner and respondent users from CSV; custom cognito email

### DIFF
--- a/web-api/attorney_users.csv
+++ b/web-api/attorney_users.csv
@@ -1,2 +1,2 @@
-practitioner;Test Practitioner from script;PT1482;rparris+250@example.com
-respondent;Test Respondent from script;RT1482;rparris+251@example.com
+practitioner;Test Practitioner from script;PT1482;test+email@example.com
+respondent;Test Respondent from script;RT1482;test+email@example.com

--- a/web-api/attorney_users.csv
+++ b/web-api/attorney_users.csv
@@ -1,0 +1,2 @@
+practitioner;Test Practitioner from script;PT1482;rparris+250@example.com
+respondent;Test Respondent from script;RT1482;rparris+251@example.com

--- a/web-api/create-attorney-users.sh
+++ b/web-api/create-attorney-users.sh
@@ -55,7 +55,7 @@ response=$(aws cognito-idp admin-initiate-auth \
   --client-id "${CLIENT_ID}" \
   --region "${REGION}" \
   --auth-flow ADMIN_NO_SRP_AUTH \
-  --auth-parameters USERNAME="ustcadmin@example.com"',PASSWORD'="${USTC_ADMIN_PASS}")
+  --auth-parameters USERNAME="petitionsclerk1@example.com"',PASSWORD'="Testing1234$")
 adminToken=$(echo "${response}" | jq -r ".AuthenticationResult.IdToken")
 echo $adminToken
 

--- a/web-api/create-attorney-users.sh
+++ b/web-api/create-attorney-users.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+ENV=$1
+REGION="us-east-1"
+
+CURRENT_COLOR=$(aws dynamodb get-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --key '{"pk":{"S":"deployed-stack"},"sk":{"S":"deployed-stack"}}' | jq -r ".Item.current.S")
+
+restApiId=$(aws apigateway get-rest-apis --region="${REGION}" --query "items[?name=='${ENV}-ef-cms-users-${CURRENT_COLOR}'].id" --output text)
+
+USER_POOL_ID=$(aws cognito-idp list-user-pools --query "UserPools[?Name == 'efcms-${ENV}'].Id | [0]" --max-results 30 --region "${REGION}")
+USER_POOL_ID="${USER_POOL_ID%\"}"
+USER_POOL_ID="${USER_POOL_ID#\"}"
+
+CLIENT_ID=$(aws cognito-idp list-user-pool-clients --user-pool-id "${USER_POOL_ID}" --query "UserPoolClients[?ClientName == 'client'].ClientId | [0]" --max-results 30 --region "${REGION}")
+CLIENT_ID="${CLIENT_ID%\"}"
+CLIENT_ID="${CLIENT_ID#\"}"
+
+generate_post_data() {
+  email=$1
+  role=$2
+  section=$3
+  name=$4
+  barNumber=$5
+  cat <<EOF
+{
+  "email": "$email",
+  "password": "Testing1234$",
+  "role": "$role",
+  "section": "$section",
+  "name": "$name",
+  "barNumber": "$barNumber"
+}
+EOF
+}
+
+createAccount() {
+  email=$1
+  role=$2
+  section=$3
+  name=$4
+  barNumber=$5
+
+  echo $(generate_post_data "${email}" "${role}" "${section}" "${name}" "${barNumber}")
+
+  echo $restApiId
+
+  curl --header "Content-Type: application/json" \
+    --header "Authorization: Bearer ${adminToken}" \
+    --request POST \
+    --data "$(generate_post_data "${email}" "${role}" "${section}" "${name}" "${barNumber}")" \
+      "https://${restApiId}.execute-api.us-east-1.amazonaws.com/${ENV}/attorney"
+}
+
+response=$(aws cognito-idp admin-initiate-auth \
+  --user-pool-id "${USER_POOL_ID}" \
+  --client-id "${CLIENT_ID}" \
+  --region "${REGION}" \
+  --auth-flow ADMIN_NO_SRP_AUTH \
+  --auth-parameters USERNAME="ustcadmin@example.com"',PASSWORD'="${USTC_ADMIN_PASS}")
+adminToken=$(echo "${response}" | jq -r ".AuthenticationResult.IdToken")
+echo $adminToken
+
+while read -r line
+do
+  IFS=';' read -ra ADDR <<< "$line"
+  section="${ADDR[0]}"
+  role="${ADDR[0]}"
+  name="${ADDR[1]}"
+  barNumber="${ADDR[2]}"
+  fakeEmail="${ADDR[3]/$'\r'}"
+  createAccount "${fakeEmail}" "${role}" "${section}" "${name}" "${barNumber}"
+done < attorney_users.csv
+

--- a/web-api/create-attorney-users.sh
+++ b/web-api/create-attorney-users.sh
@@ -27,7 +27,15 @@ generate_post_data() {
   "role": "$role",
   "section": "$section",
   "name": "$name",
-  "barNumber": "$barNumber"
+  "barNumber": "$barNumber",
+  "contact": {
+    "address1": "123 Main St",
+    "city": "Tallahassee",
+    "countryType": "domestic",
+    "phone": "+1 (555) 555-5555",
+    "postalCode": "09988",
+    "state": "FL"
+  }
 }
 EOF
 }

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -23,7 +23,10 @@ resource "aws_cognito_user_pool" "pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = false
-    unused_account_validity_days = 0
+    invite_message_template {
+      email_subject = "U.S. Tax Court account creation"
+      email_message = "An account has been created for you on the <a href='https://ui-dev.ustc-case-mgmt.flexion.us/'>U.S. Tax Court site</a>. Your username is {username} and temporary password is {####}. Please log in and change your password."
+    }
   }
 
   schema {


### PR DESCRIPTION
To use this for bulk importing practitioner and respondent users, the CSV file should be updated with the correct data in the same field order. Then the script can be run locally to add users to a deployed environment with: `./web-api/create-attorney-users.sh <ENV>`