### PR TITLE
2383: fix missing docket entry number in service emails

### DIFF
--- a/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
@@ -202,7 +202,7 @@ exports.serveCourtIssuedDocumentInteractor = async ({
 
   await applicationContext.getUseCaseHelpers().sendServedPartiesEmails({
     applicationContext,
-    caseEntity: caseToUpdate,
+    caseEntity,
     documentEntity: courtIssuedDocument,
     servedParties,
   });

--- a/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.js
+++ b/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.js
@@ -186,7 +186,7 @@ exports.fileExternalDocumentInteractor = async ({
 
         await applicationContext.getUseCaseHelpers().sendServedPartiesEmails({
           applicationContext,
-          caseEntity: caseToUpdate,
+          caseEntity,
           documentEntity,
           servedParties,
         });


### PR DESCRIPTION
These should have been using the updated case instead of the original case, so that the docket entry was present to retrieve the index number.