### PR TITLE
DevEx - setting the default ttl

### DIFF
--- a/web-client/terraform/common/variables.tf
+++ b/web-client/terraform/common/variables.tf
@@ -8,10 +8,10 @@ variable "dns_domain" {
 
 variable "cloudfront_max_ttl" {
   type = "string"
-  default = "86400"
+  default = "31536000"
 }
 
 variable "cloudfront_default_ttl" {
   type = "string"
-  default = "31536000"
+  default = "86400"
 }

--- a/web-client/terraform/main/variables.tf
+++ b/web-client/terraform/main/variables.tf
@@ -13,12 +13,12 @@ variable "dns_domain" {
 
 variable "cloudfront_default_ttl" {
   type = "string"
-  default = "0"
+  default = "86400"
 }
 
 variable "cloudfront_max_ttl" {
   type = "string"
-  default = "0"
+  default = "31536000"
 }
 
 variable "dynamsoft_s3_zip_path" {


### PR DESCRIPTION
cloudfront's ttl was set at 0 which means nothing would ever be cached.  This pr sets it back to the default of 1 day.