### PR TITLE
Ensure voiceover reads zip field

### DIFF
--- a/web-client/src/views/StartCase/Address.jsx
+++ b/web-client/src/views/StartCase/Address.jsx
@@ -215,13 +215,14 @@ export const Address = connect(
           }
         >
           <label
-            aria-label="zip code"
+            aria-hidden
             className="usa-label"
             htmlFor={`${type}.postalCode`}
           >
             ZIP code
           </label>
           <input
+            aria-label="zip code"
             autoCapitalize="none"
             className="usa-input max-width-200 tablet:usa-input--medium"
             id={`${type}.postalCode`}

--- a/web-client/src/views/TrialSessions/LocationInformationForm.jsx
+++ b/web-client/src/views/TrialSessions/LocationInformationForm.jsx
@@ -214,14 +214,11 @@ export const LocationInformationForm = connect(
           </div>
 
           <FormGroup errorText={validationErrors.postalCode}>
-            <label
-              aria-label="zip code"
-              className="usa-label"
-              htmlFor="postal-code"
-            >
+            <label aria-hidden className="usa-label" htmlFor="postal-code">
               ZIP code <span className="usa-hint">(optional)</span>
             </label>
             <input
+              aria-label="zip code"
               autoCapitalize="none"
               className="usa-input max-width-200 usa-input--medium"
               id="postal-code"


### PR DESCRIPTION
The MacOS voiceover utility fails to read `aria-label` on a <label> element. This fixes that.