### PR TITLE
Bug: printable trial session calendar throws an error

### DIFF
--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -871,6 +871,7 @@ module.exports = (appContextUser = {}) => {
     getConstants: () => ({
       CASE_INVENTORY_MAX_PAGE_SIZE: 5000,
       ORDER_TYPES_MAP: Order.ORDER_TYPES,
+      SESSION_STATUS_GROUPS: TrialSession.SESSION_STATUS_GROUPS,
     }),
     getCurrentUser,
     getDispatchers: () => ({


### PR DESCRIPTION
A necessary set of constants was missing from the app context.