### PR TITLE
Cancel Review Petition Bug

### DIFF
--- a/cypress/integration/petitions-clerk-creates-a-case.spec.js
+++ b/cypress/integration/petitions-clerk-creates-a-case.spec.js
@@ -27,4 +27,9 @@ describe('Create case and submit to IRS', function () {
       expect(xhr.responseBody).to.have.property('docketNumber');
     });
   });
+
+  it('should display a confirmation modal when the user clicks cancel on the review page', () => {
+    cy.get('button#cancel-create-case').scrollIntoView().click();
+    cy.get('div.modal-header').should('exist');
+  });
 });

--- a/web-client/src/views/CaseDetailEdit/ReviewSavedPetition.jsx
+++ b/web-client/src/views/CaseDetailEdit/ReviewSavedPetition.jsx
@@ -4,6 +4,7 @@ import { CaseDetailHeader } from '../CaseDetail/CaseDetailHeader';
 import { ConfirmModal } from '../../ustc-ui/Modal/ConfirmModal';
 import { Focus } from '../../ustc-ui/Focus/Focus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { FormCancelModalDialog } from '../FormCancelModalDialog';
 import { OrdersNeededSummary } from '../StartCaseInternal/OrdersNeededSummary';
 import { PDFPreviewButton } from '../PDFPreviewButton';
 import { connect } from '@cerebral/react';
@@ -379,6 +380,7 @@ export const ReviewSavedPetition = connect(
             </Button>
             <Button
               link
+              id="cancel-create-case"
               onClick={() => {
                 formCancelToggleCancelSequence();
               }}
@@ -388,6 +390,9 @@ export const ReviewSavedPetition = connect(
           </div>
         </section>
         {showModal == 'ConfirmServeToIrsModal' && <ConfirmServeToIrsModal />}
+        {showModal == 'FormCancelModalDialog' && (
+          <FormCancelModalDialog onCancelSequence="closeModalAndReturnToDashboardSequence" />
+        )}
       </>
     );
   },


### PR DESCRIPTION
Cancel confirmation button now displays when the user clicks cancel when reviewing a paper petition or qc-ing an efiled petition.

https://trello.com/c/kSqBFI16/599-cancel-link-not-working-on-review-and-serve-page-efile-qc-flow-and-aper-add-a-case-flow-dev