### PR TITLE
Fix local refreshing for new api

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "start:client:ci": "CI=true SKIP_VIRUS_SCAN=true npm run start:client",
     "start:client:debug": "USTC_DEBUG=true npm run start:client",
     "start:client:no-scanner": "NO_SCANNER=true npm run start:client",
-    "start:client": "FILE_UPLOAD_MODAL_TIMEOUT=1 USTC_ENV=dev parcel --no-cache --no-source-maps web-client/src/index.pug",
+    "start:client": "FILE_UPLOAD_MODAL_TIMEOUT=1 USTC_ENV=dev parcel --no-hmr --no-cache --no-source-maps web-client/src/index.pug",
     "start:madge": "node ./graph-generators/index.js",
     "start:public:ci": "npm run clean:public && CI=true USTC_ENV=dev parcel --port 5678 -d dist-public --no-cache --no-source-maps web-client/src/index-public.pug",
     "start:public": "npm run clean:public && USTC_ENV=dev parcel --port 5678 -d dist-public --no-cache --no-source-maps web-client/src/index-public.pug",

--- a/run-local.sh
+++ b/run-local.sh
@@ -78,9 +78,9 @@ npx sls offline start "$@" --config web-api/serverless-notifications.yml &
 echo "starting proxy"
 node ./web-api/proxy.js &
 
-nodemon -e 'js' --exec "node -r esm web-api/streams-local.js" &
-nodemon -e 'js' --exec "node -r esm web-api/src/app-local.js" &
-nodemon -e 'js' --exec "node -r esm web-api/src/app-public-local.js"
+nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/streams-local.js" &
+nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/src/app-local.js" &
+nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/src/app-public-local.js"
 
 echo "proxy stopped"
 


### PR DESCRIPTION
* Removed hot module reloading for the client. It was refreshing faster than the API was restarting and logging out every time a change was made.
* Ignore client file changes for restarting the API.