### PR TITLE
Bug: manually adding case to trial session

### DIFF
--- a/web-api/src/trialSessions/setNoticesForCalendaredTrialSessionLambda.js
+++ b/web-api/src/trialSessions/setNoticesForCalendaredTrialSessionLambda.js
@@ -15,6 +15,6 @@ exports.setNoticesForCalendaredTrialSessionLambda = event =>
       .setNoticesForCalendaredTrialSessionInteractor({
         applicationContext,
         trialSessionId,
-        ...JSON.parse(event.body),
+        ...event.body,
       });
   });


### PR DESCRIPTION
When manually adding case to a trial session, the case status/assigned judge and Trial Info is not refreshing on the Case Detail page immediately but the case is showing as added to the session.

https://trello.com/c/N2J0r5sc/398-when-manually-adding-case-to-a-trial-session-the-case-status-assigned-judge-and-trial-info-is-not-refreshing-on-the-case-detail

This error is being thrown by the lambda: `Unexpected token o in JSON at position 1`, so it appears that body is not sent in JSON format. This could be something related to this function being async.