### PR TITLE
updating lint rules, exceptions, and fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,15 @@ module.exports = {
         'promise/catch-or-return': 'off',
       },
     },
+    {
+      files: [
+        'web-client/integration-tests/**/*.js',
+        'web-client/integration-tests-public/**/*.js',
+      ],
+      rules: {
+        'jest/expect-expect': 'off',
+      },
+    },
   ],
   parser: 'babel-eslint',
   parserOptions: {
@@ -218,6 +227,7 @@ module.exports = {
           'dynamsoft',
           'efcms',
           'elasticsearch',
+          'enum',
           'eslint',
           'falsy',
           'fieldset',

--- a/shared/src/persistence/dynamo/elasticsearch/getElasticsearchReindexRecords.js
+++ b/shared/src/persistence/dynamo/elasticsearch/getElasticsearchReindexRecords.js
@@ -3,8 +3,9 @@ const client = require('../../dynamodbClientService');
 /**
  * getElasticsearchReindexRecords
  *
- * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
+ * @param {object} arguments deconstructed arguments
+ * @param {object} arguments.applicationContext the application context
+ * @returns {Promise} resolved with query results
  */
 exports.getElasticsearchReindexRecords = async ({ applicationContext }) => {
   return await client.query({

--- a/shared/src/persistence/dynamo/elasticsearch/getRecord.js
+++ b/shared/src/persistence/dynamo/elasticsearch/getRecord.js
@@ -3,10 +3,11 @@ const client = require('../../dynamodbClientService');
 /**
  * getRecord - get a generic record from dynamo to index in elasticsearch
  *
- * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
- * @param {object} providers.recordPk the pk of the record to get
- * @param {object} providers.recordSk the sk of the record to get
+ * @param {object} arguments deconstructed arguments
+ * @param {object} arguments.applicationContext the application context
+ * @param {string} arguments.recordPk the pk of the record to get
+ * @param {string} arguments.recordSk the sk of the record to get
+ * @returns {Promise} resolves with result of query
  */
 exports.getRecord = async ({ applicationContext, recordPk, recordSk }) => {
   return await client.get({

--- a/shared/src/persistence/elasticsearch/getIndexMappingFields.js
+++ b/shared/src/persistence/elasticsearch/getIndexMappingFields.js
@@ -1,8 +1,8 @@
 /**
- * @param {object} args deconstructed arguments
- * @param {object} args.applicationContext the application context
- * @param {string} args.index the index we're querying
- * @return {object} the mapping properties of the specified index
+ * @param {object} arguments deconstructed arguments
+ * @param {object} arguments.applicationContext the application context
+ * @param {string} arguments.index the index we're querying
+ * @returns {object} the mapping properties of the specified index
  */
 exports.getIndexMappingFields = async ({ applicationContext, index }) => {
   const searchClient = applicationContext.getSearchClient();

--- a/shared/src/persistence/elasticsearch/getIndexMappingLimit.js
+++ b/shared/src/persistence/elasticsearch/getIndexMappingLimit.js
@@ -2,7 +2,7 @@
  * @param {object} params deconstructed arguments
  * @param {object} params.applicationContext the application context
  * @param {string} params.index the index we're querying
- * @return {string} the limit for the specified index
+ * @returns {Promise<string>} the limit for the specified index
  */
 exports.getIndexMappingLimit = async ({ applicationContext, index }) => {
   const searchClient = applicationContext.getSearchClient();

--- a/web-client/integration-tests/docketClerkCreatesDocketEntryFromScans.test.js
+++ b/web-client/integration-tests/docketClerkCreatesDocketEntryFromScans.test.js
@@ -2,7 +2,7 @@ import {
   addBatchesForScanning,
   createPDFFromScannedBatches,
   selectScannerSource,
-} from './scanHelpers.js';
+} from './scanHelpers';
 import { docketClerkAddsDocketEntryFile } from './journey/docketClerkAddsDocketEntryFile';
 import { docketClerkAddsDocketEntryWithoutFile } from './journey/docketClerkAddsDocketEntryWithoutFile';
 import { docketClerkSavesDocketEntry } from './journey/docketClerkSavesDocketEntry';

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -558,6 +558,7 @@ export const setupTest = ({ useCases = {} } = {}) => {
 
 export const gotoRoute = (routes, routeToGoTo) => {
   for (let route of routes) {
+    // eslint-disable-next-line security/detect-non-literal-regexp
     const regex = new RegExp(
       route.route.replace(/\*/g, '([a-z\\-A-Z0-9]+)').replace(/\.\./g, '(.*)') +
         '$',

--- a/web-client/integration-tests/scanHelpers.js
+++ b/web-client/integration-tests/scanHelpers.js
@@ -1,6 +1,6 @@
 import { setBatchPages } from './helpers';
 
-exports.addBatchesForScanning = (
+export const addBatchesForScanning = (
   test,
   { scannerSourceIndex, scannerSourceName },
 ) => {
@@ -22,8 +22,7 @@ exports.addBatchesForScanning = (
     ]);
   });
 };
-
-exports.createPDFFromScannedBatches = test => {
+export const createPDFFromScannedBatches = test => {
   return it('Creates a PDF from added batches', async () => {
     const selectedDocumentType = test.getState(
       'currentViewMetadata.documentSelectedForScan',
@@ -43,7 +42,7 @@ exports.createPDFFromScannedBatches = test => {
   });
 };
 
-exports.selectScannerSource = (
+export const selectScannerSource = (
   test,
   { scannerSourceIndex, scannerSourceName },
 ) => {

--- a/web-client/src/presenter/actions/CaseInventoryReport/generatePrintableCaseInventoryReportAction.js
+++ b/web-client/src/presenter/actions/CaseInventoryReport/generatePrintableCaseInventoryReportAction.js
@@ -6,6 +6,7 @@ import { state } from 'cerebral';
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
  * @param {Function} providers.get the cerebral get function
+ * @returns {Promise<object>} the url of the printable pdf
  */
 export const generatePrintableCaseInventoryReportAction = async ({
   applicationContext,

--- a/web-client/src/presenter/actions/createPractitionerUserAction.js
+++ b/web-client/src/presenter/actions/createPractitionerUserAction.js
@@ -8,6 +8,7 @@ import { state } from 'cerebral';
  * @param {Function} providers.get the cerebral get function
  * @param {object} providers.path the next object in the path
  * @param {object} providers.props the props passed in to the action
+ * @returns {object} path execution results
  */
 export const createPractitionerUserAction = async ({
   applicationContext,

--- a/web-client/src/presenter/actions/getPDFForPreviewAction.js
+++ b/web-client/src/presenter/actions/getPDFForPreviewAction.js
@@ -5,6 +5,7 @@ import { state } from 'cerebral';
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
  * @param {Function} providers.props used for getting caseId and documentId
+ * @returns {Promise<object>} pdf file object for preview
  */
 export const getPDFForPreviewAction = async ({
   applicationContext,

--- a/web-client/src/presenter/actions/setCaseOnFormUsingStateAction.js
+++ b/web-client/src/presenter/actions/setCaseOnFormUsingStateAction.js
@@ -6,6 +6,7 @@ import { state } from 'cerebral';
  * @param {object} providers the providers object
  * @param {Function} providers.get the cerebral get function
  * @param {object} providers.store the cerebral store
+ * @returns {object} caseDetail onto the props stream
  */
 export const setCaseOnFormUsingStateAction = async ({ get, store }) => {
   const caseDetail = get(state.caseDetail);

--- a/web-client/src/presenter/actions/updatePractitionerUserAction.js
+++ b/web-client/src/presenter/actions/updatePractitionerUserAction.js
@@ -7,6 +7,7 @@ import { state } from 'cerebral';
  * @param {object} providers.applicationContext the applicationContext
  * @param {Function} providers.get the cerebral get function
  * @param {object} providers.path the next object in the path
+ * @returns {object} path execution results
  */
 export const updatePractitionerUserAction = async ({
   applicationContext,


### PR DESCRIPTION
Most linting warnings fixed.

Some have been preserved because they are revealing tests that have been skipped or disabled and those in particular need further attention.