### PR TITLE
lazy load quill

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "watch": "nodemon -e yml --exec sls offline start"
   },
   "staticFiles": {
-    "staticPath": "node_modules/pdfjs-dist/build",
+    "staticPath": ["node_modules/pdfjs-dist/build", "node_modules/react-quill/dist"],
     "watcherGlob": false
   },
   "resolutions": {


### PR DESCRIPTION
lazy load quill 1.16MB down to 1.11MB (compressed) 

I'm not sure if this was worth the refactor to save 0.05MB, but it was a small enough refactor to lazy load quill I guess?  Thoughts?

<img width="958" alt="Screen Shot 2020-05-29 at 5 06 54 PM" src="https://user-images.githubusercontent.com/1868782/83305468-ce052500-a1ce-11ea-83b6-93dff7dd124c.png">
