### PR TITLE
Error Warning messages persist when changing pages Advanced search

### DIFF
--- a/web-client/integration-tests/docketClerkOrderAdvancedSearch.test.js
+++ b/web-client/integration-tests/docketClerkOrderAdvancedSearch.test.js
@@ -330,4 +330,39 @@ describe('docket clerk order advanced search', () => {
       ]),
     );
   });
+
+  it('clears validation errors when switching tabs', async () => {
+    test.setState('advancedSearchForm', {
+      orderSearch: {},
+    });
+
+    await test.runSequence('submitOrderAdvancedSearchSequence');
+
+    expect(test.getState('alertError')).toEqual({
+      messages: ['Enter a keyword or phrase'],
+      title: 'Please correct the following errors:',
+    });
+
+    await test.runSequence('advancedSearchTabChangeSequence');
+
+    expect(test.getState('alertError')).not.toBeDefined();
+  });
+
+  it('includes the number of pages present in each document in the search results', async () => {
+    test.setState('advancedSearchForm', {
+      orderSearch: {
+        orderKeyword: 'Order of Dismissal Entered',
+      },
+    });
+
+    await test.runSequence('submitOrderAdvancedSearchSequence');
+
+    expect(test.getState('searchResults')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          numberOfPages: 1,
+        }),
+      ]),
+    );
+  });
 });

--- a/web-client/src/presenter/sequences/advancedSearchTabChangeSequence.js
+++ b/web-client/src/presenter/sequences/advancedSearchTabChangeSequence.js
@@ -1,7 +1,9 @@
+import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearSearchResultsAction } from '../actions/AdvancedSearch/clearSearchResultsAction';
 import { defaultAdvancedSearchFormAction } from '../actions/AdvancedSearch/defaultAdvancedSearchFormAction';
 
 export const advancedSearchTabChangeSequence = [
+  clearAlertsAction,
   defaultAdvancedSearchFormAction,
   clearSearchResultsAction,
 ];


### PR DESCRIPTION
Validation error messages no longer persist when switching between different search tabs