### PR TITLE
4657 - only scroll to the top when the page changes

### DIFF
--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -159,7 +159,7 @@ export const AppComponent = connect(
 
     useEffect(() => {
       focusMain();
-    });
+    }, [currentPage]);
 
     const CurrentPage = pages[currentPage];
     return (


### PR DESCRIPTION
We'd scroll to the top of the page whenever showModal changed... I don't think this would be a desired behavior.  @kkoskelin do you recall if this was intended or just by accident from using the generic useEffect call.