### PR TITLE
DevEx: UserCase mapping record migration

### DIFF
--- a/shared/src/business/entities/UserCase.js
+++ b/shared/src/business/entities/UserCase.js
@@ -14,6 +14,7 @@ UserCase.validationName = 'UserCase';
  * @constructor
  */
 function UserCase(rawUserCase) {
+  this.entityName = 'UserCase';
   this.caseId = rawUserCase.caseId;
   this.caseCaption = rawUserCase.caseCaption;
   this.createdAt = rawUserCase.createdAt;

--- a/shared/src/test/mockCase.js
+++ b/shared/src/test/mockCase.js
@@ -16,6 +16,7 @@ exports.MOCK_CASE = {
     title: 'Executor',
   },
   correspondence: [],
+  createdAt: '2018-03-01T21:40:46.415Z',
   docketNumber: '101-18',
   docketNumberWithSuffix: '101-18',
   docketRecord: [

--- a/web-api/migrations/00002-user-case-mapping.js
+++ b/web-api/migrations/00002-user-case-mapping.js
@@ -33,6 +33,7 @@ const mutateRecord = async (item, documentClient, tableName) => {
       return {
         ...item,
         ...userCaseEntity,
+        entityName: 'UserCase',
         gsi1pk: `user-case|${caseId}`,
       };
     }

--- a/web-api/migrations/00002-user-case-mapping.js
+++ b/web-api/migrations/00002-user-case-mapping.js
@@ -1,15 +1,17 @@
 const createApplicationContext = require('../src/applicationContext');
+const {
+  isNewUserCaseMappingRecord,
+  isUserCaseMappingRecord,
+  upGenerator,
+} = require('./utilities');
 const { Case } = require('../../shared/src/business/entities/cases/Case');
-const { isUserCaseMappingRecord, upGenerator } = require('./utilities');
 const { UserCase } = require('../../shared/src/business/entities/UserCase');
 const applicationContext = createApplicationContext({});
 
 const mutateRecord = async (item, documentClient, tableName) => {
   const caseId = item.sk.split('|')[1];
-  const shouldMigrate = item =>
-    !item.gsi1pk || !item.gsi1pk.startsWith('user-case|'); // indicates `user-case|` on gsi1pk
 
-  if (isUserCaseMappingRecord(item) && shouldMigrate(item)) {
+  if (isUserCaseMappingRecord(item) && !isNewUserCaseMappingRecord(item)) {
     const mappedCase = await documentClient
       .get({
         Key: {

--- a/web-api/migrations/00002-user-case-mapping.js
+++ b/web-api/migrations/00002-user-case-mapping.js
@@ -1,0 +1,40 @@
+const createApplicationContext = require('../src/applicationContext');
+const { Case } = require('../../shared/src/business/entities/cases/Case');
+const { isUserCaseMappingRecord, upGenerator } = require('./utilities');
+const { UserCase } = require('../../shared/src/business/entities/UserCase');
+const applicationContext = createApplicationContext({});
+
+const mutateRecord = async (item, documentClient, tableName) => {
+  const caseId = item.sk.split('|')[1];
+  const shouldMigrate = item =>
+    !item.gsi1pk || !item.gsi1pk.startsWith('user-case|'); // indicates `user-case|` on gsi1pk
+
+  if (isUserCaseMappingRecord(item) && shouldMigrate(item)) {
+    const mappedCase = await documentClient
+      .get({
+        Key: {
+          pk: `case|${caseId}`,
+          sk: `case|${caseId}`,
+        },
+        TableName: tableName,
+      })
+      .promise();
+
+    if (mappedCase.Item) {
+      const caseEntity = new Case(mappedCase.Item, { applicationContext });
+      const userCaseEntity = new UserCase(caseEntity.validate().toRawObject(), {
+        applicationContext,
+      })
+        .validate()
+        .toRawObject();
+
+      return {
+        ...item,
+        ...userCaseEntity,
+        gsi1pk: `user-case|${caseId}`,
+      };
+    }
+  }
+};
+
+module.exports = { mutateRecord, up: upGenerator(mutateRecord) };

--- a/web-api/migrations/00002-user-case-mapping.test.js
+++ b/web-api/migrations/00002-user-case-mapping.test.js
@@ -1,0 +1,85 @@
+const { forAllRecords } = require('./utilities');
+const { MOCK_CASE } = require('../../shared/src/test/mockCase');
+const { up } = require('./00002-user-case-mapping');
+const { UserCase } = require('../../shared/src/business/entities/UserCase');
+
+describe('user case mapping migration', () => {
+  let documentClient;
+  let scanStub;
+  let putStub;
+  let getStub;
+
+  const mockUserCaseItem = {
+    pk: 'user|6805d1ab-18d0-43ec-bafb-654e83405416',
+    sk: `case|${MOCK_CASE.caseId}`,
+  };
+
+  const mockUserCaseEntity = new UserCase(MOCK_CASE).validate().toRawObject();
+
+  const mockNewUserCaseItem = {
+    gsi1pk: `user-case|${MOCK_CASE.caseId}`,
+    pk: 'user|6805d1ab-18d0-43ec-bafb-654e83405416',
+    sk: `case|${MOCK_CASE.caseId}`,
+    ...mockUserCaseEntity,
+  };
+
+  const mockCaseWithKeys = {
+    ...MOCK_CASE,
+    pk: `case|${MOCK_CASE.caseId}`,
+    sk: `case|${MOCK_CASE.caseId}`,
+  };
+
+  beforeEach(() => {
+    scanStub = jest.fn().mockReturnValue({
+      promise: async () => ({
+        Items: [mockUserCaseItem],
+      }),
+    });
+
+    putStub = jest.fn().mockReturnValue({
+      promise: async () => ({}),
+    });
+
+    getStub = jest.fn().mockReturnValue({
+      promise: async () => ({
+        Item: mockCaseWithKeys,
+      }),
+    });
+
+    documentClient = {
+      get: getStub,
+      put: putStub,
+      scan: scanStub,
+    };
+  });
+
+  it('should not update the item when it is not a user-case record', async () => {
+    documentClient.scan = jest.fn().mockReturnValue({
+      promise: async () => ({
+        Items: [mockCaseWithKeys],
+      }),
+    });
+
+    await up(documentClient, '', forAllRecords);
+
+    expect(putStub).not.toHaveBeenCalled();
+  });
+
+  it('should not update the item when its a new user-case record', async () => {
+    documentClient.scan = jest.fn().mockReturnValue({
+      promise: async () => ({
+        Items: [mockNewUserCaseItem],
+      }),
+    });
+
+    await up(documentClient, '', forAllRecords);
+
+    expect(putStub).not.toHaveBeenCalled();
+  });
+
+  it('should update the item', async () => {
+    await up(documentClient, '', forAllRecords);
+
+    expect(putStub.mock.calls.length).toBe(1);
+  });
+});

--- a/web-api/migrations/utilities.js
+++ b/web-api/migrations/utilities.js
@@ -1,6 +1,8 @@
 const isCaseRecord = item => !!item.caseType;
 const isTrialSessionRecord = item =>
   !!item.caseOrder && !!item.trialSessionId && !!item.maxCases;
+const isUserCaseMappingRecord = item =>
+  item.pk.startsWith('user|') && item.sk.startsWith('case|');
 
 const forAllRecords = async (documentClient, tableName, cb) => {
   let hasMoreResults = true;
@@ -49,5 +51,6 @@ module.exports = {
   forAllRecords,
   isCaseRecord,
   isTrialSessionRecord,
+  isUserCaseMappingRecord,
   upGenerator,
 };

--- a/web-api/migrations/utilities.js
+++ b/web-api/migrations/utilities.js
@@ -3,6 +3,8 @@ const isTrialSessionRecord = item =>
   !!item.caseOrder && !!item.trialSessionId && !!item.maxCases;
 const isUserCaseMappingRecord = item =>
   item.pk.startsWith('user|') && item.sk.startsWith('case|');
+const isNewUserCaseMappingRecord = item =>
+  !!item.gsi1pk && item.gsi1pk.startsWith('user-case|');
 
 const forAllRecords = async (documentClient, tableName, cb) => {
   let hasMoreResults = true;
@@ -50,6 +52,7 @@ const upGenerator = mutateFunction => async (
 module.exports = {
   forAllRecords,
   isCaseRecord,
+  isNewUserCaseMappingRecord,
   isTrialSessionRecord,
   isUserCaseMappingRecord,
   upGenerator,

--- a/web-api/migrations/utilities.test.js
+++ b/web-api/migrations/utilities.test.js
@@ -2,6 +2,7 @@ const {
   forAllRecords,
   isCaseRecord,
   isTrialSessionRecord,
+  isUserCaseMappingRecord,
   upGenerator,
 } = require('./utilities');
 const { Case } = require('../../shared/src/business/entities/cases/Case');
@@ -41,6 +42,34 @@ describe('utilities', () => {
         caseType: Case.CASE_TYPES_MAP.cdp,
       });
 
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('isUserCaseMappingRecord', () => {
+    it('should return true if the item is a user case mapping record', () => {
+      const result = isUserCaseMappingRecord({
+        pk: 'user|',
+        sk: 'case|',
+      });
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if the item is not a user case mapping record (pk,sk = case|)', () => {
+      const result = isUserCaseMappingRecord({
+        pk: 'case|',
+        sk: 'case|',
+      });
+
+      expect(result).toEqual(false);
+    });
+
+    it('should return false if the item is not a user case mapping record (pk,sk = user|)', () => {
+      const result = isUserCaseMappingRecord({
+        pk: 'user|',
+        sk: 'user|',
+      });
       expect(result).toEqual(false);
     });
   });

--- a/web-api/migrations/utilities.test.js
+++ b/web-api/migrations/utilities.test.js
@@ -1,6 +1,7 @@
 const {
   forAllRecords,
   isCaseRecord,
+  isNewUserCaseMappingRecord,
   isTrialSessionRecord,
   isUserCaseMappingRecord,
   upGenerator,
@@ -70,6 +71,30 @@ describe('utilities', () => {
         pk: 'user|',
         sk: 'user|',
       });
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('isNewUserCaseMappingRecord', () => {
+    it('should return true if the record is a new user-case mapping record', () => {
+      const result = isNewUserCaseMappingRecord({
+        gsi1pk: 'user-case|',
+      });
+
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if the record is not a new user-case mapping record', () => {
+      const result = isNewUserCaseMappingRecord({
+        gsi1pk: 'case|',
+      });
+
+      expect(result).toEqual(false);
+    });
+
+    it('should return false if the record is not a new user-case mapping record (no gsi1pk)', () => {
+      const result = isNewUserCaseMappingRecord({});
+
       expect(result).toEqual(false);
     });
   });

--- a/web-api/storage/fixtures/seed/101-19.json
+++ b/web-api/storage/fixtures/seed/101-19.json
@@ -73,7 +73,8 @@
     "caseCaption": "Brett Osborne, Petitioner",
     "docketNumber": "101-19",
     "docketNumberWithSuffix": "101-19W",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|2fa6da8d-4328-4a20-a5d7-b76637e1dc02",

--- a/web-api/storage/fixtures/seed/102-19.json
+++ b/web-api/storage/fixtures/seed/102-19.json
@@ -92,7 +92,8 @@
     "docketNumber": "102-19",
     "status": "New",
     "createdAt": "2019-03-01T21:40:46.415Z",
-    "caseCaption": "Selma Horn & Cairo Harris, Petitioners"
+    "caseCaption": "Selma Horn & Cairo Harris, Petitioners",
+    "entityName": "UserCase"
   },
   {
     "docketNumberWithSuffix": "102-19P",

--- a/web-api/storage/fixtures/seed/102-20.json
+++ b/web-api/storage/fixtures/seed/102-20.json
@@ -54,7 +54,8 @@
     "caseCaption": "Eve Brewer, Petitioner",
     "docketNumber": "102-20",
     "docketNumberWithSuffix": "102-20S",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|c862926c-119f-49d5-8cc3-6e93ab703fa3",
@@ -74,7 +75,8 @@
     "caseCaption": "Eve Brewer, Petitioner",
     "docketNumber": "102-20",
     "docketNumberWithSuffix": "102-20S",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "docketNumberWithSuffix": "102-20S",
@@ -205,7 +207,8 @@
     "caseCaption": "Eve Brewer, Petitioner",
     "docketNumber": "102-20",
     "docketNumberWithSuffix": "102-20S",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "role": "irsPractitioner",

--- a/web-api/storage/fixtures/seed/103-19.json
+++ b/web-api/storage/fixtures/seed/103-19.json
@@ -93,7 +93,8 @@
     "caseCaption": "Samson Workman, Petitioner",
     "docketNumber": "102-20",
     "docketNumberWithSuffix": "103-19S",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|491b05b4-483f-4b85-8dd7-2dd4c069eb50",
@@ -108,7 +109,8 @@
     "caseCaption": "Samson Workman, Petitioner",
     "docketNumber": "102-20",
     "docketNumberWithSuffix": "103-19S",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "sk": "work-item|9055257a-0a95-4b80-a728-5bb754c60e59",

--- a/web-api/storage/fixtures/seed/103-20.json
+++ b/web-api/storage/fixtures/seed/103-20.json
@@ -235,7 +235,8 @@
     "createdAt": "2020-01-23T21:45:34.520Z",
     "docketNumber": "103-20",
     "docketNumberWithSuffix": "103-20L",
-    "status": "Calendared"
+    "status": "Calendared",
+    "entityName": "UserCase"
   },
   {
     "associatedJudge": "Judge Armen",

--- a/web-api/storage/fixtures/seed/104-19.json
+++ b/web-api/storage/fixtures/seed/104-19.json
@@ -97,7 +97,8 @@
     "createdAt": "2019-03-05T17:34:13.490Z",
     "docketNumber": "104-19",
     "docketNumberWithSuffix": "104-19L",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|5f6e8b8e-4fac-4fd7-bf3c-42f0d7c3ca05",

--- a/web-api/storage/fixtures/seed/105-19.json
+++ b/web-api/storage/fixtures/seed/105-19.json
@@ -75,7 +75,8 @@
     "createdAt": "2019-03-27T21:53:00.297Z",
     "docketNumber": "105-19",
     "docketNumberWithSuffix": "105-19",
-    "status": "New"
+    "status": "New",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|6f3d97f8-1bdd-4779-a150-c076d08ad8fd",

--- a/web-api/storage/fixtures/seed/105-20.json
+++ b/web-api/storage/fixtures/seed/105-20.json
@@ -580,7 +580,8 @@
     "createdAt": "2020-04-29T15:50:41.686Z",
     "docketNumber": "105-20",
     "docketNumberWithSuffix": "105-19L",
-    "status": "General Docket - Not at Issue"
+    "status": "General Docket - Not at Issue",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|28caad58-df69-4a4d-af15-6554aee7fbd6",
@@ -595,7 +596,8 @@
     "createdAt": "2020-04-29T15:50:41.686Z",
     "docketNumber": "105-20",
     "docketNumberWithSuffix": "105-19L",
-    "status": "General Docket - Not at Issue"
+    "status": "General Docket - Not at Issue",
+    "entityName": "UserCase"
   },
   {
     "associatedJudge": "Chief Judge",

--- a/web-api/storage/fixtures/seed/106-19.json
+++ b/web-api/storage/fixtures/seed/106-19.json
@@ -589,7 +589,8 @@
     "caseId": "d3d92ca6-d9b3-4bd6-8328-e94a9fc36f88",
     "status": "New",
     "docketNumber": "106-19",
-    "docketNumberWithSuffix": "106-19"
+    "docketNumberWithSuffix": "106-19",
+    "entityName": "UserCase"
   },
   {
     "docketNumberSuffix": null,

--- a/web-api/storage/fixtures/seed/107-19.json
+++ b/web-api/storage/fixtures/seed/107-19.json
@@ -29,7 +29,8 @@
     "caseId": "58c1f7a3-8062-42f0-a73e-8bd69b419878",
     "docketNumber": "107-19",
     "docketNumberWithSuffix": "107-19L",
-    "status": "General Docket - At Issue (Ready for Trial)"
+    "status": "General Docket - At Issue (Ready for Trial)",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|58c1f7a3-8062-42f0-a73e-8bd69b419878",
@@ -40,7 +41,8 @@
     "caseId": "58c1f7a3-8062-42f0-a73e-8bd69b419878",
     "docketNumber": "107-19",
     "docketNumberWithSuffix": "107-19L",
-    "status": "General Docket - At Issue (Ready for Trial)"
+    "status": "General Docket - At Issue (Ready for Trial)",
+    "entityName": "UserCase"
   },
   {
     "completedAt": "2019-08-16T17:30:10.526Z",
@@ -272,7 +274,8 @@
     "caseId": "58c1f7a3-8062-42f0-a73e-8bd69b419878",
     "docketNumber": "107-19",
     "docketNumberWithSuffix": "107-19L",
-    "status": "General Docket - At Issue (Ready for Trial)"
+    "status": "General Docket - At Issue (Ready for Trial)",
+    "entityName": "UserCase"
   },
   {
     "sk": "case|58c1f7a3-8062-42f0-a73e-8bd69b419878",

--- a/web-api/storage/fixtures/seed/108-19.json
+++ b/web-api/storage/fixtures/seed/108-19.json
@@ -229,7 +229,8 @@
     "caseId": "46c4064f-b44a-4ac3-9dfb-9ce9f00e43f5",
     "docketNumber": "108-19",
     "docketNumberWithSuffix": "108-19",
-    "status": "Calendared"
+    "status": "Calendared",
+    "entityName": "UserCase"
   },
   {
     "sk": "work-item|ba1c4ce7-6def-4eb8-9ac7-be844ba3a380",

--- a/web-api/storage/fixtures/seed/111-19.json
+++ b/web-api/storage/fixtures/seed/111-19.json
@@ -81,7 +81,8 @@
     "leadCaseId": "fd8d1139-5e54-4117-9b94-7a69359423c2",
     "docketNumber": "111-19",
     "docketNumberWithSuffix": "111-19L",
-    "status": "Submitted"
+    "status": "Submitted",
+    "entityName": "UserCase"
   },
   {
     "documentType": "Statement of Taxpayer Identification",

--- a/web-api/storage/fixtures/seed/112-19.json
+++ b/web-api/storage/fixtures/seed/112-19.json
@@ -82,7 +82,8 @@
     "leadCaseId": "fd8d1139-5e54-4117-9b94-7a69359423c2",
     "docketNumber": "112-19",
     "docketNumberWithSuffix": "112-19L",
-    "status": "Submitted"
+    "status": "Submitted",
+    "entityName": "UserCase"
   },
   {
     "documentType": "Statement of Taxpayer Identification",

--- a/web-api/storage/fixtures/seed/113-19.json
+++ b/web-api/storage/fixtures/seed/113-19.json
@@ -82,7 +82,8 @@
     "leadCaseId": "fd8d1139-5e54-4117-9b94-7a69359423c2",
     "docketNumber": "113-19",
     "docketNumberWithSuffix": "113-19L",
-    "status": "Submitted"
+    "status": "Submitted",
+    "entityName": "UserCase"
   },
   {
     "documentType": "Statement of Taxpayer Identification",


### PR DESCRIPTION
migrates user-case mapping records from:

```
{
  pk: 'user|abc-def-123',
  sk: 'case|abc-def-321'
}
```

to:
```
{
  pk: 'user|abc-def-123',
  sk: 'case|abc-def-321',
  gsi1pk: 'user-case|abc-def-321',
  caseId: 'abc-def-321',
  leadCaseId: ...,
  caseCaption: '...',
  docketNumber: '101-20',
  status: 'Submitted',
  docketNumberWithSuffix: '101-20W',
  createdAt: '...' // timestamp
}
```

* note: i thought the case entity validation would fail since it's not passing a populated docketRecord (due to us splitting the case entity a while back in dynamodb); however, i remember us removing that "docketRecord must have at least one item" restriction and it didn't fail when running locally. maybe i'm wrong?