### PR TITLE
add header object to public state

### DIFF
--- a/web-client/src/presenter/state-public.js
+++ b/web-client/src/presenter/state-public.js
@@ -28,6 +28,12 @@ export const state = {
     showUsaBannerDetails: false,
   },
   currentPage: 'Interstitial',
+  header: {
+    searchTerm: '',
+    showBetaBar: true,
+    showMobileMenu: false,
+    showUsaBannerDetails: false,
+  },
   isPublic: true,
   progressIndicator: {
     // used for the spinner that shows when waiting for network responses

--- a/web-client/src/views/UsaBanner.jsx
+++ b/web-client/src/views/UsaBanner.jsx
@@ -34,7 +34,7 @@ export const UsaBanner = connect(
               </div>
               <button
                 aria-controls="gov-banner"
-                aria-expanded={showUsaBannerDetails}
+                aria-expanded={!!showUsaBannerDetails}
                 className="usa-accordion__button usa-banner__button"
                 onClick={() => toggleUsaBannerDetailsSequence()}
               >


### PR DESCRIPTION
coerce boolean from state, too.

CSS rule was dependent upon [aria-expanded=false] but when item was not found in state, resulted in 'undefined' rather than 'false'.
![Screen Shot 2020-06-12 at 10 55 40 AM](https://user-images.githubusercontent.com/2445917/84522145-bb452280-ac9b-11ea-8903-eca0c00a0723.png)

https://trello.com/c/FdJQqQqs/519-display-bug-in-public-header
