### PR TITLE
Bug fixes: session working copy notes, petitions clerk document edit link

### DIFF
--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -164,10 +164,6 @@ const formatDocketRecordWithDocument = (
       if (formattedDocument.additionalInfo) {
         record.description += ` ${formattedDocument.additionalInfo}`;
       }
-
-      formattedDocument.canEdit =
-        !formattedDocument.isPetition &&
-        !formattedDocument.qcWorkItemsCompleted;
     }
 
     return { document: formattedDocument, index, record };

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -89,7 +89,6 @@ describe('formatCase', () => {
       ],
     });
     expect(result.documents[0].isPetition).toBeTruthy();
-    expect(result.documents[0].canEdit).toBeFalsy();
     expect(result.documents[0].qcWorkItemsCompleted).toBeTruthy();
     expect(result.documents[0].qcWorkItemsUntouched).toEqual(false);
 

--- a/shared/src/persistence/dynamo/userCaseNotes/getUserCaseNoteForCases.js
+++ b/shared/src/persistence/dynamo/userCaseNotes/getUserCaseNoteForCases.js
@@ -18,7 +18,7 @@ exports.getUserCaseNoteForCases = async ({
     applicationContext,
     keys: caseIds.map(caseId => ({
       pk: `user-case-note|${caseId}`,
-      sk: userId,
+      sk: `user|${userId}`,
     })),
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkViewsDocketRecordEditLinks.js
+++ b/web-client/integration-tests/journey/petitionsClerkViewsDocketRecordEditLinks.js
@@ -1,0 +1,42 @@
+import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+export default test => {
+  return it('Petitions Clerk views the docket record edit links', async () => {
+    await test.runSequence('gotoCaseDetailSequence', {
+      docketNumber: test.docketNumber,
+    });
+
+    const caseDetailFormatted = runCompute(
+      withAppContextDecorator(formattedCaseDetail),
+      {
+        state: test.getState(),
+      },
+    );
+
+    expect(caseDetailFormatted.formattedDocketEntries).toMatchObject([
+      { description: 'Petition', editLink: '/edit-saved' },
+      {
+        description: 'Request for Place of Trial at Seattle, Washington',
+        editLink: '',
+      },
+      // externally-filed documents should not be editable by a petitions clerk
+      // and editLink should be empty string to go to the document detail page
+      {
+        description: 'Motion for Leave to File Out of Time Statement Anything',
+        editLink: '',
+      },
+      {
+        description:
+          'Affidavit of  in Support of Motion for Leave to File Out of Time Statement Anything',
+        editLink: '',
+      },
+      { description: 'Statement Anything', editLink: '' },
+      {
+        description: 'Declaration of  in Support of Statement Anything',
+        editLink: '',
+      },
+    ]);
+  });
+};

--- a/web-client/integration-tests/journey/trialClerkViewsTrialSessionWorkingCopyWithNotes.js
+++ b/web-client/integration-tests/journey/trialClerkViewsTrialSessionWorkingCopyWithNotes.js
@@ -1,0 +1,29 @@
+import { runCompute } from 'cerebral/test';
+import { trialSessionWorkingCopyHelper as trialSessionWorkingCopyHelperComputed } from '../../src/presenter/computeds/trialSessionWorkingCopyHelper';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+const trialSessionWorkingCopyHelper = withAppContextDecorator(
+  trialSessionWorkingCopyHelperComputed,
+);
+
+export default test => {
+  return it('Trial Clerk views trial session working copy with notes', async () => {
+    await test.runSequence('gotoTrialSessionWorkingCopySequence', {
+      trialSessionId: test.trialSessionId,
+    });
+    expect(test.getState('currentPage')).toEqual('TrialSessionWorkingCopy');
+    expect(test.getState('trialSessionWorkingCopy.trialSessionId')).toEqual(
+      test.trialSessionId,
+    );
+
+    let workingCopyHelper = runCompute(trialSessionWorkingCopyHelper, {
+      state: test.getState(),
+    });
+
+    const { caseId } = workingCopyHelper.formattedCases[0];
+
+    expect(
+      test.getState(`trialSessionWorkingCopy.userNotes.${caseId}.notes`),
+    ).toEqual('this is a note added from the modal');
+  });
+};

--- a/web-client/integration-tests/petitionsClerkDocketRecordJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkDocketRecordJourney.test.js
@@ -1,0 +1,21 @@
+import { fakeFile, loginAs, setupTest, uploadPetition } from './helpers';
+import petitionerFilesDocumentForCase from './journey/petitionerFilesDocumentForCase';
+import petitionsClerkViewsDocketRecordEditLinks from './journey/petitionsClerkViewsDocketRecordEditLinks';
+
+const test = setupTest();
+
+describe('Petitions clerk docket record journey', () => {
+  beforeAll(() => {
+    jest.setTimeout(30000);
+  });
+
+  loginAs(test, 'petitioner');
+  it('create the case for this test', async () => {
+    const caseDetail = await uploadPetition(test);
+    test.docketNumber = caseDetail.docketNumber;
+  });
+  petitionerFilesDocumentForCase(test, fakeFile);
+
+  loginAs(test, 'petitionsclerk');
+  petitionsClerkViewsDocketRecordEditLinks(test);
+});

--- a/web-client/integration-tests/trialClerkWorkingCopy.test.js
+++ b/web-client/integration-tests/trialClerkWorkingCopy.test.js
@@ -12,6 +12,7 @@ import petitionsClerkUpdatesFiledBy from './journey/petitionsClerkUpdatesFiledBy
 import trialClerkAddsNotesFromWorkingCopyCaseList from './journey/trialClerkAddsNotesFromWorkingCopyCaseList';
 import trialClerkViewsNotesFromCaseDetail from './journey/trialClerkViewsNotesFromCaseDetail';
 import trialClerkViewsTrialSessionWorkingCopy from './journey/trialClerkViewsTrialSessionWorkingCopy';
+import trialClerkViewsTrialSessionWorkingCopyWithNotes from './journey/trialClerkViewsTrialSessionWorkingCopyWithNotes';
 
 const test = setupTest();
 
@@ -69,4 +70,5 @@ describe('Trial Clerk Views Trial Session Working Copy', () => {
   trialClerkViewsTrialSessionWorkingCopy(test);
   trialClerkAddsNotesFromWorkingCopyCaseList(test);
   trialClerkViewsNotesFromCaseDetail(test);
+  trialClerkViewsTrialSessionWorkingCopyWithNotes(test);
 });

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -106,7 +106,8 @@ export const formattedCaseDetail = (get, applicationContext) => {
         } else if (
           !document.isCourtIssuedDocument &&
           !document.isPetition &&
-          qcWorkItemsUntouched
+          qcWorkItemsUntouched &&
+          permissions.DOCKET_ENTRY
         ) {
           editLink = '/edit';
         } else if (document.isPetition && !document.servedAt) {
@@ -125,7 +126,6 @@ export const formattedCaseDetail = (get, applicationContext) => {
 
       return {
         action: record.action,
-        canEdit: document && document.canEdit,
         createdAtFormatted: record.createdAtFormatted,
         description: record.description,
         descriptionDisplay,

--- a/web-client/src/presenter/computeds/formattedCaseDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.test.js
@@ -521,7 +521,7 @@ describe('formattedCaseDetail', () => {
         showDocumentEditLink: true,
       },
       {
-        editLink: '/edit',
+        editLink: '',
         showDocumentEditLink: true,
       },
     ]);


### PR DESCRIPTION
https://trello.com/c/BKjfg854/409-staging-trial-clerk-can-add-a-judges-note-to-a-case-it-overrides-any-notes-a-judge-may-have-made

https://trello.com/c/YGe3sodd/415-petitions-clerk-should-not-see-document-info-tab-for-external-filed-docs
