### PR TITLE
5224: fix service emails for non-petition docs

### DIFF
--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
@@ -78,6 +78,8 @@ exports.serveCaseToIrsInteractor = async ({ applicationContext, caseId }) => {
 
   const caseEntity = new Case(caseToBatch, { applicationContext });
 
+  caseEntity.markAsSentToIRS();
+
   for (const initialDocumentTypeKey of Object.keys(
     Document.INITIAL_DOCUMENT_TYPES,
   )) {
@@ -137,8 +139,6 @@ exports.serveCaseToIrsInteractor = async ({ applicationContext, caseId }) => {
   // caseEntity.documents = caseEntity.documents.filter(
   //   item => item.documentId !== deletedStinDocumentId,
   // );
-
-  caseEntity.markAsSentToIRS();
 
   const petitionDocument = caseEntity.documents.find(
     document =>


### PR DESCRIPTION
The email service helper was checking the case status to determine whether to send the email to the IRS superuser, but it was not being marked as General Docket until after the helper was called. 