### PR TITLE
DevEx: Remove Document.status and Document.trialLocation

### DIFF
--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -3,16 +3,12 @@ const documentMapExternal = require('../../tools/externalFilingEvents.json');
 const documentMapInternal = require('../../tools/internalFilingEvents.json');
 const joi = require('@hapi/joi');
 const {
-  DOCKET_NUMBER_MATCHER,
-  TRIAL_LOCATION_MATCHER,
-} = require('./cases/CaseConstants');
-const {
   joiValidationDecorator,
 } = require('../../utilities/JoiValidationDecorator');
 const { createISODateString } = require('../utilities/DateHandler');
+const { DOCKET_NUMBER_MATCHER } = require('./cases/CaseConstants');
 const { flatten } = require('lodash');
 const { Order } = require('./orders/Order');
-const { TrialSession } = require('./trialSessions/TrialSession');
 const { User } = require('./User');
 const { WorkItem } = require('./WorkItem');
 
@@ -171,9 +167,7 @@ function Document(rawDocument, { applicationContext, filtered = false }) {
   this.servedParties = rawDocument.servedParties;
   this.serviceDate = rawDocument.serviceDate;
   this.serviceStamp = rawDocument.serviceStamp;
-  this.status = rawDocument.status; // TODO: look into this
   this.supportingDocument = rawDocument.supportingDocument;
-  this.trialLocation = rawDocument.trialLocation; // TODO: look into this
 
   if (applicationContext.getCurrentUser().userId === rawDocument.userId) {
     this.userId = rawDocument.userId;
@@ -478,16 +472,7 @@ joiValidationDecorator(
     signedAt: joi.date().iso().optional().allow(null),
     signedByUserId: joi.string().optional().allow(null),
     signedJudgeName: joi.string().optional().allow(null),
-    status: joi.string().valid('served').optional(),
     supportingDocument: joi.string().optional().allow(null),
-    trialLocation: joi
-      .alternatives()
-      .try(
-        joi.string().valid(...TrialSession.TRIAL_CITY_STRINGS),
-        joi.string().pattern(TRIAL_LOCATION_MATCHER), // Allow unique values for testing
-        joi.string().allow(null),
-      )
-      .optional(),
     userId: joi.string().required(),
     workItems: joi.array().optional(),
   }),

--- a/web-client/integration-tests/journey/petitionerViewsCaseDetailAfterFilingDocument.js
+++ b/web-client/integration-tests/journey/petitionerViewsCaseDetailAfterFilingDocument.js
@@ -41,22 +41,18 @@ export const petitionerViewsCaseDetailAfterFilingDocument = (
         expect.objectContaining({
           eventCode: 'M014',
           servedAt: expect.anything(),
-          status: 'served',
         }),
         expect.objectContaining({
           eventCode: 'AFF',
           servedAt: expect.anything(),
-          status: 'served',
         }),
         expect.objectContaining({
           eventCode: 'MISL',
           servedAt: expect.anything(),
-          status: 'served',
         }),
         expect.objectContaining({
           eventCode: 'MISL',
           servedAt: expect.anything(),
-          status: 'served',
         }),
       ]),
     );

--- a/web-client/integration-tests/signAndServeStipulatedDecision.test.js
+++ b/web-client/integration-tests/signAndServeStipulatedDecision.test.js
@@ -132,7 +132,7 @@ describe('a user signs and serves a stipulated decision', () => {
     const signedDocument = caseDetail.documents.find(
       d => d.documentId === signedDocumentId,
     );
-    expect(signedDocument.status).toEqual('served');
+    expect(signedDocument.servedAt).toBeDefined();
     expect(caseDetail.status).toEqual(Case.STATUS_TYPES.closed);
   });
 });


### PR DESCRIPTION
- Document.status only allowed "served", we can use the servedAt value instead
- Document.trialLocation is not needed, as this value exists on the Case