### PR TITLE
4296: case caption

### DIFF
--- a/web-client/src/presenter/actions/caseDetailEdit/getCaseCaptionForCaseInfoTabAction.js
+++ b/web-client/src/presenter/actions/caseDetailEdit/getCaseCaptionForCaseInfoTabAction.js
@@ -15,7 +15,7 @@ export const getCaseCaptionForCaseInfoTabAction = ({
   const { Case } = applicationContext.getEntityConstructors();
   let caseCaption = Case.getCaseCaption(get(state.caseDetail)) || '';
 
-  caseCaption += ` ${Case.CASE_CAPTION_POSTFIX}`;
+  // NOTE: case caption should never have the postfix value. Perhaps you're looking for case title?
 
   return { caseCaption };
 };

--- a/web-client/src/presenter/actions/caseDetailEdit/getCaseCaptionForCaseInfoTabAction.test.js
+++ b/web-client/src/presenter/actions/caseDetailEdit/getCaseCaptionForCaseInfoTabAction.test.js
@@ -8,7 +8,7 @@ presenter.providers.applicationContext = applicationContext;
 describe('getCaseCaptionForCaseInfoTabAction', () => {
   const { Case, ContactFactory } = applicationContext.getEntityConstructors();
 
-  it('should return just the postfix when party type has not been selected', async () => {
+  it('should return an empty string when the party type has not been selected', async () => {
     const result = await runAction(getCaseCaptionForCaseInfoTabAction, {
       modules: {
         presenter,
@@ -19,11 +19,12 @@ describe('getCaseCaptionForCaseInfoTabAction', () => {
         },
       },
     });
-
-    expect(result.output.caseCaption).toBe(` ${Case.CASE_CAPTION_POSTFIX}`);
+    // case caption should not, ever, contain the postfix "v. Commissioner..."
+    // that would make it the case title.
+    expect(result.output.caseCaption).toBe('');
   });
 
-  it('should return a generated case caption when party type has been selected', async () => {
+  it('should return a generated case caption WITHOUT the postfix when party type has been selected', async () => {
     const result = await runAction(getCaseCaptionForCaseInfoTabAction, {
       modules: {
         presenter,
@@ -38,8 +39,9 @@ describe('getCaseCaptionForCaseInfoTabAction', () => {
       },
     });
 
-    expect(result.output.caseCaption).toBe(
-      `Guy Fieri, Petitioner ${Case.CASE_CAPTION_POSTFIX}`,
-    );
+    expect(result.output.caseCaption).toBe('Guy Fieri, Petitioner');
+    expect(
+      result.output.caseCaption.includes(Case.CASE_CAPTION_POSTFIX),
+    ).toBeFalsy();
   });
 });

--- a/web-client/src/views/CaseDetailEdit/ReviewSavedPetition.jsx
+++ b/web-client/src/views/CaseDetailEdit/ReviewSavedPetition.jsx
@@ -185,7 +185,8 @@ export const ReviewSavedPetition = connect(
                           >
                             Case caption
                           </label>
-                          {caseDetail.caseCaption}
+                          {caseDetail.caseCaption}{' '}
+                          {constants.CASE_CAPTION_POSTFIX}
                         </div>
                         <div className="margin-top-3 margin-bottom-2">
                           <label

--- a/web-client/src/views/CaseDetailEdit/UpdateCaseModalDialog.jsx
+++ b/web-client/src/views/CaseDetailEdit/UpdateCaseModalDialog.jsx
@@ -9,6 +9,7 @@ export const UpdateCaseModalDialog = connect(
   {
     cancelSequence: sequences.clearModalSequence,
     confirmSequence: sequences.submitUpdateCaseModalSequence,
+    constants: state.constants,
     modal: state.modal,
     newStatus: state.constants.STATUS_TYPES.new,
     updateCaseModalHelper: state.updateCaseModalHelper,
@@ -19,6 +20,7 @@ export const UpdateCaseModalDialog = connect(
   ({
     cancelSequence,
     confirmSequence,
+    constants,
     modal,
     newStatus,
     updateCaseModalHelper,
@@ -54,6 +56,9 @@ export const UpdateCaseModalDialog = connect(
                 validateUpdateCaseModalSequence();
               }}
             />
+            <span className="display-inline-block margin-top-1">
+              {constants.CASE_CAPTION_POSTFIX}
+            </span>
           </FormGroup>
         </div>
         {updateCaseModalHelper.showCalendaredAlert && (

--- a/web-client/src/views/StartCaseInternal/CaseInformation.jsx
+++ b/web-client/src/views/StartCaseInternal/CaseInformation.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 export const CaseInformation = connect(
   {
     clearPreferredTrialCitySequence: sequences.clearPreferredTrialCitySequence,
+    constants: state.constants,
     form: state.form,
     startCaseInternalHelper: state.startCaseInternalHelper,
     trialCitiesHelper: state.trialCitiesHelper,
@@ -20,6 +21,7 @@ export const CaseInformation = connect(
   },
   ({
     clearPreferredTrialCitySequence,
+    constants,
     form,
     startCaseInternalHelper,
     trialCitiesHelper,
@@ -84,6 +86,9 @@ export const CaseInformation = connect(
               });
             }}
           />
+          <span className="display-inline-block margin-top-1">
+            {constants.CASE_CAPTION_POSTFIX}
+          </span>
         </FormGroup>
         <ProcedureType
           legend="Case procedure"

--- a/web-client/src/views/StartCaseInternal/ReviewPetitionFromPaper.jsx
+++ b/web-client/src/views/StartCaseInternal/ReviewPetitionFromPaper.jsx
@@ -172,7 +172,7 @@ export const ReviewPetitionFromPaper = connect(
                           >
                             Case caption
                           </label>
-                          {form.caseCaption}
+                          {form.caseCaption} {constants.CASE_CAPTION_POSTFIX}
                         </div>
                         <div className="margin-top-3 margin-bottom-2">
                           <label


### PR DESCRIPTION
Updating flow for case caption, both paper and electronic, to show the postfix when both editing and reviewing changes.
https://trello.com/c/yaNMV6ej/597-case-caption-display-is-not-consistent
<img width="499" alt="Screen Shot 2020-03-04 at 11 19 02 AM" src="https://user-images.githubusercontent.com/2445917/75907039-46955900-5e0d-11ea-853b-d41dfe5b4ec0.png">
<img width="584" alt="Screen Shot 2020-03-04 at 11 42 24 AM" src="https://user-images.githubusercontent.com/2445917/75907048-4bf2a380-5e0d-11ea-9aa3-69d988f8316b.png">
<img width="617" alt="Screen Shot 2020-03-04 at 11 42 32 AM" src="https://user-images.githubusercontent.com/2445917/75907051-4e54fd80-5e0d-11ea-94cc-55c6c1c96486.png">


