### PR TITLE
4296: rename sequence

### DIFF
--- a/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
@@ -59,7 +59,7 @@ export default (test, fakeFile, trialLocation = 'Birmingham, Alabama') => {
       value: trialLocation,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(
       test.getState('validationErrors.requestForPlaceOfTrialFile'),
@@ -105,7 +105,7 @@ export default (test, fakeFile, trialLocation = 'Birmingham, Alabama') => {
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(
       test.getState('validationErrors.requestForPlaceOfTrialFile'),

--- a/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
@@ -8,7 +8,7 @@ export default (test, fakeFile, trialLocation = 'Birmingham, Alabama') => {
     await test.runSequence('gotoStartCaseWizardSequence');
     expect(test.getState('form.hasVerifiedIrsNotice')).toEqual(false);
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('alertError.title')).toEqual(
       'Please correct the following errors on the page:',
@@ -186,7 +186,7 @@ export default (test, fakeFile, trialLocation = 'Birmingham, Alabama') => {
     expect(test.getState('alertError')).toBeUndefined();
     expect(test.getState('validationErrors')).toEqual({});
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
 

--- a/web-client/integration-tests/journey/petitionsClerkCreatesNewCaseAndSavesForLater.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesNewCaseAndSavesForLater.js
@@ -150,7 +150,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
 
   it('should default to parties tab when creating a new case', async () => {
     await test.runSequence('gotoStartCaseWizardSequence');
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('StartCaseInternal');
     expect(test.getState('currentViewMetadata.startCaseInternal.tab')).toBe(
@@ -248,7 +248,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
   });
 
   it('should navigate to review screen when case information has been validated', async () => {
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
   });
@@ -274,7 +274,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: 'One fish, two fish',
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
     expect(test.getState('form.caseCaption')).toBe('One fish, two fish');
@@ -297,7 +297,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: Case.CASE_TYPES_MAP.interestAbatement,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
     expect(test.getState('form.caseType')).toBe(
@@ -316,7 +316,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: fakeFile,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
     expect(test.getState('form.stinFile').name).toBe('differentFakeFile.pdf');
@@ -376,7 +376,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
     expect(test.getState('form.petitionFile')).toBe(fakeFile);
   });
@@ -407,7 +407,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
     expect(test.getState('form.stinFile')).toBe(fakeFile);
   });
@@ -438,7 +438,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
 
     expect(test.getState('form.requestForPlaceOfTrialFile')).toBe(fakeFile);
@@ -465,7 +465,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
 
     expect(test.getState('form.odsFile')).toBe(fakeFile);
@@ -492,7 +492,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
     expect(test.getState('currentPage')).toEqual('ReviewPetitionFromPaper');
 
     expect(test.getState('form.apwFile')).toBe(fakeFile);
@@ -570,7 +570,7 @@ export const petitionsClerkCreatesNewCaseAndSavesForLater = (
   });
 
   it('should navigate to Document QC inbox page when saving an in progress case for later', async () => {
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('validationErrors')).toEqual({});
 

--- a/web-client/integration-tests/journey/petitionsClerkVerifiesOrderForOdsCheckbox.js
+++ b/web-client/integration-tests/journey/petitionsClerkVerifiesOrderForOdsCheckbox.js
@@ -21,7 +21,7 @@ export const petitionsClerkVerifiesOrderForOdsCheckbox = (test, fakeFile) => {
 
     expect(test.getState('form.orderForOds')).toBeTruthy();
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(
       test.getState('validationErrors.ownershipDisclosureFile'),
@@ -32,7 +32,7 @@ export const petitionsClerkVerifiesOrderForOdsCheckbox = (test, fakeFile) => {
       value: false,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('validationErrors.ownershipDisclosureFile')).toEqual(
       CaseInternal.VALIDATION_ERROR_MESSAGES.ownershipDisclosureFile,

--- a/web-client/integration-tests/journey/petitionsClerkVerifiesPetitionPaymentFeeOptions.js
+++ b/web-client/integration-tests/journey/petitionsClerkVerifiesPetitionPaymentFeeOptions.js
@@ -19,7 +19,7 @@ export const petitionsClerkVerifiesPetitionPaymentFeeOptions = (
 
     expect(test.getState('form.orderForFilingFee')).toEqual(false);
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('validationErrors')).toMatchObject({
       petitionPaymentDate: Case.VALIDATION_ERROR_MESSAGES.petitionPaymentDate,
@@ -44,7 +44,7 @@ export const petitionsClerkVerifiesPetitionPaymentFeeOptions = (
       value: 'check',
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(
       test.getState('validationErrors.petitionPaymentDate'),
@@ -60,7 +60,7 @@ export const petitionsClerkVerifiesPetitionPaymentFeeOptions = (
 
     expect(test.getState('form.orderForFilingFee')).toEqual(true);
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(
       test.getState('validationErrors.petitionPaymentDate'),
@@ -76,7 +76,7 @@ export const petitionsClerkVerifiesPetitionPaymentFeeOptions = (
 
     expect(test.getState('form.orderForFilingFee')).toEqual(false);
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(test.getState('validationErrors')).toMatchObject({
       applicationForWaiverOfFilingFeeFile:
@@ -107,7 +107,7 @@ export const petitionsClerkVerifiesPetitionPaymentFeeOptions = (
       value: 1,
     });
 
-    await test.runSequence('navigateToReviewPetitionFromPaperSequence');
+    await test.runSequence('reviewPetitionFromPaperSequence');
 
     expect(
       test.getState('validationErrors.petitionPaymentWaivedDate'),

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -145,7 +145,6 @@ import { navigateToPathSequence } from './sequences/navigateToPathSequence';
 import { navigateToPrintPreviewSequence } from './sequences/navigateToPrintPreviewSequence';
 import { navigateToPrintableCaseConfirmationSequence } from './sequences/navigateToPrintableCaseConfirmationSequence';
 import { navigateToPrintableDocketRecordSequence } from './sequences/navigateToPrintableDocketRecordSequence';
-import { navigateToReviewPetitionFromPaperSequence } from './sequences/navigateToReviewPetitionFromPaperSequence';
 import { navigateToReviewSavedPetitionSequence } from './sequences/navigateToReviewSavedPetitionSequence';
 import { notFoundErrorSequence } from './sequences/notFoundErrorSequence';
 import { noticeGenerationCompleteSequence } from './sequences/noticeGenerationCompleteSequence';
@@ -209,6 +208,7 @@ import { rescanBatchSequence } from './sequences/rescanBatchSequence';
 import { resetCaseMenuSequence } from './sequences/resetCaseMenuSequence';
 import { resetHeaderAccordionsSequence } from './sequences/resetHeaderAccordionsSequence';
 import { reviewExternalDocumentInformationSequence } from './sequences/reviewExternalDocumentInformationSequence';
+import { reviewPetitionFromPaperSequence } from './sequences/reviewPetitionFromPaperSequence';
 import { reviewRequestAccessInformationSequence } from './sequences/reviewRequestAccessInformationSequence';
 import { runTrialSessionPlanningReportSequence } from './sequences/runTrialSessionPlanningReportSequence';
 import { saveCaseAndServeToIrsSequence } from './sequences/saveCaseAndServeToIrsSequence';
@@ -536,7 +536,6 @@ export const presenter = {
     navigateToPrintPreviewSequence,
     navigateToPrintableCaseConfirmationSequence,
     navigateToPrintableDocketRecordSequence,
-    navigateToReviewPetitionFromPaperSequence,
     navigateToReviewSavedPetitionSequence,
     notFoundErrorSequence,
     noticeGenerationCompleteSequence,
@@ -600,6 +599,7 @@ export const presenter = {
     resetCaseMenuSequence,
     resetHeaderAccordionsSequence,
     reviewExternalDocumentInformationSequence,
+    reviewPetitionFromPaperSequence,
     reviewRequestAccessInformationSequence,
     runTrialSessionPlanningReportSequence,
     saveCaseAndServeToIrsSequence,

--- a/web-client/src/presenter/sequences/reviewPetitionFromPaperSequence.js
+++ b/web-client/src/presenter/sequences/reviewPetitionFromPaperSequence.js
@@ -12,7 +12,7 @@ import { startShowValidationAction } from '../actions/startShowValidationAction'
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
 import { validatePetitionFromPaperAction } from '../actions/validatePetitionFromPaperAction';
 
-export const navigateToReviewPetitionFromPaperSequence = [
+export const reviewPetitionFromPaperSequence = [
   checkForActiveBatchesAction,
   {
     hasActiveBatches: [setShowModalFactoryAction('UnfinishedScansModal')],

--- a/web-client/src/views/StartCaseInternal/StartCaseInternal.jsx
+++ b/web-client/src/views/StartCaseInternal/StartCaseInternal.jsx
@@ -16,14 +16,13 @@ export const StartCaseInternal = connect(
   {
     documentSelectedForScan: state.currentViewMetadata.documentSelectedForScan,
     formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
-    navigateToReviewPetitionFromPaperSequence:
-      sequences.navigateToReviewPetitionFromPaperSequence,
+    reviewPetitionFromPaperSequence: sequences.reviewPetitionFromPaperSequence,
     showModal: state.modal.showModal,
   },
   function StartCaseInternal({
     documentSelectedForScan,
     formCancelToggleCancelSequence,
-    navigateToReviewPetitionFromPaperSequence,
+    reviewPetitionFromPaperSequence,
     showModal,
   }) {
     return (
@@ -96,7 +95,7 @@ export const StartCaseInternal = connect(
                   id="submit-case"
                   type="button"
                   onClick={() => {
-                    navigateToReviewPetitionFromPaperSequence();
+                    reviewPetitionFromPaperSequence();
                   }}
                 >
                   Review Petition


### PR DESCRIPTION
Updating this naming to more closely match the pattern we're following in:
```     
reviewExternalDocumentInformationSequence
reviewRequestAccessInformationSequence
```