### PR TITLE
pdf signature bugfix

### DIFF
--- a/web-client/src/presenter/actions/completeDocumentSigningAction.js
+++ b/web-client/src/presenter/actions/completeDocumentSigningAction.js
@@ -31,7 +31,7 @@ export const completeDocumentSigningAction = async ({
       signatureData: { scale, x, y },
     } = get(state.pdfForSigning);
 
-    const { pdfjsObj } = window;
+    const pdfjsObj = window.pdfjsObj || get(state.pdfForSigning.pdfjsObj);
 
     // generate signed document to bytes
     const signedPdfBytes = await applicationContext


### PR DESCRIPTION
I refactored this last week in the pursuit of test-coverage.  I messed things up, and the ability to actually save the signature data was broken.  This small change fixes it.