### PR TITLE
Bug: manually adding case to trial session, content security policy issue

### DIFF
--- a/web-api/storage/fixtures/seed/trial-sessions.json
+++ b/web-api/storage/fixtures/seed/trial-sessions.json
@@ -206,7 +206,7 @@
   {
     "caseOrder": [],
     "gsi1pk": "trial-session-catalog",
-    "trialLocation": "Birmingham, AL",
+    "trialLocation": "Birmingham, Alabama",
     "createdAt": "2019-10-27T05:00:00.000Z",
     "sk": "trial-session-159c4338-0fac-42eb-b0eb-d53b8d0195cc",
     "sessionType": "Hybrid",
@@ -227,7 +227,7 @@
   {
     "caseOrder": [],
     "gsi1pk": "trial-session-catalog",
-    "trialLocation": "Washington, DC",
+    "trialLocation": "Washington, District of Columbia",
     "createdAt": "2019-10-27T05:00:00.000Z",
     "sk": "trial-session-359c4338-0fac-42eb-b0eb-d53b8d0195cc",
     "sessionType": "Hybrid",
@@ -248,7 +248,7 @@
   {
     "caseOrder": [],
     "gsi1pk": "trial-session-catalog",
-    "trialLocation": "New York, NY",
+    "trialLocation": "New York City, New York",
     "createdAt": "2019-10-27T05:00:00.000Z",
     "sk": "trial-session-459c4338-0fac-42eb-b0eb-d53b8d0195cc",
     "sessionType": "Hybrid",
@@ -269,7 +269,7 @@
   {
     "caseOrder": [],
     "gsi1pk": "trial-session-catalog",
-    "trialLocation": "San Francisco, CA",
+    "trialLocation": "San Francisco, California",
     "createdAt": "2019-10-27T05:00:00.000Z",
     "sk": "trial-session-539c4338-0fac-42eb-b0eb-d53b8d0195cc",
     "sessionType": "Hybrid",

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -31,12 +31,13 @@ exports.handler = (event, context, callback) => {
   const applicationUrl = `https://${allowedDomainString}`;
   const cognitoUrl = 'https://*.auth.us-east-1.amazoncognito.com';
   const dynamsoftUrl = 'https://dynamsoft-lib-stg.ef-cms.ustaxcourt.gov';
+  const websocketUrl = 'wss://${allowedDomainString}';
   const localUrl = 'https://127.0.0.1:*';
   const localWebsocketUrl = 'ws://127.0.0.1:*';
   const s3Url = 'https://s3.us-east-1.amazonaws.com';
   const contentSecurityPolicy = [
     'base-uri resource://pdf.js',
-    `connect-src ${applicationUrl} ${cognitoUrl} ${s3Url} ${dynamsoftUrl} ${localUrl} ${localWebsocketUrl}`,
+    `connect-src ${applicationUrl} ${cognitoUrl} ${s3Url} ${dynamsoftUrl} ${localUrl} ${websocketUrl} ${localWebsocketUrl}`,
     `default-src ${applicationUrl} ${s3Url} data: blob:`,
     `form-action ${applicationUrl}`,
     "object-src 'none'",


### PR DESCRIPTION
Also fixed some invalid trial session locations in our seed data.

https://trello.com/c/N2J0r5sc/398-when-manually-adding-case-to-a-trial-session-the-case-status-assigned-judge-and-trial-info-is-not-refreshing-on-the-case-detail