### PR TITLE
eslint cleanup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:jest/all',
+    'plugin:jest/recommended',
     'plugin:prettier/recommended',
     'plugin:promise/recommended',
     'plugin:react/recommended',
@@ -42,8 +42,10 @@ module.exports = {
   ],
   rules: {
     'arrow-parens': ['error', 'as-needed'],
-    complexity: ['warn', { max: 50 }], // module default is 20!
+    complexity: ['warn', { max: 40 }], // module default is 20!
     'import/named': 1,
+    'jest/no-identical-title': 'warn',
+    'jest/no-test-callback': 'warn',
     'jsdoc/check-param-names': 1,
     'jsdoc/check-types': 1,
     'jsdoc/newline-after-description': 1,
@@ -77,6 +79,7 @@ module.exports = {
     'no-irregular-whitespace': [2, { skipStrings: false }],
     'no-prototype-builtins': 0,
     'no-underscore-dangle': ['error', { allowAfterThis: true }],
+    'no-var': 'error',
     'no-warning-comments': [
       'error',
       { location: 'anywhere', terms: ['fixme', 'xxx'] },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,29 @@
+// re-format this file with `npx eslint --ignore-pattern '!.eslintrc.js' .eslintrc.js --fix`
 module.exports = {
+  env: {
+    browser: true,
+    'cypress/globals': true,
+    es6: true,
+    'jest/globals': true,
+    node: true,
+  },
   extends: [
     'eslint:recommended',
+    'plugin:jest/all',
     'plugin:prettier/recommended',
+    'plugin:promise/recommended',
     'plugin:react/recommended',
     'plugin:security/recommended',
     'prettier/react',
     'prettier/standard',
     'plugin:import/errors',
   ],
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 9,
+    jsx: true,
+    sourceType: 'module',
+  },
   plugins: [
     'cypress',
     'eslint-plugin-sort-imports-es6-autofix',
@@ -16,6 +32,7 @@ module.exports = {
     'jsdoc',
     'jsx-a11y',
     'prettier',
+    'promise',
     'react',
     'security',
     'sort-destructure-keys',
@@ -24,44 +41,22 @@ module.exports = {
     'spellcheck',
   ],
   rules: {
-    'import/named': 1,
-    'no-prototype-builtins': 0,
-    'react/prop-types': 0,
-    'require-atomic-updates': 0,
-    'security/detect-child-process': 0,
-    'security/detect-non-literal-fs-filename': 0,
-    'security/detect-object-injection': 0,
-    'react/jsx-sort-props': [
-      'error',
-      {
-        callbacksLast: true,
-        shorthandFirst: true,
-        shorthandLast: false,
-        ignoreCase: false,
-        noSortAlphabetically: false,
-      },
-    ],
     'arrow-parens': ['error', 'as-needed'],
+    complexity: ['warn', { max: 50 }], // module default is 20!
+    'import/named': 1,
     'jsdoc/check-param-names': 1,
     'jsdoc/check-types': 1,
     'jsdoc/newline-after-description': 1,
     'jsdoc/require-jsdoc': 1,
+    'jsdoc/require-param': 1,
     'jsdoc/require-param-description': 1,
     'jsdoc/require-param-name': 1,
     'jsdoc/require-param-type': 1,
-    'jsdoc/require-param': 1,
+    'jsdoc/require-returns': 1,
     'jsdoc/require-returns-check': 1,
     'jsdoc/require-returns-description': 1,
     'jsdoc/require-returns-type': 1,
-    'jsdoc/require-returns': 1,
     'jsdoc/valid-types': 1,
-    'no-underscore-dangle': ['error', { allowAfterThis: true }],
-    'no-warning-comments': [
-      'error',
-      { terms: ['fixme', 'xxx'], location: 'anywhere' },
-    ],
-    'prettier/prettier': 'error',
-    quotes: ['error', 'single', { avoidEscape: true }],
     'jsx-a11y/anchor-is-valid': [
       'error',
       {
@@ -72,14 +67,69 @@ module.exports = {
     'jsx-a11y/label-has-for': [
       2,
       {
+        allowChildren: false,
         components: ['Label'],
         required: {
           every: ['id'],
         },
-        allowChildren: false,
       },
     ],
     'no-irregular-whitespace': [2, { skipStrings: false }],
+    'no-prototype-builtins': 0,
+    'no-underscore-dangle': ['error', { allowAfterThis: true }],
+    'no-warning-comments': [
+      'error',
+      { location: 'anywhere', terms: ['fixme', 'xxx'] },
+    ],
+    'prefer-destructuring': [
+      'error',
+      {
+        AssignmentExpression: {
+          array: false,
+          object: true,
+        },
+        VariableDeclarator: {
+          array: false,
+          object: true,
+        },
+      },
+      {
+        enforceForRenamedProperties: false,
+      },
+    ],
+    'prettier/prettier': 'error',
+    'promise/always-return': 'warn',
+    'promise/avoid-new': 'off',
+    'promise/catch-or-return': 'warn',
+    'promise/no-callback-in-promise': 'warn',
+    'promise/no-native': 'off',
+    'promise/no-nesting': 'warn',
+    'promise/no-new-statics': 'error',
+    'promise/no-promise-in-callback': 'warn',
+    'promise/no-return-in-finally': 'warn',
+    'promise/no-return-wrap': 'error',
+    'promise/param-names': 'error',
+    'promise/valid-params': 'warn',
+    quotes: ['error', 'single', { avoidEscape: true }],
+    'react/jsx-sort-props': [
+      'error',
+      {
+        callbacksLast: true,
+        ignoreCase: false,
+        noSortAlphabetically: false,
+        shorthandFirst: true,
+        shorthandLast: false,
+      },
+    ],
+    'react/prop-types': 0,
+    'require-atomic-updates': 0,
+    'security/detect-child-process': 0,
+    'security/detect-non-literal-fs-filename': 0,
+    'security/detect-object-injection': 0,
+    'sort-destructure-keys/sort-destructure-keys': [
+      2,
+      { caseSensitive: false },
+    ],
     'sort-imports-es6-autofix/sort-imports-es6': [
       2,
       {
@@ -93,35 +143,15 @@ module.exports = {
       'asc',
       { caseSensitive: true, natural: true },
     ],
-    'sort-destructure-keys/sort-destructure-keys': [
-      2,
-      { caseSensitive: false },
-    ],
-    'prefer-destructuring': [
-      'error',
-      {
-        VariableDeclarator: {
-          array: false,
-          object: true,
-        },
-        AssignmentExpression: {
-          array: false,
-          object: true,
-        },
-      },
-      {
-        enforceForRenamedProperties: false,
-      },
-    ],
     'sort-requires/sort-requires': 2,
     'spellcheck/spell-checker': [
       1,
       {
         comments: true,
-        strings: false,
         identifiers: false,
-        templates: false,
         lang: 'en_US',
+        minLength: 4,
+        skipIfMatch: ['^https?://[^\\s]*$', '^[^\\s]{35,}$'],
         skipWords: [
           'anthony',
           'args',
@@ -304,32 +334,19 @@ module.exports = {
           'workitems',
           'xpos',
         ],
-        skipIfMatch: ['^https?://[^\\s]*$', '^[^\\s]{35,}$'],
-        minLength: 4,
+        strings: false,
+        templates: false,
       },
     ],
   },
   settings: {
-    react: {
-      version: '16.12.0',
-    },
     'import/resolver': {
       node: {
         extensions: ['.js', '.jsx'],
       },
     },
+    react: {
+      version: '16.12.0',
+    },
   },
-  env: {
-    'cypress/globals': true,
-    'jest/globals': true,
-    browser: true,
-    es6: true,
-    node: true,
-  },
-  parserOptions: {
-    ecmaVersion: 9,
-    jsx: true,
-    sourceType: 'module',
-  },
-  parser: 'babel-eslint',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9700,6 +9700,12 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4422,9 +4422,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
       "dev": true
     },
     "acorn-globals": {
@@ -9069,9 +9069,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.431",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.431.tgz",
-      "integrity": "sha512-2okqkXCIda7qDwjYhUFxPcQdZDIZZ/zBLDzVOif7WW/TSNfEhdT6SO07O1x/sFteEHX189Z//UwjbZKKCOn2Fg==",
+      "version": "1.3.432",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.432.tgz",
+      "integrity": "sha512-/GdNhXyLP5Yl2322CUX/+Xi8NhdHBqL6lD9VJVKjH6CjoPGakvwZ5CpKgj/oOlbzuWWjOvMjDw1bBuAIRCNTlw==",
       "dev": true
     },
     "elegant-spinner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3359,17 +3359,17 @@
       }
     },
     "@serverless/enterprise-plugin": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.6.10.tgz",
-      "integrity": "sha512-z6/BKEfuuvgTqmFl7oCCNNfqL9QTZD/vPIsKjpbcZIo65qRFgbbMvpf+uVJKBwwDYHLKoLWyMHzpqqmZfa+W/A==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.6.11.tgz",
+      "integrity": "sha512-cnn9A9ebpdW5Q1v9FHB7nbcFHkAttcownaw2AALXIld04hrIMpR3YILa47WxdXFyvyPg0dyKT5OhEly9Cc2BMQ==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
-        "@serverless/platform-client": "^0.25.6",
+        "@serverless/platform-client": "^0.25.7",
         "@serverless/platform-sdk": "^2.3.0",
         "chalk": "^2.4.2",
-        "child-process-ext": "^2.1.0",
-        "chokidar": "^3.3.1",
+        "child-process-ext": "^2.1.1",
+        "chokidar": "^3.4.0",
         "cli-color": "^2.0.0",
         "dependency-tree": "^7.2.1",
         "find-process": "^1.4.3",
@@ -3378,17 +3378,17 @@
         "iso8601-duration": "^1.2.0",
         "isomorphic-fetch": "^2.2.1",
         "js-yaml": "^3.13.1",
-        "jsonata": "^1.8.1",
-        "jszip": "^3.2.2",
+        "jsonata": "^1.8.3",
+        "jszip": "^3.4.0",
         "lodash": "^4.17.15",
         "memoizee": "^0.4.14",
-        "moment": "^2.24.0",
+        "moment": "^2.25.3",
         "node-dir": "^0.1.17",
         "node-fetch": "^2.6.0",
         "regenerator-runtime": "^0.13.5",
         "semver": "^6.3.0",
         "simple-git": "^1.132.0",
-        "source-map-support": "^0.5.16",
+        "source-map-support": "^0.5.19",
         "update-notifier": "^2.5.0",
         "uuid": "^3.4.0",
         "yamljs": "^0.3.0"
@@ -3473,6 +3473,12 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "moment": {
+          "version": "2.25.3",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+          "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==",
           "dev": true
         },
         "node-fetch": {
@@ -3895,9 +3901,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.6.tgz",
-      "integrity": "sha512-U2oynuRIB17GIbEdvjFrrEACOy7GQkzsX7bPEBz1H41vZYEU4j0fLL97sawmHDwHUXpUQDBMHIyM9vejqP9o1A==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -5048,9 +5054,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.671.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.671.0.tgz",
-      "integrity": "sha512-i83+/TIOLlhAxvV2xVLz5+XGtNqJgQJwP/e8J49rzDkyMV6OE2FgxU8utujGrComrSJFpITqMFqug+ZfdHoLIQ==",
+      "version": "2.673.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.673.0.tgz",
+      "integrity": "sha512-OoEPqTLmA5+4uSFf/k4ZLb8cEdx+CwlzovqGf6/gKvb8VrUxe5B5/d2RGlGM777Ke9TmuFhJtTIDugpgc2jo/Q==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -5337,39 +5343,6 @@
         "@babel/runtime": "^7.7.2",
         "cosmiconfig": "^6.0.0",
         "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "dev": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        },
-        "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -6485,9 +6458,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001052",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001052.tgz",
-      "integrity": "sha512-b2/oWZwkpWzEB1+Azr2Z4FcpdDkH+9R4dn+bkwk/6eH9mRSrnZjhA6v32+zsV+TSqC0pp2Rxush2yUVTJ0dJTQ==",
+      "version": "1.0.30001054",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001054.tgz",
+      "integrity": "sha512-jiKlTI6Ur8Kjfj8z0muGrV6FscpRvefcQVPSuMuXnvRCfExU7zlVLNjmOz1TnurWgUrAY7MMmjyy+uTgIl1XHw==",
       "dev": true
     },
     "capture-exit": {
@@ -7412,41 +7385,34 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
       "dev": true,
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
       },
       "dependencies": {
-        "import-fresh": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
-        },
         "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
           "dev": true,
           "requires": {
+            "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
           }
         },
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
       }
@@ -7738,6 +7704,46 @@
         "cssnano-preset-default": "^4.0.7",
         "is-resolvable": "^1.0.0",
         "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "cssnano-preset-default": {
@@ -8688,15 +8694,15 @@
       "dev": true
     },
     "detective-typescript": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-5.7.0.tgz",
-      "integrity": "sha512-4SQeACXWAjIOsd2kJykPL8gWC9nVA+z8w7KtAdtd/7BCpDfrpI2ZA7pdhsmHv/zxf3ofeqpYi72vCkZ65bAjtA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-5.8.0.tgz",
+      "integrity": "sha512-SrsUCfCaDTF64QVMHMidRal+kmkbIc5zP8cxxZPsomWx9vuEUjBlSJNhf7/ypE5cLdJJDI4qzKDmyzqQ+iz/xg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "^2.4.0",
-        "ast-module-types": "^2.5.0",
+        "@typescript-eslint/typescript-estree": "^2.29.0",
+        "ast-module-types": "^2.6.0",
         "node-source-walk": "^4.2.0",
-        "typescript": "^3.6.4"
+        "typescript": "^3.8.3"
       }
     },
     "diagnostics": {
@@ -9063,9 +9069,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.429",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.429.tgz",
-      "integrity": "sha512-YW8rXMJx33FalISp0uP0+AkvBx9gfzzQ4NotblGga6Z8ZX00bg2e5FNWV8fyDD/VN3WLhEtjFXNwzdJrdaAHEQ==",
+      "version": "1.3.431",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.431.tgz",
+      "integrity": "sha512-2okqkXCIda7qDwjYhUFxPcQdZDIZZ/zBLDzVOif7WW/TSNfEhdT6SO07O1x/sFteEHX189Z//UwjbZKKCOn2Fg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -9647,9 +9653,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.9.0.tgz",
-      "integrity": "sha512-8mt5xJQIFh33W5nE7vCikkDTE4saTo08V91KjU6yI5sLQ9e8Jkp1OXkWJoIHLheFqY5OXIZdAjZmNYHSJ3IpzQ==",
+      "version": "23.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.10.0.tgz",
+      "integrity": "sha512-cHC//nesojSO1MLxVmFJR/bUaQQG7xvMHQD8YLbsQzevR41WKm8paKDUv2wMHlUy5XLZUmNcWuflOi4apS8D+Q==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
@@ -12067,19 +12073,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "dev": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -12129,28 +12122,10 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
-        "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
         "pkg-dir": {
@@ -15368,13 +15343,13 @@
           "dev": true
         },
         "whatwg-url": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.0.0.tgz",
-          "integrity": "sha512-41ou2Dugpij8/LPO5Pq64K5q++MnRCBpEHvQr26/mArEKTkCV5aoXIqyhuYtE0pkqScXwhf2JP57rkRTYM29lQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
+          "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
           "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
-            "tr46": "^2.0.0",
+            "tr46": "^2.0.2",
             "webidl-conversions": "^5.0.0"
           },
           "dependencies": {
@@ -15852,8 +15827,7 @@
       "dependencies": {
         "bl": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.1"
@@ -15861,14 +15835,12 @@
         },
         "chownr": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-          "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+          "bundled": true,
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -15876,26 +15848,22 @@
         },
         "fs-constants": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+          "bundled": true,
           "dev": true
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "bundled": true,
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -15903,8 +15871,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -15912,8 +15879,7 @@
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -15922,8 +15888,7 @@
         },
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -15933,14 +15898,12 @@
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "bundled": true,
           "dev": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -15948,8 +15911,7 @@
         },
         "tar-fs": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-          "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -15960,8 +15922,7 @@
         },
         "tar-stream": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-          "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "bl": "^3.0.0",
@@ -15973,14 +15934,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -16202,19 +16161,6 @@
           "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
           "dev": true
         },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "dev": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        },
         "cross-spawn": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
@@ -16328,28 +16274,10 @@
             "mimic-fn": "^2.1.0"
           }
         },
-        "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
         "shebang-command": {
@@ -17225,16 +17153,16 @@
       "dev": true
     },
     "madge": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/madge/-/madge-3.8.0.tgz",
-      "integrity": "sha512-bcX2QxiTwWvZrNM+XkmZY1SPl18C2HGaQGhroj3YzqSRxQ1ns7WXCYDyGCfZwp/uLibnNd6IOWrRLOkCS+lpAg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-3.9.0.tgz",
+      "integrity": "sha512-ABR2ZTFga+TPLzlu2u46lcv8WwOzoI6VMTMqe3DyaY0igzyGpXiOIH1vAtziSKC4UHuyTpwkfhjWN5qOYR/5OA==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "commander": "^4.0.1",
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
         "commondir": "^1.0.1",
         "debug": "^4.0.1",
-        "dependency-tree": "^7.0.2",
+        "dependency-tree": "^7.2.1",
         "detective-amd": "^3.0.0",
         "detective-cjs": "^3.1.1",
         "detective-es6": "^2.1.0",
@@ -17243,12 +17171,12 @@
         "detective-sass": "^3.0.1",
         "detective-scss": "^2.0.1",
         "detective-stylus": "^1.0.0",
-        "detective-typescript": "^5.7.0",
+        "detective-typescript": "^5.8.0",
         "graphviz": "0.0.9",
-        "ora": "^4.0.2",
-        "pify": "^4.0.0",
+        "ora": "^4.0.4",
+        "pify": "^5.0.0",
         "pluralize": "^8.0.0",
-        "pretty-ms": "^5.0.0",
+        "pretty-ms": "^7.0.0",
         "rc": "^1.2.7",
         "walkdir": "^0.4.1"
       },
@@ -17264,9 +17192,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -17288,6 +17216,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -17307,6 +17241,12 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
           "dev": true
         },
         "supports-color": {
@@ -21139,9 +21079,9 @@
       }
     },
     "pretty-ms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.1.0.tgz",
-      "integrity": "sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
+      "integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
       "dev": true,
       "requires": {
         "parse-ms": "^2.1.0"
@@ -25054,9 +24994,9 @@
       }
     },
     "stringify-entities": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.0.tgz",
-      "integrity": "sha512-h7NJJIssprqlyjHT2eQt2W1F+MCcNmwPGlKb0bWEdET/3N44QN3QbUF/ueKCgAssyKRZ3Br9rQ7FcXjHr0qLHw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz",
+      "integrity": "sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==",
       "dev": true,
       "requires": {
         "character-entities-html4": "^1.0.0",
@@ -25292,19 +25232,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "dev": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -25485,12 +25412,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
         "read-pkg": {
@@ -27448,9 +27369,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz",
-      "integrity": "sha512-sAjOC+Kki6aJVbUOXJbcR0MnbfjvBzwKZazEJymA2IX49uoOdEdk+4fBq5cXgYgiyKtAyrrJNtBZdOeDIF+Fng==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+      "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -147,19 +147,17 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx}": [
-      "eslint"
-    ],
-    "*.{css,scss}": [
-      "stylelint"
-    ],
-    "swagger.json": [
-      "swagger-cli validate"
-    ]
+    "*.{js,jsx}": [ "eslint" ],
+    "shared/*.test.js": [ "jest --config shared/jest.config.js" ],
+    "web-api/*.test.js": [ "jest --config web-api/jest.config.js" ],
+    "web-client/src/*.test.js": [ "jest --config web-client/jest.config.js" ],
+    "*.{css,scss}": [ "stylelint" ],
+    "swagger.json": ["swagger-cli validate"]
   },
+
   "scripts": {
     "build:_api": "parcel build --no-minify --no-source-maps --bundle-node-modules --target node",
-    "build:all": "npm run clean && npm run build:assets && npm run build:_api -- web-api/src/apiHandlers.js web-api/src/casesHandlers.js web-api/src/casePartiesHandlers.js  web-api/src/caseMetaHandlers.js web-api/src/usersHandlers.js web-api/src/caseDeadlinesHandlers.js web-api/src/caseDocumentsHandlers.js web-api/src/caseNotesHandlers.js web-api/src/documentsHandlers.js web-api/src/workItemsHandlers.js web-api/src/sectionsHandlers.js web-api/src/trialSessionsHandlers.js web-api/src/migrateHandlers.js web-api/src/notificationHandlers.js web-api/src/streamsHandlers.js web-api/src/reportsHandlers.js web-api/src/practitionersHandlers.js && mkdir -p web-api/dist && find dist -name '*Handlers.js' -exec cp {} web-api/dist/ \\; && npm run build:client",
+    "build:all": "npm run clean && npm run build:assets && npm run build:_api -- web-api/src/*Handlers.js && mkdir -p web-api/dist && cp web-api/src/*Handlers.js web-api/dist/ && npm run build:client",
     "build:api:case:deadlines": "npm run build:_api -- web-api/src/caseDeadlinesHandlers.js",
     "build:api:case:documents": "npm run build:_api -- web-api/src/caseDocumentsHandlers.js",
     "build:api:case:meta": "npm run build:_api -- web-api/src/caseMetaHandlers.js",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jsdoc": "^24.0.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-sort-destructure-keys": "^1.3.3",
@@ -62,6 +63,7 @@
     "http-aws-es": "^6.0.0",
     "http-proxy": "^1.18.0",
     "http-proxy-middleware": "^1.0.3",
+    "husky": "^4.2.5",
     "i": "^0.3.6",
     "imagemin": "^7.0.1",
     "imagemin-pngquant": "^8.0.0",
@@ -74,6 +76,7 @@
     "json2md": "^1.7.0",
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.3",
+    "lint-staged": "^10.2.2",
     "lodash": "^4.17.15",
     "madge": "^3.7.0",
     "moment": "2.24.0",
@@ -137,6 +140,22 @@
     "webpack": "^4.42.1",
     "websocket": "^1.0.31",
     "wicg-inert": "^3.0.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "eslint"
+    ],
+    "*.{css,scss}": [
+      "stylelint"
+    ],
+    "swagger.json": [
+      "swagger-cli validate"
+    ]
   },
   "scripts": {
     "build:_api": "parcel build --no-minify --no-source-maps --bundle-node-modules --target node",

--- a/package.json
+++ b/package.json
@@ -148,9 +148,6 @@
   },
   "lint-staged": {
     "*.{js,jsx}": [ "eslint" ],
-    "shared/*.test.js": [ "jest --config shared/jest.config.js" ],
-    "web-api/*.test.js": [ "jest --config web-api/jest.config.js" ],
-    "web-client/src/*.test.js": [ "jest --config web-client/jest.config.js" ],
     "*.{css,scss}": [ "stylelint" ],
     "swagger.json": ["swagger-cli validate"]
   },

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -2767,36 +2767,40 @@ describe('Case entity', () => {
   });
 
   describe('DocketRecord indices must be unique', () => {
-    applicationContext.getCurrentUser.mockReturnValue(
-      MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
-    );
-    const caseEntity = new Case(
-      {
-        ...MOCK_CASE,
-        docketRecord: [
-          {
-            description: 'first record',
-            documentId: '8675309b-18d0-43ec-bafb-654e83405411',
-            eventCode: 'P',
-            filingDate: '2018-03-01T00:01:00.000Z',
-            index: 1,
-          },
-          {
-            description: 'second record',
-            documentId: '8675309b-28d0-43ec-bafb-654e83405412',
-            eventCode: 'STIN',
-            filingDate: '2018-03-01T00:02:00.000Z',
-            index: 1,
-          },
-        ],
-      },
-      {
-        applicationContext,
-      },
-    );
-
-    expect(caseEntity.getFormattedValidationErrors()).toEqual({
-      'docketRecord[1]': '"docketRecord[1]" contains a duplicate value',
+    let caseEntity;
+    beforeAll(() => {
+      applicationContext.getCurrentUser.mockReturnValue(
+        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
+      );
+      caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          docketRecord: [
+            {
+              description: 'first record',
+              documentId: '8675309b-18d0-43ec-bafb-654e83405411',
+              eventCode: 'P',
+              filingDate: '2018-03-01T00:01:00.000Z',
+              index: 1,
+            },
+            {
+              description: 'second record',
+              documentId: '8675309b-28d0-43ec-bafb-654e83405412',
+              eventCode: 'STIN',
+              filingDate: '2018-03-01T00:02:00.000Z',
+              index: 1,
+            },
+          ],
+        },
+        {
+          applicationContext,
+        },
+      );
+    });
+    it('identifies duplicate values in docket record indices', () => {
+      expect(caseEntity.getFormattedValidationErrors()).toEqual({
+        'docketRecord[1]': '"docketRecord[1]" contains a duplicate value',
+      });
     });
   });
 

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -95,8 +95,9 @@ describe('Case entity', () => {
 
   describe('filtered', () => {
     it('does not return private data if filtered is true and the user is external', () => {
-      applicationContext.getCurrentUser = () =>
-        MOCK_USERS['d7d90c05-f6cd-442c-a168-202db587f16f']; //petitioner user
+      applicationContext.getCurrentUser.mockReturnValue(
+        MOCK_USERS['d7d90c05-f6cd-442c-a168-202db587f16f'],
+      ); //petitioner user
 
       const myCase = new Case(
         { ...MOCK_CASE, associatedJudge: 'Chief Judge' },
@@ -109,8 +110,9 @@ describe('Case entity', () => {
     });
 
     it('returns private data if filtered is true and the user is internal', () => {
-      applicationContext.getCurrentUser = () =>
-        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f']; //docketclerk user
+      applicationContext.getCurrentUser.mockReturnValue(
+        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
+      ); //docketclerk user
 
       const myCase = new Case(
         { ...MOCK_CASE, associatedJudge: 'Chief Judge' },
@@ -123,8 +125,9 @@ describe('Case entity', () => {
     });
 
     it('returns private data if filtered is false and the user is external', () => {
-      applicationContext.getCurrentUser = () =>
-        MOCK_USERS['d7d90c05-f6cd-442c-a168-202db587f16f']; //petitioner user
+      applicationContext.getCurrentUser.mockReturnValue(
+        MOCK_USERS['d7d90c05-f6cd-442c-a168-202db587f16f'],
+      ); //petitioner user
 
       const myCase = new Case(
         { ...MOCK_CASE, associatedJudge: 'Chief Judge' },
@@ -137,8 +140,9 @@ describe('Case entity', () => {
     });
 
     it('returns private data if filtered is false and the user is internal', () => {
-      applicationContext.getCurrentUser = () =>
-        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f']; //docketclerk user
+      applicationContext.getCurrentUser.mockReturnValue(
+        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
+      ); //docketclerk user
 
       const myCase = new Case(
         { ...MOCK_CASE, associatedJudge: 'Chief Judge' },
@@ -2674,6 +2678,9 @@ describe('Case entity', () => {
   describe('isAssociatedUser', () => {
     let caseEntity;
     beforeEach(() => {
+      applicationContext.getCurrentUser.mockReturnValue(
+        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
+      );
       caseEntity = new Case(
         {
           ...MOCK_CASE,
@@ -2685,10 +2692,7 @@ describe('Case entity', () => {
           ],
         },
         {
-          applicationContext: {
-            getCurrentUser: () =>
-              MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
-          },
+          applicationContext,
         },
       );
     });
@@ -2767,12 +2771,11 @@ describe('Case entity', () => {
   });
 
   describe('DocketRecord indices must be unique', () => {
-    let caseEntity;
-    beforeAll(() => {
+    it('identifies duplicate values in docket record indices', () => {
       applicationContext.getCurrentUser.mockReturnValue(
         MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'],
       );
-      caseEntity = new Case(
+      const caseEntity = new Case(
         {
           ...MOCK_CASE,
           docketRecord: [
@@ -2796,8 +2799,7 @@ describe('Case entity', () => {
           applicationContext,
         },
       );
-    });
-    it('identifies duplicate values in docket record indices', () => {
+
       expect(caseEntity.getFormattedValidationErrors()).toEqual({
         'docketRecord[1]': '"docketRecord[1]" contains a duplicate value',
       });

--- a/shared/src/business/entities/trialSessions/TrialSession.test.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.test.js
@@ -292,7 +292,10 @@ describe('TrialSession entity', () => {
       const trialSession = new TrialSession(
         {
           ...VALID_TRIAL_SESSION,
-          caseOrder: [{ caseId: '46c4064f-b44a-4ac3-9dfb-9ce9f00e43f5' }],
+          caseOrder: [
+            { caseId: '46c4064f-b44a-4ac3-9dfb-9ce9f00e43f5' },
+            { caseId: '58c1f7a3-8062-42f0-a73e-8bd69b419878' },
+          ],
         },
         {
           applicationContext,
@@ -305,7 +308,7 @@ describe('TrialSession entity', () => {
         { caseId: '46c4064f-b44a-4ac3-9dfb-9ce9f00e43f5' },
       ]);
     });
-    it('should remove the expected case from the order', () => {
+    it('should remove the expected case from the order when there is only one entry', () => {
       const trialSession = new TrialSession(
         {
           ...VALID_TRIAL_SESSION,

--- a/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.js
@@ -278,7 +278,7 @@ exports.setNoticesForCalendaredTrialSessionInteractor = async ({
     return servedParties;
   };
 
-  for (var calendaredCase of calendaredCases) {
+  for (let calendaredCase of calendaredCases) {
     await setNoticeForCase(calendaredCase);
   }
 

--- a/shared/src/business/utilities/replaceBracketed.js
+++ b/shared/src/business/utilities/replaceBracketed.js
@@ -6,7 +6,7 @@
  * @returns {string} the template with the brackets replaced with replacement values
  */
 const replaceBracketed = (template, ...values) => {
-  var bracketsMatcher = /\[.*?\]/;
+  const bracketsMatcher = /\[.*?\]/;
   while (bracketsMatcher.test(template)) {
     template = template.replace(bracketsMatcher, values.shift() || '');
   }

--- a/shared/src/persistence/dynamsoft/getScannerInterface.js
+++ b/shared/src/persistence/dynamsoft/getScannerInterface.js
@@ -10,9 +10,9 @@ exports.getScannerInterface = () => {
   const getScanCount = () => DWObject.HowManyImagesInBuffer;
 
   const getSources = () => {
-    var count = DWObject.SourceCount;
+    const count = DWObject.SourceCount;
     const sources = [];
-    for (var i = 0; i < count; i++) {
+    for (let i = 0; i < count; i++) {
       sources.push(DWObject.GetSourceNameItems(i));
     }
     return sources;
@@ -138,16 +138,13 @@ exports.getScannerInterface = () => {
 
         return Promise.all(promises)
           .then(async blobs => {
-            const blobBuffers = [];
+            const blobBuffers = await Promise.all(
+              blobs.map(applicationContext.convertBlobToUInt8Array),
+            );
 
-            for (let blob of blobs) {
-              blobBuffers.push(
-                await applicationContext.convertBlobToUInt8Array(blob),
-              );
-            }
             response.scannedBuffer = blobBuffers;
             DWObject.RemoveAllImages();
-            resolve(response);
+            return resolve(response);
           })
           .catch(err => {
             response.error = err;

--- a/shared/src/persistence/dynamsoft/getScannerInterface.test.js
+++ b/shared/src/persistence/dynamsoft/getScannerInterface.test.js
@@ -119,15 +119,17 @@ describe('getScannerInterface', () => {
   it('can set a scanner source by index', () => {
     const scannerAPI = getScannerInterface();
     scannerAPI.setDWObject(DWObject);
-    scannerAPI.setSourceByIndex(1);
-    expect(scannerAPI.DWObject);
+    const result = scannerAPI.setSourceByIndex(1);
+    expect(scannerAPI.DWObject).toBe(DWObject);
+    expect(result).toBe(true);
   });
 
   it('can set a scanner source by name', () => {
     const scannerAPI = getScannerInterface();
     scannerAPI.setDWObject(DWObject);
-    scannerAPI.setSourceByName(mockSources[0]);
-    expect(scannerAPI.DWObject);
+    const result = scannerAPI.setSourceByName(mockSources[0]);
+    expect(scannerAPI.DWObject).toBe(DWObject);
+    expect(result).toBe(true);
   });
 
   it('setSourceByName returns `false` when the source is not found', () => {

--- a/shared/src/persistence/s3/getDocument.test.js
+++ b/shared/src/persistence/s3/getDocument.test.js
@@ -79,9 +79,8 @@ describe('getDocument', () => {
       protocol: 'S3',
     });
 
-    // expect(
-    //   applicationContext.getStorageClient().getObject,
-    // ).toHaveBeenCalledWith({ Bucket: 'DocumentBucketName' });
-    expect();
+    expect(
+      applicationContext.getStorageClient().getObject,
+    ).toHaveBeenCalledWith({ Bucket: 'DocumentBucketName' });
   });
 });

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-export */
 import { CerebralTest } from 'cerebral/test';
 import { JSDOM } from 'jsdom';
 import { applicationContext } from '../src/applicationContext';
@@ -570,10 +571,10 @@ export const refreshElasticsearchIndex = async () => {
 };
 
 export const base64ToUInt8Array = b64 => {
-  var binaryStr = Buffer.from(b64, 'base64').toString('binary');
-  var len = binaryStr.length;
-  var bytes = new Uint8Array(len);
-  for (var i = 0; i < len; i++) {
+  const binaryStr = Buffer.from(b64, 'base64').toString('binary');
+  const len = binaryStr.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
     bytes[i] = binaryStr.charCodeAt(i);
   }
   return bytes;

--- a/web-client/integration-tests/helpers.test.js
+++ b/web-client/integration-tests/helpers.test.js
@@ -2,12 +2,12 @@ import { gotoRoute } from './helpers';
 
 describe('helpers', () => {
   describe('gotoRoute', () => {
-    it('should invoke the expected route definition', async () => {
+    it('should invoke the expected documents route definition', async () => {
       const cbSpy = jest.fn().mockResolvedValue('awesome');
       const routes = [
         {
-          route: '/case-detail/*/documents/*',
           cb: cbSpy,
+          route: '/case-detail/*/documents/*',
         },
       ];
       const results = await gotoRoute(
@@ -18,12 +18,12 @@ describe('helpers', () => {
       expect(cbSpy).toHaveBeenCalledWith('abc-123-Z', '123-ABC-T');
     });
 
-    it('should invoke the expected route definition', async () => {
+    it('should invoke the expected messages route definition', async () => {
       const cbSpy = jest.fn().mockResolvedValue('awesome');
       const routes = [
         {
-          route: '/messages..',
           cb: cbSpy,
+          route: '/messages..',
         },
       ];
       const results = await gotoRoute(routes, '/messages/section/inbox');
@@ -31,16 +31,16 @@ describe('helpers', () => {
       expect(cbSpy).toHaveBeenCalledWith('/section/inbox');
     });
 
-    it('should invoke the expected route definition', async () => {
+    it('should invoke the expected root route definition', async () => {
       const cbSpy = jest.fn().mockResolvedValue('awesome');
       const routes = [
         {
-          route: '/',
           cb: cbSpy,
+          route: '/',
         },
         {
-          route: '/messages..',
           cb: () => null,
+          route: '/messages..',
         },
       ];
       const results = await gotoRoute(routes, '/');

--- a/web-client/src/presenter/actions/closeFileUploadStatusModalAction.js
+++ b/web-client/src/presenter/actions/closeFileUploadStatusModalAction.js
@@ -6,12 +6,11 @@ import { state } from 'cerebral';
  * @returns {Promise} async action
  */
 export const closeFileUploadStatusModalAction = async ({ store }) => {
+  store.set(state.fileUploadProgress.percentComplete, 100);
+  store.set(state.fileUploadProgress.timeRemaining, 0);
+  store.set(state.fileUploadProgress.isUploading, false);
   await new Promise(resolve => {
-    store.set(state.fileUploadProgress.percentComplete, 100);
-    store.set(state.fileUploadProgress.timeRemaining, 0);
-    store.set(state.fileUploadProgress.isUploading, false);
     setTimeout(resolve, process.env.FILE_UPLOAD_MODAL_TIMEOUT || 3000);
-  }).then(() => {
-    store.set(state.modal.showModal, '');
   });
+  store.set(state.modal.showModal, '');
 };

--- a/web-client/src/presenter/sequences/startScanSequence.test.js
+++ b/web-client/src/presenter/sequences/startScanSequence.test.js
@@ -31,7 +31,7 @@ describe('startScanSequence', () => {
     await test.runSequence('startScanSequence', {});
 
     expect(applicationContext.getScanner().startScanSession).toHaveBeenCalled();
-    expect(test.getState('scanner.isScanning')).toBeTruthy;
+    expect(test.getState('scanner.isScanning')).toBeTruthy();
   });
 
   it('provides a flow for setting a scan source if one is not cached', async () => {

--- a/web-client/src/ustc-ui/Tabs/Tabs.jsx
+++ b/web-client/src/ustc-ui/Tabs/Tabs.jsx
@@ -64,7 +64,7 @@ export function TabsComponent({
     const isActiveTab = tabName === activeKey;
     const tabContentId = asSwitch ? '' : `tabContent-${camelCase(tabName)}`;
 
-    var liClass = classNames('ustc-ui-tabs', {
+    const liClass = classNames('ustc-ui-tabs', {
       active: isActiveTab,
       'grid-col': boxed,
     });

--- a/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
+++ b/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
@@ -43,17 +43,19 @@ export const StateDrivenFileInput = connect(
             const { name } = e.target;
             limitFileSize(e, constants.MAX_FILE_SIZE_MB, () => {
               const file = e.target.files[0];
-              cloneFile(file).then(clonedFile => {
-                updateFormValueSequence({
-                  key: name,
-                  value: clonedFile,
-                });
-                updateFormValueSequence({
-                  key: `${name}Size`,
-                  value: clonedFile.size,
-                });
-                validationSequence();
-              });
+              cloneFile(file)
+                .then(clonedFile => {
+                  updateFormValueSequence({
+                    key: name,
+                    value: clonedFile,
+                  });
+                  updateFormValueSequence({
+                    key: `${name}Size`,
+                    value: clonedFile.size,
+                  });
+                  return validationSequence();
+                })
+                .catch(e => throw e);
             });
           }}
           onClick={e => {

--- a/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
+++ b/web-client/src/views/FileDocument/StateDrivenFileInput.jsx
@@ -55,7 +55,9 @@ export const StateDrivenFileInput = connect(
                   });
                   return validationSequence();
                 })
-                .catch(e => throw e);
+                .catch(() => {
+                  /* no-op */
+                });
             });
           }}
           onClick={e => {

--- a/web-client/src/views/SignOrder.jsx
+++ b/web-client/src/views/SignOrder.jsx
@@ -55,7 +55,9 @@ export const SignOrder = connect(
           };
           return page.render(renderContext);
         })
-        .catch(e => throw e);
+        .catch(() => {
+          /* no-op*/
+        });
     };
 
     const moveSig = (sig, x, y) => {

--- a/web-client/src/views/SignOrder.jsx
+++ b/web-client/src/views/SignOrder.jsx
@@ -41,18 +41,21 @@ export const SignOrder = connect(
       const canvas = canvasRef.current;
       const context = canvas.getContext('2d');
 
-      pdfObj.getPage(pageNumber).then(page => {
-        const scale = 1;
-        const viewport = page.getViewport({ scale });
-        canvas.height = viewport.height;
-        canvas.width = viewport.width;
+      pdfObj
+        .getPage(pageNumber)
+        .then(page => {
+          const scale = 1;
+          const viewport = page.getViewport({ scale });
+          canvas.height = viewport.height;
+          canvas.width = viewport.width;
 
-        var renderContext = {
-          canvasContext: context,
-          viewport: viewport,
-        };
-        page.render(renderContext);
-      });
+          const renderContext = {
+            canvasContext: context,
+            viewport: viewport,
+          };
+          return page.render(renderContext);
+        })
+        .catch(e => throw e);
     };
 
     const moveSig = (sig, x, y) => {

--- a/web-client/src/views/SignStipDecision.jsx
+++ b/web-client/src/views/SignStipDecision.jsx
@@ -119,7 +119,7 @@ export const SignStipDecision = connect(
         canvas.height = viewport.height;
         canvas.width = viewport.width;
 
-        var renderContext = {
+        const renderContext = {
           canvasContext: context,
           viewport: viewport,
         };

--- a/web-client/src/views/cloneFile.js
+++ b/web-client/src/views/cloneFile.js
@@ -16,6 +16,6 @@ export const cloneFile = file =>
       );
     });
     reader.addEventListener('error', () => {
-      reject();
+      reject(new Error('failed to read file'));
     });
   });

--- a/web-client/src/views/cloneFile.test.js
+++ b/web-client/src/views/cloneFile.test.js
@@ -32,24 +32,29 @@ describe('cloneFile', () => {
     jest.restoreAllMocks();
   });
 
-  it('should successfully clone a file', done => {
-    cloneFile(new File([], 'tmp.pdf')).then(clonedFile => {
-      expect(clonedFile).toBeDefined();
-      expect(readAsArrayBufferSpy).toHaveBeenCalledTimes(1);
-      expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
-      expect(addEventListenerSpy.mock.calls[0][0]).toEqual('load');
-      expect(addEventListenerSpy.mock.calls[1][0]).toEqual('error');
-      done();
-    });
+  it('should successfully clone a file', async () => {
+    const clonePromise = cloneFile(new File([], 'tmp.pdf'));
     keys.load();
+    const clonedFile = await clonePromise;
+
+    expect(clonedFile).toBeDefined();
+    expect(readAsArrayBufferSpy).toHaveBeenCalledTimes(1);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
+    expect(addEventListenerSpy.mock.calls[0][0]).toEqual('load');
+    expect(addEventListenerSpy.mock.calls[1][0]).toEqual('error');
   });
 
-  it('should fail when attempting to clone something other than a file', done => {
-    cloneFile(2).catch(() => {
-      expect(readAsArrayBufferSpy).toHaveBeenCalledTimes(1);
-      expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
-      done();
-    });
-    keys.error();
+  it('should fail when attempting to clone something other than a file', async () => {
+    let error;
+    try {
+      const clonePromise = cloneFile(2);
+      keys.error();
+      await clonePromise;
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeDefined();
+    expect(readAsArrayBufferSpy).toHaveBeenCalledTimes(1);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
We had installed a jest plugin for eslint, but it wasn't wired up.  This PR remedies that, and also addresses new complaints that arose from a few more eslint modules.

A few rules were `error` according to the `recommended` rules, but fixing them all in this PR was a bit much -- I've made some of them `warn` instead.  These rules will give us some rainy-day things to address based on lint warnings as we go along.

The complexity rule is new -- default is `20` but we have a handful of files that are far beyond that (one is 78!).  