### PR TITLE
async true requires a different path

### DIFF
--- a/web-api/src/trialSessions/setNoticesForCalendaredTrialSessionLambda.js
+++ b/web-api/src/trialSessions/setNoticesForCalendaredTrialSessionLambda.js
@@ -9,11 +9,13 @@ const { genericHandler } = require('../genericHandler');
 exports.handler = event =>
   genericHandler(event, async ({ applicationContext }) => {
     const { caseId } = JSON.parse(event.body);
+    const { trialSessionId } = event.pathParameters || event.path || {};
+
     return await applicationContext
       .getUseCases()
       .setNoticesForCalendaredTrialSessionInteractor({
         applicationContext,
         caseId: caseId,
-        trialSessionId: event.pathParameters.trialSessionId,
+        trialSessionId,
       });
   });


### PR DESCRIPTION
using async: true uses a different event.path... this oversight has occurred numerous times which means we should probably just have the genericHandler have this fallback logic.