### PR TITLE
4658 Correspondence endpoint bug fix

### DIFF
--- a/shared/src/business/useCases/correspondence/deleteCorrespondenceDocumentInteractor.js
+++ b/shared/src/business/useCases/correspondence/deleteCorrespondenceDocumentInteractor.js
@@ -7,7 +7,7 @@ const { UnauthorizedError } = require('../../../errors/errors');
 exports.deleteCorrespondenceDocumentInteractor = async ({
   applicationContext,
   caseId,
-  documentIdToDelete,
+  documentId,
 }) => {
   const user = applicationContext.getCurrentUser();
 
@@ -17,12 +17,12 @@ exports.deleteCorrespondenceDocumentInteractor = async ({
 
   await applicationContext.getPersistenceGateway().deleteDocument({
     applicationContext,
-    key: documentIdToDelete,
+    key: documentId,
   });
 
   await applicationContext.getPersistenceGateway().deleteCaseCorrespondence({
     applicationContext,
     caseId,
-    documentIdToDelete,
+    documentId,
   });
 };

--- a/shared/src/business/useCases/correspondence/deleteCorrespondenceDocumentInteractor.test.js
+++ b/shared/src/business/useCases/correspondence/deleteCorrespondenceDocumentInteractor.test.js
@@ -33,7 +33,7 @@ describe('deleteCorrespondenceDocumentInteractor', () => {
     await deleteCorrespondenceDocumentInteractor({
       applicationContext,
       caseId: '111',
-      documentIdToDelete: 'abc',
+      documentId: 'abc',
     });
 
     expect(
@@ -48,7 +48,7 @@ describe('deleteCorrespondenceDocumentInteractor', () => {
     await deleteCorrespondenceDocumentInteractor({
       applicationContext,
       caseId: '111',
-      documentIdToDelete: 'abc',
+      documentId: 'abc',
     });
 
     expect(
@@ -56,7 +56,7 @@ describe('deleteCorrespondenceDocumentInteractor', () => {
         .calls[0][0],
     ).toMatchObject({
       caseId: '111',
-      documentIdToDelete: 'abc',
+      documentId: 'abc',
     });
   });
 });

--- a/shared/src/persistence/dynamo/correspondence/deleteCaseCorrespondence.js
+++ b/shared/src/persistence/dynamo/correspondence/deleteCaseCorrespondence.js
@@ -12,13 +12,13 @@ const client = require('../../dynamodbClientService');
 exports.deleteCaseCorrespondence = async ({
   applicationContext,
   caseId,
-  documentIdToDelete,
+  documentId,
 }) => {
   return await client.delete({
     applicationContext,
     key: {
       pk: `case|${caseId}`,
-      sk: `correspondence|${documentIdToDelete}`,
+      sk: `correspondence|${documentId}`,
     },
   });
 };

--- a/shared/src/persistence/dynamo/correspondence/deleteCaseCorrespondence.test.js
+++ b/shared/src/persistence/dynamo/correspondence/deleteCaseCorrespondence.test.js
@@ -12,7 +12,7 @@ describe('deleteCaseCorrespondence', () => {
     await deleteCaseCorrespondence({
       applicationContext,
       caseId: '234',
-      documentIdToDelete: '123',
+      documentId: '123',
     });
 
     expect(

--- a/shared/src/persistence/dynamo/helpers/aggregateCaseItems.js
+++ b/shared/src/persistence/dynamo/helpers/aggregateCaseItems.js
@@ -21,8 +21,6 @@ exports.aggregateCaseItems = caseAndCaseItems => {
     item.sk.startsWith('correspondence|'),
   );
 
-  console.log('correspondences', correspondences);
-
   const sortedDocketRecord = sortBy(docketRecord, 'index');
   const sortedDocuments = sortBy(documents, 'createdAt');
   const sortedCorrespondences = sortBy(correspondences, 'filingDate');

--- a/shared/src/proxies/correspondence/deleteCorrespondenceDocumentProxy.js
+++ b/shared/src/proxies/correspondence/deleteCorrespondenceDocumentProxy.js
@@ -6,16 +6,16 @@ const { remove } = require('../requests');
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
  * @param {object} providers.caseId the id of the case that contains the document to delete
- * @param {string} providers.documentIdToDelete the id of the correspondence document
+ * @param {string} providers.documentId the id of the correspondence document
  * @returns {Promise<*>} the promise of the api call
  */
 exports.deleteCorrespondenceDocumentInteractor = ({
   applicationContext,
   caseId,
-  documentIdToDelete,
+  documentId,
 }) => {
   return remove({
     applicationContext,
-    endpoint: `/case-documents/${caseId}/correspondence/${documentIdToDelete}`,
+    endpoint: `/case-documents/${caseId}/correspondence/${documentId}`,
   });
 };

--- a/shared/src/proxies/correspondence/updateCorrespondenceDocumentProxy.js
+++ b/shared/src/proxies/correspondence/updateCorrespondenceDocumentProxy.js
@@ -11,15 +11,16 @@ const { put } = require('../requests');
  */
 exports.updateCorrespondenceDocumentInteractor = ({
   applicationContext,
-  documentIdToEdit,
+  documentId,
   documentMetadata,
 }) => {
   const { caseId } = documentMetadata;
+
   return put({
     applicationContext,
     body: {
       documentMetadata,
     },
-    endpoint: `/case-documents/${caseId}/correspondence/${documentIdToEdit}`,
+    endpoint: `/case-documents/${caseId}/correspondence/${documentId}`,
   });
 };

--- a/web-api/serverless-case-documents.yml
+++ b/web-api/serverless-case-documents.yml
@@ -417,7 +417,7 @@ functions:
     handler: web-api/${self:provider.dir}/caseDocumentsHandlers.updateCorrespondenceDocumentLambda
     events:
       - http:
-          path: /{caseId}/correspondence/{documentIdToEdit}
+          path: /{caseId}/correspondence/{documentId}
           method: put
           cors: ui-${self:provider.stage}.ef-cms.${opt:domain}
           authorizer:
@@ -429,7 +429,7 @@ functions:
     handler: web-api/${self:provider.dir}/caseDocumentsHandlers.deleteCorrespondenceDocumentLambda
     events:
       - http:
-          path: /{caseId}/correspondence/{documentIdToDelete}
+          path: /{caseId}/correspondence/{documentId}
           method: delete
           cors: ui-${self:provider.stage}.ef-cms.${opt:domain}
           authorizer:

--- a/web-api/src/correspondence/deleteCorrespondenceDocumentLambda.js
+++ b/web-api/src/correspondence/deleteCorrespondenceDocumentLambda.js
@@ -8,13 +8,13 @@ const { genericHandler } = require('../genericHandler');
  */
 exports.deleteCorrespondenceDocumentLambda = event =>
   genericHandler(event, async ({ applicationContext }) => {
-    const { caseId, documentIdToDelete } = event.pathParameters || {};
+    const { caseId, documentId } = event.pathParameters || {};
 
     return await applicationContext
       .getUseCases()
       .deleteCorrespondenceDocumentInteractor({
         applicationContext,
         caseId,
-        documentIdToDelete,
+        documentId,
       });
   });

--- a/web-client/src/presenter/actions/CorrespondenceDocument/deleteCorrespondenceDocumentAction.js
+++ b/web-client/src/presenter/actions/CorrespondenceDocument/deleteCorrespondenceDocumentAction.js
@@ -15,7 +15,7 @@ export const deleteCorrespondenceDocumentAction = async ({
   path,
 }) => {
   const caseId = get(state.caseDetail.caseId);
-  const documentIdToDelete = get(state.modal.correspondenceToDelete.documentId);
+  const documentId = get(state.modal.correspondenceToDelete.documentId);
 
   try {
     await applicationContext
@@ -23,7 +23,7 @@ export const deleteCorrespondenceDocumentAction = async ({
       .deleteCorrespondenceDocumentInteractor({
         applicationContext,
         caseId,
-        documentIdToDelete,
+        documentId,
       });
 
     return path.success();

--- a/web-client/src/presenter/actions/CorrespondenceDocument/submitCorrespondenceAction.js
+++ b/web-client/src/presenter/actions/CorrespondenceDocument/submitCorrespondenceAction.js
@@ -48,7 +48,7 @@ export const submitCorrespondenceAction = async ({
       .getUseCases()
       .updateCorrespondenceDocumentInteractor({
         applicationContext,
-        documentIdToEdit,
+        documentId: documentIdToEdit,
         documentMetadata,
       });
   } else {


### PR DESCRIPTION
API Gateway does not allow 2 matching URLs to have different variable names

Correct:
![image](https://user-images.githubusercontent.com/20249233/82953857-60ec5800-9f60-11ea-861a-3d4c1a18d087.png)

Incorrect:
![image (1)](https://user-images.githubusercontent.com/20249233/82953883-6cd81a00-9f60-11ea-9adb-54a8ba489dc3.png)
