### PR TITLE
universal obliterator cleans all the things

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,9 +4026,9 @@
       }
     },
     "@types/node": {
-      "version": "13.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+      "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -4152,21 +4152,21 @@
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.32.0.tgz",
-      "integrity": "sha512-oDWuB2q5AXsQ/mLq2N4qtWiBASWXPf7KhqXgeGH4QsyVKx+km8F6Vfqd3bspJQyhyCqxcbLO/jKJuIV3DzHZ6A==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.33.0.tgz",
+      "integrity": "sha512-qzPM2AuxtMrRq78LwyZa8Qn6gcY8obkIrBs1ehqmQADwkYzTE1Pb4y2W+U3rE/iFkSWcWHG2LS6MJfj6SmHApg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.32.0",
+        "@typescript-eslint/typescript-estree": "2.33.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.32.0.tgz",
-      "integrity": "sha512-hQpbWM/Y2iq6jB9FHYJBqa3h1R9IEGodOtajhb261cVHt9cz30AKjXM6WP7LxJdEPPlyJ9rPTZVgBUgZgiyPgw==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.33.0.tgz",
+      "integrity": "sha512-d8rY6/yUxb0+mEwTShCQF2zYQdLlqihukNfG9IUlLYz5y1CH6G/9XYbrxQLq3Z14RNvkCC6oe+OcFlyUpwUbkg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -5033,9 +5033,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.675.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.675.0.tgz",
-      "integrity": "sha512-me3AiDvgE4ABzWTz/CWBPgBMAbmf4AI2jpiCOXvrgCrwQu559VSUANeTZq5pfxGyzkHsmaAtJ7iu2Y8f8SikQA==",
+      "version": "2.676.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.676.0.tgz",
+      "integrity": "sha512-+ftolB59dL+7M6hRihhlKSDKNPfm0AJe48gtkwVJYljYubz1Y7vAwveRgBc18L9aoRXH2obFC5Ivf3r0dcfF2A==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -9048,9 +9048,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.434",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.434.tgz",
-      "integrity": "sha512-WjzGrE6appXvMyc2kH9Ide7OxsgTuRzag9sjQ5AcbOnbS9ut7P1HzOeEbJFLhr81IR7n2Hlr6qTTSGTXLIX5Pg==",
+      "version": "1.3.436",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.436.tgz",
+      "integrity": "sha512-qE378nzCj/E680nApDh8ctJ3gY8k58xIRCBbQC9S6i3OCRlwnTzTBVGXWDh37RZYgIYyFR0n6X14xlND1EkezQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -9752,18 +9752,18 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.10.0.tgz",
-      "integrity": "sha512-cHC//nesojSO1MLxVmFJR/bUaQQG7xvMHQD8YLbsQzevR41WKm8paKDUv2wMHlUy5XLZUmNcWuflOi4apS8D+Q==",
+      "version": "23.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.11.0.tgz",
+      "integrity": "sha512-qedvh6mcMgoLFHjITtG40yKOCu5Fa1GMYesDOclU30ZvtVkf+DaH0fnCn1ysOX/QMdk2SGhQvxvYLowcLaM0GA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-25.2.1.tgz",
-      "integrity": "sha512-xVf6asIk/Rp4NmX392K72002Dj8GdPW5dKWYu/tzT86H+Yi3Djeee0VF3Y94Wcj7xTH08C3hGpmtJJdtWnMiqQ==",
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-25.4.0.tgz",
+      "integrity": "sha512-FQgEALA8nmxyBORBinKJ7kM2fMcF6pXRdLgPfj0H3q5lalVAcgNxmeuLXownAGiS9Z3jU/fD2VX1gykR77qvfw==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.7.4",
@@ -9839,9 +9839,9 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
-      "integrity": "sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.0.tgz",
+      "integrity": "sha512-rqe1abd0vxMjmbPngo4NaYxTcR3Y4Hrmc/jg4T+sYz63yqlmJRknpEQfmWY+eDWPuMmix6iUIK+mv0zExjeLgA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -9853,7 +9853,6 @@
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
         "resolve": "^1.15.1",
-        "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.2",
         "xregexp": "^4.3.0"
       },
@@ -9866,12 +9865,6 @@
           "requires": {
             "esutils": "^2.0.2"
           }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         }
       }
     },
@@ -17454,9 +17447,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.7.tgz",
-      "integrity": "sha512-REFmIaSS6szaD1bye80DMbp7ePwsPNvLTR5HunsUcZ0SG0rWJQ+Pz24R4UlTKtjKBPhxo0v0tOBDYjZQQknW8Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
       "dev": true
     },
     "markdown-table": {
@@ -24634,9 +24627,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -26773,9 +26766,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.12.0.tgz",
+      "integrity": "sha512-5rxCQkP0kytf4H1T4xz1imjxaUUPMvc5aWp0rJ/VMIN7ClRiH1FwFvBt8wOeMasp/epeUnmSW6CixSIePtiLqA==",
       "dev": true
     },
     "tsscmp": {
@@ -26867,9 +26860,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "uc.micro": {
@@ -27588,6 +27581,12 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "13.13.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.6.tgz",
+          "integrity": "sha512-zqRj8ugfROCjXCNbmPBe2mmQ0fJWP9lQaN519hwunOgpHgVykme4G6FW95++dyNFDvJUk4rtExkVkL0eciu5NA==",
+          "dev": true
+        },
         "typescript": {
           "version": "2.9.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "build:jsdoc": "jsdoc -c web-client/jsdoc.conf.json",
     "build:public": "USTC_ENV=prod parcel build --no-source-maps -d dist-public web-client/src/index-public.pug -o index.html; npm run build:jsdoc",
     "clean:public": "rm -rf dist-public/",
-    "clean": "rm -rf dist/ web-client/.cache/ .dynamodb .elasticsearch",
+    "clean": "./reset-dependencies.sh CLEAN_ONLY",
     "cypress:open": "TEMP_DOCUMENTS_BUCKET_NAME=noop-temp-documents-local-us-east-1 DOCUMENTS_BUCKET_NAME=noop-documents-local-us-east-1 S3_ENDPOINT=http://localhost:9000 MASTER_DYNAMODB_ENDPOINT=http://localhost:8000  AWS_ACCESS_KEY_ID=S3RVER AWS_SECRET_ACCESS_KEY=S3RVER SLS_DEPLOYMENT_BUCKET=noop cypress open",
     "cypress:smoketests:open": "cypress open -C cypress-smoketests.json --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY,ENV=$ENV",
     "cypress:smoketests": "cypress run -C cypress-smoketests.json --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY,ENV=$ENV",

--- a/reset-dependencies.sh
+++ b/reset-dependencies.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
 
-rm -rf node_modules dist package-lock.json
-npm i
-npm upgrade --dev
-npx npm-force-resolutions
-npm prune
+CLEAN_ONLY=$1
+
+# removes ONLY artifacts from previous runs
+rm -rf \
+  ~/.serverless \
+  .cache/ \
+  .dynamodb \
+  .elasticsearch \
+  dist/ \
+  dist-public/
+
+npx jest --clearCache
+
+# if *not* CLEAN_ONLY, do this
+if [ -z "$CLEAN_ONLY" ]; then
+  # removes all modules, reinstalls
+  rm -rf \
+    node_modules \
+    package-lock.json
+
+  npm i
+  npm update
+  npx npm-force-resolutions
+  npm prune
+fi


### PR DESCRIPTION
when run as `./reset-dependencies.sh` it will perform as the original did, removing `node_modules/` and `package-lock.json` before reinstalling.  With an argument (as seen in the `clean` script in `package.json`) it will only remove artifacts from previous builds and tests.