### PR TITLE
updating eslint rules, plugins, exclusions for cypress

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable spellcheck/spell-checker */
 // re-format this file with `npx eslint --ignore-pattern '!.eslintrc.js' .eslintrc.js --fix`
 module.exports = {
   env: {
@@ -9,6 +10,7 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
+    'plugin:cypress/recommended',
     'plugin:jest/recommended',
     'plugin:prettier/recommended',
     'plugin:promise/recommended',
@@ -17,6 +19,17 @@ module.exports = {
     'prettier/react',
     'prettier/standard',
     'plugin:import/errors',
+  ],
+  overrides: [
+    {
+      files: ['cypress/**/*.js', 'cypress-smoketests/**/*.js'],
+      rules: {
+        'jest/expect-expect': 'off',
+        'jest/valid-expect': 'off',
+        'promise/always-return': 'off',
+        'promise/catch-or-return': 'off',
+      },
+    },
   ],
   parser: 'babel-eslint',
   parserOptions: {
@@ -44,9 +57,10 @@ module.exports = {
     'arrow-parens': ['error', 'as-needed'],
     complexity: ['warn', { max: 40 }], // module default is 20!
     'import/named': 1,
+    'jest/expect-expect': 1,
+    'jest/no-export': 0,
     'jest/no-identical-title': 'warn',
     'jest/no-test-callback': 'warn',
-    'jest/no-export': 0,
     'jsdoc/check-param-names': 1,
     'jsdoc/check-types': 1,
     'jsdoc/newline-after-description': 1,
@@ -155,7 +169,7 @@ module.exports = {
         identifiers: false,
         lang: 'en_US',
         minLength: 4,
-        skipIfMatch: ['^https?://[^\\s]*$', '^[^\\s]{35,}$'],
+        skipIfMatch: ['https?://[^\\s]{10,}', '^[^\\s]{35,}$'],
         skipWords: [
           'anthony',
           'args',

--- a/cypress-smoketests/plugins/index.js
+++ b/cypress-smoketests/plugins/index.js
@@ -11,6 +11,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
+// eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config

--- a/cypress/integration/assign-a-work-item-to-self.spec.js
+++ b/cypress/integration/assign-a-work-item-to-self.spec.js
@@ -30,9 +30,7 @@ describe('Assign a work item ', () => {
       .contains('td.to', 'Test Petitionsclerk')
       .should('exist');
 
-    getWorkItemRow('101-19W')
-      .contains('a', 'Petition')
-      .click();
+    getWorkItemRow('101-19W').contains('a', 'Petition').click();
     getWorkItemMessages();
 
     getWorkItemMessage('2611344f-f7bf-4f47-8ba0-60c70cb25446').contains(

--- a/cypress/integration/edit-a-trial-session.spec.js
+++ b/cypress/integration/edit-a-trial-session.spec.js
@@ -16,6 +16,7 @@ describe('Edit a trial session ', () => {
 
     getCancelButton().click();
 
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(3000);
     getCancelModalTitle().should('exist');
   });

--- a/cypress/integration/edit-case-caption-via-case-detail-header.spec.js
+++ b/cypress/integration/edit-case-caption-via-case-detail-header.spec.js
@@ -7,15 +7,13 @@ const {
   navigateTo: navigateToCaseDetail,
 } = require('../support/pages/case-detail');
 
-describe('Edit a case caption from case detail header', function() {
+describe('Edit a case caption from case detail header', function () {
   before(() => {
     cy.task('seed');
     navigateToCaseDetail('docketclerk', '101-19');
     getActionMenuButton().click();
     getEditCaseCaptionButton().click();
-    getCaptionTextArea()
-      .clear()
-      .type('there is no cow level');
+    getCaptionTextArea().clear().type('there is no cow level');
     getSaveButton().click();
   });
 

--- a/cypress/integration/file-an-answer.spec.js
+++ b/cypress/integration/file-an-answer.spec.js
@@ -2,7 +2,7 @@ const {
   navigateTo: navigateToDashboard,
 } = require('../support/pages/dashboard');
 
-describe('Filing an Answer', function() {
+describe('Filing an Answer', function () {
   before(() => {
     cy.task('seed');
     cy.login('irsPractitioner', '/case-detail/102-19');
@@ -39,15 +39,11 @@ describe('Filing an Answer', function() {
   });
 
   it('docket record table reflects newly-added record', () => {
-    cy.get('table.docket-record')
-      .find('a')
-      .should('contain', 'Answer');
+    cy.get('table.docket-record').find('a').should('contain', 'Answer');
   });
 
   it('reflects changes to 102-19 by showing it in irsPractitioner case list', () => {
     navigateToDashboard('irsPractitioner');
-    cy.get('table#case-list')
-      .find('a')
-      .should('contain', '102-19');
+    cy.get('table#case-list').find('a').should('contain', '102-19');
   });
 });

--- a/cypress/integration/petitions-clerk-creates-a-case.spec.js
+++ b/cypress/integration/petitions-clerk-creates-a-case.spec.js
@@ -17,8 +17,7 @@ describe('Create case and submit to IRS', function () {
   });
 
   it('should display parties tab when user navigates to create a case', () => {
-    const partiesTabElement = cy.get('#tab-parties');
-    partiesTabElement.should('have.attr', 'aria-selected');
+    cy.get('#tab-parties').should('have.attr', 'aria-selected');
 
     fillInCreateCaseFromPaperForm();
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -13,6 +13,7 @@
 
 const { reseedDatabase } = require('./database');
 
+// eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/cypress/support/pages/dashboard.js
+++ b/cypress/support/pages/dashboard.js
@@ -21,6 +21,7 @@ exports.viewSectionOutbox = () => {
 
 exports.viewDocumentQCMyInbox = () => {
   cy.visit('/document-qc/my/inbox');
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(1000);
 };
 

--- a/cypress/support/pages/start-a-case.js
+++ b/cypress/support/pages/start-a-case.js
@@ -10,52 +10,30 @@ exports.fillInAndSubmitForm = () => {
   //step 2
   cy.upload_file('w3-dummy.pdf', '#petition-file');
   cy.get('#irs-notice-radios').scrollIntoView();
-  cy.get('#irs-notice-radios label')
-    .first()
-    .click();
-  cy.get('#case-type')
-    .scrollIntoView()
-    .select('Notice of Deficiency');
+  cy.get('#irs-notice-radios label').first().click();
+  cy.get('#case-type').scrollIntoView().select('Notice of Deficiency');
   cy.get('button#submit-case').click();
 
   //step 3
-  cy.get('label[for="Individual petitioner"]')
-    .scrollIntoView()
-    .click();
-  cy.get('input#name')
-    .scrollIntoView()
-    .type('John');
+  cy.get('label[for="Individual petitioner"]').scrollIntoView().click();
+  cy.get('input#name').scrollIntoView().type('John');
   cy.get('input[name="contactPrimary.address1"]')
     .scrollIntoView()
     .type('111 South West St.');
-  cy.get('input[name="contactPrimary.city"]')
-    .scrollIntoView()
-    .type('Orlando');
-  cy.get('select[name="contactPrimary.state"]')
-    .scrollIntoView()
-    .select('AL');
+  cy.get('input[name="contactPrimary.city"]').scrollIntoView().type('Orlando');
+  cy.get('select[name="contactPrimary.state"]').scrollIntoView().select('AL');
   cy.get('input[name="contactPrimary.postalCode"]')
     .scrollIntoView()
     .type('12345');
-  cy.get('input#phone')
-    .scrollIntoView()
-    .type('1111111111');
+  cy.get('input#phone').scrollIntoView().type('1111111111');
   cy.get('button#submit-case').click();
 
   //step 4
   cy.get('#procedure-type-radios').scrollIntoView();
-  cy.get('#procedure-type-radios label')
-    .first()
-    .click();
-  cy.get('#preferred-trial-city')
-    .scrollIntoView()
-    .select('Mobile, Alabama');
-  cy.get('button#submit-case')
-    .scrollIntoView()
-    .click();
+  cy.get('#procedure-type-radios label').first().click();
+  cy.get('#preferred-trial-city').scrollIntoView().select('Mobile, Alabama');
+  cy.get('button#submit-case').scrollIntoView().click();
 
   // step 5
-  cy.get('button#submit-case')
-    .scrollIntoView()
-    .click();
+  cy.get('button#submit-case').scrollIntoView().click();
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-cypress": "^2.10.1",
+    "eslint-plugin-cypress": "^2.10.3",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^23.10.0",
     "eslint-plugin-jsdoc": "^25.2.0",


### PR DESCRIPTION
Ensured that jest-plugin for cypress is configured to use its recommended rule sets.
added rule exclusions for cypress files which do not actually use jest.
fixed spellcheck rule for URLs
some linting fixes for integration test files