### PR TITLE
DevEx 564: puppeteer/chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 COPY package.json /home/app/package.json
 COPY package-lock.json /home/app/package-lock.json
 RUN npm set progress=false && \
+  npm i puppeteer --unsafe-perm=true --allow-root && \
+  npm config set puppeteer_skip_chromium_download true && \
   npm i
 
 COPY . /home/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM cypress/base:12.16.0
-
-RUN echo "recache again"
+FROM cypress/base:12.16.2
 
 WORKDIR /home/app
 
@@ -46,8 +44,6 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 COPY package.json /home/app/package.json
 COPY package-lock.json /home/app/package-lock.json
 RUN npm set progress=false && \
-  npm i puppeteer --unsafe-perm=true --allow-root && \
-  npm config set puppeteer_skip_chromium_download true && \
   npm i
 
 COPY . /home/app


### PR DESCRIPTION
updated base image

edit: potential solution for stacktrace:
```
ERROR: Failed to download Chromium r686378! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download.
Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:205:27)
  -- ASYNC --
    at BrowserFetcher.<anonymous> (/home/app/node_modules/puppeteer/lib/helper.js:111:15)
    at Object.<anonymous> (/home/app/node_modules/puppeteer/install.js:64:16)
    at Module._compile (internal/modules/cjs/loader.js:1157:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1177:10)
    at Module.load (internal/modules/cjs/loader.js:1001:32)
    at Function.Module._load (internal/modules/cjs/loader.js:900:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47 {
  errno: 'ECONNRESET',
  code: 'ECONNRESET',
  syscall: 'read'
}```