### PR TITLE
4658 correspondence button display

### DIFF
--- a/web-api/storage/fixtures/seed/103-19.json
+++ b/web-api/storage/fixtures/seed/103-19.json
@@ -688,5 +688,14 @@
     "sk": "document|f1aa4aa2-c214-424c-8870-d0049c5744d7",
     "documentId": "f1aa4aa2-c214-424c-8870-d0049c5744d7",
     "pk": "case|491b05b4-483f-4b85-8dd7-2dd4c069eb50"
+  },
+  {
+    "filingDate": "2020-05-25T15:31:03.673Z",
+    "filedBy": "Test Petitionsclerk",
+    "sk": "correspondence|f1aa4aa3-c214-424c-8870-d0049c5744d7",
+    "documentId": "f1aa4aa3-c214-424c-8870-d0049c5744d7",
+    "pk": "case|491b05b4-483f-4b85-8dd7-2dd4c069eb50",
+    "documentTitle": "Internal Memo",
+    "userId": "3805d1ab-18d0-43ec-bafb-654e83405416"
   }
 ]

--- a/web-client/pa11y/pa11y-petitionsclerk.js
+++ b/web-client/pa11y/pa11y-petitionsclerk.js
@@ -233,6 +233,16 @@ module.exports = [
   },
   {
     actions: [
+      'wait for #tab-correspondence to be visible',
+      'click element #tab-correspondence',
+      'wait for #correspondence-documents-table to be visible',
+    ],
+    notes: 'checks a11y of correspondence tab',
+    url:
+      'http://localhost:1234/mock-login?token=petitionsclerk&path=/case-detail/103-19&info=correspondence-tab',
+  },
+  {
+    actions: [
       'wait for #tab-case-information to be visible',
       'click element #tab-case-information',
       'wait for #remove-from-trial-session-btn to be visible',

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -26,7 +26,6 @@ export const caseDetailHelper = (get, applicationContext) => {
   let showCaseDeadlinesInternalEmpty = false;
   let userHasAccessToCase = false;
   let showQcWorkItemsUntouchedState = false;
-  let showAddCorrespondenceButton = false;
 
   if (isExternalUser) {
     if (userAssociatedWithCase) {
@@ -42,12 +41,6 @@ export const caseDetailHelper = (get, applicationContext) => {
   } else {
     userHasAccessToCase = true;
     showQcWorkItemsUntouchedState = true;
-
-    if (
-      [USER_ROLES.petitionsClerk, USER_ROLES.docketClerk].includes(user.role)
-    ) {
-      showAddCorrespondenceButton = true;
-    }
 
     if (caseDeadlines && caseDeadlines.length > 0) {
       showCaseDeadlinesInternal = true;
@@ -112,7 +105,7 @@ export const caseDetailHelper = (get, applicationContext) => {
       modalState &&
       modalState.respondentMatches &&
       modalState.respondentMatches.length,
-    showAddCorrespondenceButton,
+    showAddCorrespondenceButton: permissions.CASE_CORRESPONDENCE,
     showCaseDeadlinesExternal,
     showCaseDeadlinesInternal,
     showCaseDeadlinesInternalEmpty,

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -26,6 +26,7 @@ export const caseDetailHelper = (get, applicationContext) => {
   let showCaseDeadlinesInternalEmpty = false;
   let userHasAccessToCase = false;
   let showQcWorkItemsUntouchedState = false;
+  let showAddCorrespondenceButton = false;
 
   if (isExternalUser) {
     if (userAssociatedWithCase) {
@@ -41,6 +42,12 @@ export const caseDetailHelper = (get, applicationContext) => {
   } else {
     userHasAccessToCase = true;
     showQcWorkItemsUntouchedState = true;
+
+    if (
+      [USER_ROLES.petitionsClerk, USER_ROLES.docketClerk].includes(user.role)
+    ) {
+      showAddCorrespondenceButton = true;
+    }
 
     if (caseDeadlines && caseDeadlines.length > 0) {
       showCaseDeadlinesInternal = true;
@@ -105,6 +112,7 @@ export const caseDetailHelper = (get, applicationContext) => {
       modalState &&
       modalState.respondentMatches &&
       modalState.respondentMatches.length,
+    showAddCorrespondenceButton,
     showCaseDeadlinesExternal,
     showCaseDeadlinesInternal,
     showCaseDeadlinesInternalEmpty,

--- a/web-client/src/presenter/computeds/caseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.test.js
@@ -22,6 +22,48 @@ const getBaseState = user => {
 };
 
 describe('case detail computed', () => {
+  it('should set showAddCorrespondenceButton to false when the current user is not a petitions clerk or a docket clerk', () => {
+    const user = {
+      role: User.ROLES.privatePractitioner,
+      userId: '123',
+    };
+
+    const result = runCompute(caseDetailHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { privatePractitioners: [] },
+        currentPage: 'CaseDetail',
+        form: {},
+        screenMetadata: {
+          isAssociated: false,
+        },
+      },
+    });
+
+    expect(result.showAddCorrespondenceButton).toEqual(false);
+  });
+
+  it('should set showAddCorrespondenceButton to true when the current user is a petitions clerk', () => {
+    const user = {
+      role: User.ROLES.petitionsClerk,
+      userId: '123',
+    };
+
+    const result = runCompute(caseDetailHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { privatePractitioners: [] },
+        currentPage: 'CaseDetail',
+        form: {},
+        screenMetadata: {
+          isAssociated: false,
+        },
+      },
+    });
+
+    expect(result.showAddCorrespondenceButton).toEqual(true);
+  });
+
   it('should set showFileDocumentButton to true if current page is CaseDetail, user role is practitioner, and case is owned by user', () => {
     const user = {
       role: User.ROLES.privatePractitioner,

--- a/web-client/src/views/Correspondence/Correspondence.jsx
+++ b/web-client/src/views/Correspondence/Correspondence.jsx
@@ -10,11 +10,14 @@ export const Correspondence = connect(
     formattedCaseDetail: state.formattedCaseDetail,
     openConfirmDeleteCorrespondenceModalSequence:
       sequences.openConfirmDeleteCorrespondenceModalSequence,
+    showAddCorrespondenceButton:
+      state.caseDetailHelper.showAddCorrespondenceButton,
     showModal: state.modal.showModal,
   },
   function Correspondence({
     formattedCaseDetail,
     openConfirmDeleteCorrespondenceModalSequence,
+    showAddCorrespondenceButton,
     showModal,
   }) {
     return (
@@ -25,8 +28,9 @@ export const Correspondence = connect(
         )}
         {formattedCaseDetail.correspondence.length > 0 && (
           <table
-            aria-label="docket record"
-            className="usa-table case-detail docket-record responsive-table row-border-only"
+            aria-label="correspondence"
+            className="usa-table case-detail responsive-table row-border-only"
+            id="correspondence-documents-table"
           >
             <thead>
               <tr>
@@ -53,29 +57,33 @@ export const Correspondence = connect(
                     </td>
                     <td>{document.filedBy}</td>
                     <td>
-                      <Button
-                        link
-                        className="text-left padding-0 margin-left-1"
-                        href={`/case-detail/${formattedCaseDetail.docketNumber}/edit-correspondence/${document.documentId}`}
-                        icon="edit"
-                      >
-                        Edit
-                      </Button>
+                      {showAddCorrespondenceButton && (
+                        <Button
+                          link
+                          className="text-left padding-0 margin-left-1"
+                          href={`/case-detail/${formattedCaseDetail.docketNumber}/edit-correspondence/${document.documentId}`}
+                          icon="edit"
+                        >
+                          Edit
+                        </Button>
+                      )}
                     </td>
                     <td>
-                      <Button
-                        link
-                        className="red-warning padding-0 text-left margin-left-1"
-                        icon="trash"
-                        onClick={() => {
-                          openConfirmDeleteCorrespondenceModalSequence({
-                            documentId: document.documentId,
-                            documentTitle: document.documentTitle,
-                          });
-                        }}
-                      >
-                        Delete
-                      </Button>
+                      {showAddCorrespondenceButton && (
+                        <Button
+                          link
+                          className="red-warning padding-0 text-left margin-left-1"
+                          icon="trash"
+                          onClick={() => {
+                            openConfirmDeleteCorrespondenceModalSequence({
+                              documentId: document.documentId,
+                              documentTitle: document.documentTitle,
+                            });
+                          }}
+                        >
+                          Delete
+                        </Button>
+                      )}
                     </td>
                   </tr>
                 );

--- a/web-client/src/views/Correspondence/CorrespondenceHeader.jsx
+++ b/web-client/src/views/Correspondence/CorrespondenceHeader.jsx
@@ -6,8 +6,13 @@ import React from 'react';
 export const CorrespondenceHeader = connect(
   {
     formattedCaseDetail: state.formattedCaseDetail,
+    showAddCorrespondenceButton:
+      state.caseDetailHelper.showAddCorrespondenceButton,
   },
-  function CorrespondenceHeader({ formattedCaseDetail }) {
+  function CorrespondenceHeader({
+    formattedCaseDetail,
+    showAddCorrespondenceButton,
+  }) {
     return (
       <React.Fragment>
         <div className="grid-container padding-0 docket-record-header">
@@ -16,15 +21,17 @@ export const CorrespondenceHeader = connect(
               <h1>Correspondence Files</h1>
             </div>
             <div className="tablet:grid-col-2 text-right hide-on-mobile add-correspondence-file">
-              <Button
-                link
-                aria-label="printable docket record"
-                className="margin-right-0"
-                href={`/case-detail/${formattedCaseDetail.docketNumber}/upload-correspondence`}
-                icon="envelope-open"
-              >
-                Add Correspondence File
-              </Button>
+              {showAddCorrespondenceButton && (
+                <Button
+                  link
+                  aria-label="printable docket record"
+                  className="margin-right-0"
+                  href={`/case-detail/${formattedCaseDetail.docketNumber}/upload-correspondence`}
+                  icon="envelope-open"
+                >
+                  Add Correspondence File
+                </Button>
+              )}
             </div>
             <div className="only-small-screens">
               <Button


### PR DESCRIPTION
Only display add/edit/delete correspondence buttons when user is a petitions or docket clerk. 

petitionsClerk user:
![image](https://user-images.githubusercontent.com/20249233/82829991-6adf5f80-9e69-11ea-8d2f-6aeb9ce05b13.png)


armensChambers user:
![image](https://user-images.githubusercontent.com/20249233/82829944-5733f900-9e69-11ea-8f47-2ce918a0f13a.png)

Also accidentally included some DOD items: pa11y test, seed data.