### PR TITLE
reduce the build size by import fonts directly

### DIFF
--- a/web-client/src/app.jsx
+++ b/web-client/src/app.jsx
@@ -10,83 +10,82 @@ import {
   route,
   router,
 } from './router';
-import {
-  faArrowAltCircleLeft as faArrowAltCircleLeftRegular,
-  faCheckCircle as faCheckCircleRegular,
-  faClock,
-  faClone,
-  faCopy,
-  faEdit,
-  faEyeSlash,
-  faFileAlt,
-  faFilePdf as faFilePdfRegular,
-  faTimesCircle as faTimesCircleRegular,
-  faUser,
-} from '@fortawesome/free-regular-svg-icons';
-import {
-  faArrowAltCircleLeft as faArrowAltCircleLeftSolid,
-  faCalculator,
-  faCalendarAlt,
-  faCalendarCheck,
-  faCalendarPlus,
-  faCaretDown,
-  faCaretLeft,
-  faCaretRight,
-  faCaretUp,
-  faCheck,
-  faCheckCircle,
-  faClipboardList,
-  faClock as faClockSolid,
-  faCloudDownloadAlt,
-  faCloudUploadAlt,
-  faCopy as faCopySolid,
-  faDollarSign,
-  faEdit as faEditSolid,
-  faEnvelopeOpen,
-  faEnvelope as faEnvelopeSolid,
-  faExclamation,
-  faExclamationCircle,
-  faExclamationTriangle,
-  faFile,
-  faFileAlt as faFileAltSolid,
-  faFilePdf,
-  faFingerprint,
-  faFlag,
-  faGavel,
-  faHandPaper,
-  faHome,
-  faInfoCircle,
-  faLaptop,
-  faLink,
-  faListUl,
-  faLock,
-  faMinus,
-  faMinusCircle,
-  faPaperPlane,
-  faPaperclip,
-  faPencilAlt,
-  faPlus,
-  faPlusCircle,
-  faPrint,
-  faQuestionCircle,
-  faRedoAlt,
-  faSearch,
-  faShareSquare,
-  faShieldAlt,
-  faSignOutAlt,
-  faSlash,
-  faSort,
-  faSpinner,
-  faStar,
-  faStepBackward,
-  faStepForward,
-  faStickyNote,
-  faSync,
-  faThumbtack,
-  faTimesCircle,
-  faTrash,
-  faUserCheck,
-} from '@fortawesome/free-solid-svg-icons';
+
+import { faArrowAltCircleLeft as faArrowAltCircleLeftRegular } from '@fortawesome/free-regular-svg-icons/faArrowAltCircleLeft';
+import { faCheckCircle as faCheckCircleRegular } from '@fortawesome/free-regular-svg-icons/faCheckCircle';
+import { faClock } from '@fortawesome/free-regular-svg-icons/faClock';
+import { faClone } from '@fortawesome/free-regular-svg-icons/faClone';
+import { faCopy } from '@fortawesome/free-regular-svg-icons/faCopy';
+import { faEdit } from '@fortawesome/free-regular-svg-icons/faEdit';
+import { faEyeSlash } from '@fortawesome/free-regular-svg-icons/faEyeSlash';
+import { faFileAlt } from '@fortawesome/free-regular-svg-icons/faFileAlt';
+import { faFilePdf as faFilePdfRegular } from '@fortawesome/free-regular-svg-icons/faFilePdf';
+import { faTimesCircle as faTimesCircleRegular } from '@fortawesome/free-regular-svg-icons/faTimesCircle';
+import { faUser } from '@fortawesome/free-regular-svg-icons/faUser';
+
+import { faArrowAltCircleLeft as faArrowAltCircleLeftSolid } from '@fortawesome/free-solid-svg-icons/faArrowAltCircleLeft';
+import { faCalculator } from '@fortawesome/free-solid-svg-icons/faCalculator';
+import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons/faCalendarAlt';
+import { faCalendarCheck } from '@fortawesome/free-solid-svg-icons/faCalendarCheck';
+import { faCalendarPlus } from '@fortawesome/free-solid-svg-icons/faCalendarPlus';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
+import { faCaretLeft } from '@fortawesome/free-solid-svg-icons/faCaretLeft';
+import { faCaretRight } from '@fortawesome/free-solid-svg-icons/faCaretRight';
+import { faCaretUp } from '@fortawesome/free-solid-svg-icons/faCaretUp';
+import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
+import { faClipboardList } from '@fortawesome/free-solid-svg-icons/faClipboardList';
+import { faClock as faClockSolid } from '@fortawesome/free-solid-svg-icons/faClock';
+import { faCloudDownloadAlt } from '@fortawesome/free-solid-svg-icons/faCloudDownloadAlt';
+import { faCloudUploadAlt } from '@fortawesome/free-solid-svg-icons/faCloudUploadAlt';
+import { faCopy as faCopySolid } from '@fortawesome/free-solid-svg-icons/faCopy';
+import { faDollarSign } from '@fortawesome/free-solid-svg-icons/faDollarSign';
+import { faEdit as faEditSolid } from '@fortawesome/free-solid-svg-icons/faEdit';
+import { faEnvelopeOpen } from '@fortawesome/free-solid-svg-icons/faEnvelopeOpen';
+import { faEnvelope as faEnvelopeSolid } from '@fortawesome/free-solid-svg-icons/faEnvelope';
+import { faExclamation } from '@fortawesome/free-solid-svg-icons/faExclamation';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
+import { faFile } from '@fortawesome/free-solid-svg-icons/faFile';
+import { faFileAlt as faFileAltSolid } from '@fortawesome/free-solid-svg-icons/faFileAlt';
+import { faFilePdf } from '@fortawesome/free-solid-svg-icons/faFilePdf';
+import { faFingerprint } from '@fortawesome/free-solid-svg-icons/faFingerprint';
+import { faFlag } from '@fortawesome/free-solid-svg-icons/faFlag';
+import { faGavel } from '@fortawesome/free-solid-svg-icons/faGavel';
+import { faHandPaper } from '@fortawesome/free-solid-svg-icons/faHandPaper';
+import { faHome } from '@fortawesome/free-solid-svg-icons/faHome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
+import { faLaptop } from '@fortawesome/free-solid-svg-icons/faLaptop';
+import { faLink } from '@fortawesome/free-solid-svg-icons/faLink';
+import { faListUl } from '@fortawesome/free-solid-svg-icons/faListUl';
+import { faLock } from '@fortawesome/free-solid-svg-icons/faLock';
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
+import { faMinusCircle } from '@fortawesome/free-solid-svg-icons/faMinusCircle';
+import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
+import { faPaperclip } from '@fortawesome/free-solid-svg-icons/faPaperclip';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons/faPencilAlt';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faPlusCircle } from '@fortawesome/free-solid-svg-icons/faPlusCircle';
+import { faPrint } from '@fortawesome/free-solid-svg-icons/faPrint';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
+import { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt';
+import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
+import { faShareSquare } from '@fortawesome/free-solid-svg-icons/faShareSquare';
+import { faShieldAlt } from '@fortawesome/free-solid-svg-icons/faShieldAlt';
+import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
+import { faSlash } from '@fortawesome/free-solid-svg-icons/faSlash';
+import { faSort } from '@fortawesome/free-solid-svg-icons/faSort';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner';
+import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
+import { faStepBackward } from '@fortawesome/free-solid-svg-icons/faStepBackward';
+import { faStepForward } from '@fortawesome/free-solid-svg-icons/faStepForward';
+import { faStickyNote } from '@fortawesome/free-solid-svg-icons/faStickyNote';
+import { faSync } from '@fortawesome/free-solid-svg-icons/faSync';
+import { faThumbtack } from '@fortawesome/free-solid-svg-icons/faThumbtack';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
+import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
+import { faUserCheck } from '@fortawesome/free-solid-svg-icons/faUserCheck';
+
 import { isFunction, mapValues } from 'lodash';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { presenter } from './presenter/presenter';


### PR DESCRIPTION
This change allows parcel tree shaking to work correctly and reduces the number of font awesome icons we actually bundle into our .dist.js file:

Went from:
- 6.06MB down to 5.35MB (uncompressed)
- 1.39MB down to 1.16MB (compressed)

<img width="998" alt="Screen Shot 2020-05-29 at 3 53 54 PM" src="https://user-images.githubusercontent.com/1868782/83299989-2b947400-a1c5-11ea-9c85-d2e7d7ebf11c.png">

<img width="936" alt="Screen Shot 2020-05-29 at 3 54 02 PM" src="https://user-images.githubusercontent.com/1868782/83299994-2d5e3780-a1c5-11ea-8ea5-7a210e8ae0ea.png">
