### PR TITLE
udpated order search query to search for filingDate instead of received date

### DIFF
--- a/shared/src/persistence/elasticsearch/orderKeywordSearch.js
+++ b/shared/src/persistence/elasticsearch/orderKeywordSearch.js
@@ -84,7 +84,7 @@ exports.orderKeywordSearch = async ({
   if (startDate && endDate) {
     queryParams.push({
       range: {
-        'receivedAt.S': {
+        'filingDate.S': {
           format: 'strict_date_time', // ISO-8601 time stamp
           gte: startDate,
           lte: endDate,

--- a/shared/src/persistence/elasticsearch/orderKeywordSearch.test.js
+++ b/shared/src/persistence/elasticsearch/orderKeywordSearch.test.js
@@ -142,7 +142,7 @@ describe('orderKeywordSearch', () => {
       ...baseQueryParams,
       {
         range: {
-          'receivedAt.S': {
+          'filingDate.S': {
             format: 'strict_date_time',
             gte: '2020-02-20T05:00:00.000Z',
             lte: '2020-02-21T04:59:59.999Z',


### PR DESCRIPTION
Order search by date range now searches based on the document filing date instead of received date, as specified on Figma