### PR TITLE
DevEx: remove custom validate functions

### DIFF
--- a/shared/src/business/entities/Batch.js
+++ b/shared/src/business/entities/Batch.js
@@ -60,11 +60,6 @@ Batch.schema = joi.object().keys({
   pages: joi.array().min(1).required(),
 });
 
-joiValidationDecorator(
-  Batch,
-  Batch.schema,
-  undefined,
-  Batch.VALIDATION_ERROR_MESSAGES,
-);
+joiValidationDecorator(Batch, Batch.schema, Batch.VALIDATION_ERROR_MESSAGES);
 
 module.exports = { Batch };

--- a/shared/src/business/entities/CaseAssociationRequestFactory.js
+++ b/shared/src/business/entities/CaseAssociationRequestFactory.js
@@ -138,8 +138,6 @@ function CaseAssociationRequestFactory(rawProps) {
     supportingDocuments: joi.array().optional(),
   };
 
-  let customValidate;
-
   const makeRequired = itemName => {
     schema[itemName] = schemaOptionalItems[itemName];
   };
@@ -175,7 +173,6 @@ function CaseAssociationRequestFactory(rawProps) {
   joiValidationDecorator(
     entityConstructor,
     schema,
-    customValidate,
     CaseAssociationRequestFactory.VALIDATION_ERROR_MESSAGES,
   );
 

--- a/shared/src/business/entities/CaseDeadline.js
+++ b/shared/src/business/entities/CaseDeadline.js
@@ -75,7 +75,6 @@ CaseDeadline.schema = joi.object().keys({
 joiValidationDecorator(
   CaseDeadline,
   CaseDeadline.schema,
-  undefined,
   CaseDeadline.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/DocketRecord.js
+++ b/shared/src/business/entities/DocketRecord.js
@@ -97,7 +97,6 @@ joiValidationDecorator(
       .optional()
       .description('Served parties code to override system-computed code.'),
   }),
-  undefined,
   DocketRecord.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -448,9 +448,6 @@ joiValidationDecorator(
     userId: joi.string().required(),
     workItems: joi.array().optional(),
   }),
-  function () {
-    return WorkItem.validateCollection(this.workItems);
-  },
 );
 
 /**

--- a/shared/src/business/entities/ForwardMessage.js
+++ b/shared/src/business/entities/ForwardMessage.js
@@ -32,7 +32,6 @@ joiValidationDecorator(
     forwardMessage: joi.string().required(),
     section: joi.string().required(),
   }),
-  undefined,
   ForwardMessage.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/InitialWorkItemMessage.js
+++ b/shared/src/business/entities/InitialWorkItemMessage.js
@@ -32,7 +32,6 @@ joiValidationDecorator(
     message: joi.string().required(),
     section: joi.string().required(),
   }),
-  undefined,
   InitialWorkItemMessage.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/IrsPractitioner.js
+++ b/shared/src/business/entities/IrsPractitioner.js
@@ -32,7 +32,6 @@ joiValidationDecorator(
       .valid(...Object.values(SERVICE_INDICATOR_TYPES))
       .required(),
   }),
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/NewPractitioner.js
+++ b/shared/src/business/entities/NewPractitioner.js
@@ -35,7 +35,6 @@ joiValidationDecorator(
     role: joi.string().optional().allow(null),
     userId: joi.string().optional().allow(null),
   }),
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/Practitioner.js
+++ b/shared/src/business/entities/Practitioner.js
@@ -169,7 +169,6 @@ joiValidationDecorator(
   joi.object().keys({
     ...validationRules,
   }),
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/PrivatePractitioner.js
+++ b/shared/src/business/entities/PrivatePractitioner.js
@@ -32,7 +32,6 @@ joiValidationDecorator(
       .valid(...Object.values(SERVICE_INDICATOR_TYPES))
       .required(),
   }),
-  undefined,
   {},
 );
 

--- a/shared/src/business/entities/PublicUser.js
+++ b/shared/src/business/entities/PublicUser.js
@@ -50,7 +50,6 @@ function PublicUser(rawUser) {
 joiValidationDecorator(
   PublicUser,
   joi.object().keys(userValidation),
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/Scan.js
+++ b/shared/src/business/entities/Scan.js
@@ -89,11 +89,6 @@ Scan.schema = joi.object().keys({
     .required(),
 });
 
-joiValidationDecorator(
-  Scan,
-  Scan.schema,
-  undefined,
-  Scan.VALIDATION_ERROR_MESSAGES,
-);
+joiValidationDecorator(Scan, Scan.schema, Scan.VALIDATION_ERROR_MESSAGES);
 
 module.exports = { Scan };

--- a/shared/src/business/entities/User.js
+++ b/shared/src/business/entities/User.js
@@ -144,7 +144,6 @@ User.validationName = 'User';
 joiValidationDecorator(
   User,
   joi.object().keys(userValidation),
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/WorkItem.js
+++ b/shared/src/business/entities/WorkItem.js
@@ -109,9 +109,6 @@ joiValidationDecorator(
       })
       .required(),
   }),
-  function () {
-    return Message.validateCollection(this.messages);
-  },
 );
 
 /**

--- a/shared/src/business/entities/caseAssociation/AddIrsPractitioner.js
+++ b/shared/src/business/entities/caseAssociation/AddIrsPractitioner.js
@@ -25,7 +25,6 @@ AddIrsPractitioner.schema = joi.object().keys({
 joiValidationDecorator(
   AddIrsPractitioner,
   AddIrsPractitioner.schema,
-  undefined,
   AddIrsPractitioner.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/caseAssociation/AddPrivatePractitionerFactory.js
+++ b/shared/src/business/entities/caseAssociation/AddPrivatePractitionerFactory.js
@@ -41,8 +41,6 @@ AddPrivatePractitionerFactory.get = metadata => {
     representingSecondary: joi.boolean(),
   };
 
-  let customValidate;
-
   const makeRequired = itemName => {
     makeRequiredHelper({
       itemName,
@@ -61,7 +59,6 @@ AddPrivatePractitionerFactory.get = metadata => {
   joiValidationDecorator(
     entityConstructor,
     schema,
-    customValidate,
     AddPrivatePractitionerFactory.VALIDATION_ERROR_MESSAGES,
   );
 

--- a/shared/src/business/entities/caseAssociation/EditPrivatePractitionerFactory.js
+++ b/shared/src/business/entities/caseAssociation/EditPrivatePractitionerFactory.js
@@ -39,8 +39,6 @@ EditPrivatePractitionerFactory.get = metadata => {
     representingSecondary: joi.boolean(),
   };
 
-  let customValidate;
-
   const makeRequired = itemName => {
     makeRequiredHelper({
       itemName,
@@ -59,7 +57,6 @@ EditPrivatePractitionerFactory.get = metadata => {
   joiValidationDecorator(
     entityConstructor,
     schema,
-    customValidate,
     EditPrivatePractitionerFactory.VALIDATION_ERROR_MESSAGES,
   );
 

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -703,7 +703,6 @@ Case.validationRules = {
 joiValidationDecorator(
   Case,
   joi.object().keys(Case.validationRules),
-  undefined,
   Case.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/cases/CaseExternal.js
+++ b/shared/src/business/entities/cases/CaseExternal.js
@@ -95,9 +95,6 @@ CaseExternal.commonRequirements = {
 joiValidationDecorator(
   CaseExternal,
   joi.object().keys(CaseExternal.commonRequirements),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   CaseExternal.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/cases/CaseExternalIncomplete.js
+++ b/shared/src/business/entities/cases/CaseExternalIncomplete.js
@@ -54,11 +54,6 @@ joiValidationDecorator(
     preferredTrialCity: CaseExternal.commonRequirements.preferredTrialCity,
     procedureType: CaseExternal.commonRequirements.procedureType,
   }),
-  //TODO - remove all customValidation functions - they are not being used anymore
-  // function () {
-  //   return !this.getFormattedValidationErrors();
-  // },
-  undefined,
   CaseExternalIncomplete.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/cases/CaseExternalInformationFactory.js
+++ b/shared/src/business/entities/cases/CaseExternalInformationFactory.js
@@ -82,9 +82,6 @@ const schema = {
 joiValidationDecorator(
   CaseExternalInformationFactory,
   joi.object().keys(schema),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   CaseExternalInformationFactory.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/cases/CaseInternal.js
+++ b/shared/src/business/entities/cases/CaseInternal.js
@@ -177,9 +177,6 @@ const paperRequirements = joi
 joiValidationDecorator(
   CaseInternal,
   paperRequirements,
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   CaseInternal.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/cases/CaseSearch.js
+++ b/shared/src/business/entities/cases/CaseSearch.js
@@ -53,7 +53,6 @@ CaseSearch.schema = joi.object().keys({
 joiValidationDecorator(
   CaseSearch,
   CaseSearch.schema,
-  undefined,
   CaseSearch.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/cases/PublicCase.js
+++ b/shared/src/business/entities/cases/PublicCase.js
@@ -77,7 +77,6 @@ joiValidationDecorator(
   joi.object(publicCaseSchema).when(joi.object({ isSealed: true }).unknown(), {
     then: joi.object(sealedCaseSchemaRestricted),
   }),
-  undefined,
   {},
 );
 

--- a/shared/src/business/entities/cases/PublicContact.js
+++ b/shared/src/business/entities/cases/PublicContact.js
@@ -20,7 +20,6 @@ joiValidationDecorator(
     name: joi.string().optional(),
     state: joi.string().optional(),
   }),
-  undefined,
   {},
 );
 

--- a/shared/src/business/entities/cases/PublicDocketRecordEntry.js
+++ b/shared/src/business/entities/cases/PublicDocketRecordEntry.js
@@ -26,7 +26,6 @@ joiValidationDecorator(
     filingDate: joi.date().max('now').iso().optional(), // Required on DocketRecord so probably should be required here.
     index: joi.number().integer().optional(),
   }),
-  undefined,
   {},
 );
 

--- a/shared/src/business/entities/cases/PublicDocument.js
+++ b/shared/src/business/entities/cases/PublicDocument.js
@@ -56,7 +56,6 @@ joiValidationDecorator(
     servedParties: joi.array().optional(),
     status: joi.string().optional(),
   }),
-  undefined,
   {},
 );
 

--- a/shared/src/business/entities/contacts/ContactFactory.js
+++ b/shared/src/business/entities/contacts/ContactFactory.js
@@ -443,7 +443,6 @@ ContactFactory.createContactFactory = ({
         ...ContactFactory.getValidationObject({ countryType, isPaper }),
         ...additionalValidation,
       }),
-      undefined,
       GenericContactConstructor.errorToMessageMap,
     );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentDefault.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentDefault.js
@@ -25,7 +25,6 @@ CourtIssuedDocumentDefault.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentDefault,
   CourtIssuedDocumentDefault.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeA.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeA.js
@@ -47,7 +47,6 @@ CourtIssuedDocumentTypeA.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeA,
   CourtIssuedDocumentTypeA.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeB.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeB.js
@@ -33,7 +33,6 @@ CourtIssuedDocumentTypeB.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeB,
   CourtIssuedDocumentTypeB.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeC.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeC.js
@@ -31,7 +31,6 @@ CourtIssuedDocumentTypeC.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeC,
   CourtIssuedDocumentTypeC.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeD.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeD.js
@@ -49,7 +49,6 @@ CourtIssuedDocumentTypeD.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeD,
   CourtIssuedDocumentTypeD.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeE.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeE.js
@@ -46,7 +46,6 @@ CourtIssuedDocumentTypeE.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeE,
   CourtIssuedDocumentTypeE.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.js
@@ -33,7 +33,6 @@ CourtIssuedDocumentTypeF.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeF,
   CourtIssuedDocumentTypeF.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.js
@@ -38,7 +38,6 @@ CourtIssuedDocumentTypeG.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeG,
   CourtIssuedDocumentTypeG.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeH.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeH.js
@@ -38,7 +38,6 @@ CourtIssuedDocumentTypeH.schema = {
 joiValidationDecorator(
   CourtIssuedDocumentTypeH,
   CourtIssuedDocumentTypeH.schema,
-  undefined,
   VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/docketEntry/DocketEntryFactory.js
+++ b/shared/src/business/entities/docketEntry/DocketEntryFactory.js
@@ -104,8 +104,6 @@ function DocketEntryFactory(rawProps) {
     secondaryDocumentFile: joi.object().optional(),
   };
 
-  let customValidate;
-
   const addToSchema = itemName => {
     schema = schema.keys({
       [itemName]: schemaOptionalItems[itemName],
@@ -160,7 +158,6 @@ function DocketEntryFactory(rawProps) {
   joiValidationDecorator(
     entityConstructor,
     schema,
-    customValidate,
     DocketEntryFactory.VALIDATION_ERROR_MESSAGES,
   );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.js
@@ -288,12 +288,7 @@ ExternalDocumentInformationFactory.get = documentMetadata => {
     }
   }
 
-  joiValidationDecorator(
-    entityConstructor,
-    schema,
-    undefined,
-    VALIDATION_ERROR_MESSAGES,
-  );
+  joiValidationDecorator(entityConstructor, schema, VALIDATION_ERROR_MESSAGES);
 
   return new entityConstructor(documentMetadata);
 };

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardA.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardA.js
@@ -46,7 +46,6 @@ ExternalDocumentNonStandardA.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardA,
   ExternalDocumentNonStandardA.schema,
-  undefined,
   ExternalDocumentNonStandardA.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardB.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardB.js
@@ -37,7 +37,6 @@ ExternalDocumentNonStandardB.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardB,
   ExternalDocumentNonStandardB.schema,
-  undefined,
   ExternalDocumentNonStandardB.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardC.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardC.js
@@ -50,7 +50,6 @@ ExternalDocumentNonStandardC.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardC,
   ExternalDocumentNonStandardC.schema,
-  undefined,
   ExternalDocumentNonStandardC.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardD.js
@@ -50,7 +50,6 @@ ExternalDocumentNonStandardD.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardD,
   ExternalDocumentNonStandardD.schema,
-  undefined,
   ExternalDocumentNonStandardD.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardE.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardE.js
@@ -37,7 +37,6 @@ ExternalDocumentNonStandardE.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardE,
   ExternalDocumentNonStandardE.schema,
-  undefined,
   ExternalDocumentNonStandardE.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardF.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardF.js
@@ -49,7 +49,6 @@ ExternalDocumentNonStandardF.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardF,
   ExternalDocumentNonStandardF.schema,
-  undefined,
   ExternalDocumentNonStandardF.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardG.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardG.js
@@ -41,7 +41,6 @@ ExternalDocumentNonStandardG.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardG,
   joi.object(ExternalDocumentNonStandardG.schema),
-  undefined,
   ExternalDocumentNonStandardG.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardH.js
@@ -43,9 +43,6 @@ ExternalDocumentNonStandardH.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardH,
   ExternalDocumentNonStandardH.schema,
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   ExternalDocumentNonStandardH.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardI.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardI.js
@@ -39,7 +39,6 @@ ExternalDocumentNonStandardI.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardI,
   ExternalDocumentNonStandardI.schema,
-  undefined,
   ExternalDocumentNonStandardI.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardJ.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentNonStandardJ.js
@@ -39,7 +39,6 @@ ExternalDocumentNonStandardJ.schema = {
 joiValidationDecorator(
   ExternalDocumentNonStandardJ,
   ExternalDocumentNonStandardJ.schema,
-  undefined,
   ExternalDocumentNonStandardJ.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentStandard.js
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentStandard.js
@@ -42,7 +42,6 @@ ExternalDocumentStandard.schema = joi.object({
 joiValidationDecorator(
   ExternalDocumentStandard,
   ExternalDocumentStandard.schema,
-  undefined,
   ExternalDocumentStandard.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/externalDocument/SecondaryDocumentInformationFactory.js
+++ b/shared/src/business/entities/externalDocument/SecondaryDocumentInformationFactory.js
@@ -71,12 +71,7 @@ SecondaryDocumentInformationFactory.get = (
     }
   }
 
-  joiValidationDecorator(
-    entityConstructor,
-    schema,
-    undefined,
-    VALIDATION_ERROR_MESSAGES,
-  );
+  joiValidationDecorator(entityConstructor, schema, VALIDATION_ERROR_MESSAGES);
 
   return new entityConstructor(documentMetadata);
 };

--- a/shared/src/business/entities/externalDocument/SupportingDocumentInformationFactory.js
+++ b/shared/src/business/entities/externalDocument/SupportingDocumentInformationFactory.js
@@ -95,12 +95,7 @@ SupportingDocumentInformationFactory.get = (
     makeRequired('supportingDocumentFile');
   }
 
-  joiValidationDecorator(
-    entityConstructor,
-    schema,
-    undefined,
-    VALIDATION_ERROR_MESSAGES,
-  );
+  joiValidationDecorator(entityConstructor, schema, VALIDATION_ERROR_MESSAGES);
 
   return new entityConstructor(documentMetadata);
 };

--- a/shared/src/business/entities/notes/Note.js
+++ b/shared/src/business/entities/notes/Note.js
@@ -23,11 +23,6 @@ Note.schema = joi.object().keys({
   notes: joi.string().required(),
 });
 
-joiValidationDecorator(
-  Note,
-  Note.schema,
-  undefined,
-  Note.VALIDATION_ERROR_MESSAGES,
-);
+joiValidationDecorator(Note, Note.schema, Note.VALIDATION_ERROR_MESSAGES);
 
 module.exports = { Note };

--- a/shared/src/business/entities/notes/UserCaseNote.js
+++ b/shared/src/business/entities/notes/UserCaseNote.js
@@ -43,7 +43,6 @@ UserCaseNote.schema = joi.object().keys({
 joiValidationDecorator(
   UserCaseNote,
   UserCaseNote.schema,
-  undefined,
   UserCaseNote.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/orders/Order.js
+++ b/shared/src/business/entities/orders/Order.js
@@ -69,9 +69,6 @@ joiValidationDecorator(
     eventCode: joi.string().optional(),
     orderBody: joi.string().required(),
   }),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   Order.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/orders/OrderSearch.js
+++ b/shared/src/business/entities/orders/OrderSearch.js
@@ -100,7 +100,6 @@ OrderSearch.schema = joi
 joiValidationDecorator(
   OrderSearch,
   OrderSearch.schema,
-  undefined,
   OrderSearch.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/orders/OrderWithoutBody.js
+++ b/shared/src/business/entities/orders/OrderWithoutBody.js
@@ -25,9 +25,6 @@ joiValidationDecorator(
     documentType: joi.string().required(),
     eventCode: joi.string().required(),
   }),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   OrderWithoutBody.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/trialSessions/NewTrialSession.js
+++ b/shared/src/business/entities/trialSessions/NewTrialSession.js
@@ -26,9 +26,6 @@ joiValidationDecorator(
     ...TrialSession.validationRules.COMMON,
     startDate: joi.date().iso().min('now').required(),
   }),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   NewTrialSession.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/trialSessions/TrialSession.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.js
@@ -274,9 +274,6 @@ joiValidationDecorator(
     ),
     isCalendared: joi.boolean().required(),
   }),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   TrialSession.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.js
+++ b/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.js
@@ -98,9 +98,6 @@ TrialSessionWorkingCopy.validationRules = {
 joiValidationDecorator(
   TrialSessionWorkingCopy,
   joi.object().keys(TrialSessionWorkingCopy.validationRules),
-  function () {
-    return !this.getFormattedValidationErrors();
-  },
   TrialSessionWorkingCopy.VALIDATION_ERROR_MESSAGES,
 );
 

--- a/shared/src/utilities/JoiValidationDecorator.js
+++ b/shared/src/utilities/JoiValidationDecorator.js
@@ -103,13 +103,11 @@ function getFormattedValidationErrors(entity) {
  *
  * @param {Function} entityConstructor the entity constructor
  * @param {object} schema the joi validation schema
- * @param {Function} customValidate a custom validation function
  * @param {object} errorToMessageMap the map of error fields and messages
  */
 exports.joiValidationDecorator = function (
   entityConstructor,
   schema,
-  customValidate,
   errorToMessageMap = {},
 ) {
   if (!schema.validate && typeof schema === 'object') {

--- a/shared/src/utilities/JoiValidationDecorator.test.js
+++ b/shared/src/utilities/JoiValidationDecorator.test.js
@@ -24,7 +24,6 @@ joiValidationDecorator(
     hasNickname: joi.boolean().required(),
     name: joi.string().required(),
   }),
-  undefined,
   MockEntity1.errorToMessageMap,
 );
 
@@ -44,7 +43,7 @@ const MockEntity2Schema = joi.object().keys({
   obj1: joi.object().keys({ foo: joi.string().required() }).required(),
 });
 
-joiValidationDecorator(MockEntity2, MockEntity2Schema, undefined, {
+joiValidationDecorator(MockEntity2, MockEntity2Schema, {
   arry1: 'That is required',
   foo: 'lend me some sugar',
 });
@@ -58,7 +57,7 @@ const MockEntity3Schema = joi.object().keys({
   anotherItem: joi.string().required(),
 });
 
-joiValidationDecorator(MockEntity3, MockEntity3Schema, undefined, {
+joiValidationDecorator(MockEntity3, MockEntity3Schema, {
   anotherItem: 'Another item is required',
 });
 


### PR DESCRIPTION
The custom validate function is no longer being used in `JoiValidationDecorator` - the nested entity validation has been fixed, so we no longer require this function.