### PR TITLE
provide information on validation failures

### DIFF
--- a/shared/src/utilities/JoiValidationDecorator.js
+++ b/shared/src/utilities/JoiValidationDecorator.js
@@ -141,7 +141,11 @@ exports.joiValidationDecorator = function (
       );
       throw new InvalidEntityError(
         entityConstructor.validationName,
-        JSON.stringify(pick(this, helpfulKeys)),
+        JSON.stringify(pick(this, helpfulKeys), (key, value) =>
+          this.hasOwnProperty(key) && typeof value === 'undefined'
+            ? '<undefined>'
+            : value,
+        ),
         JSON.stringify(this.getFormattedValidationErrors()),
       );
     }

--- a/shared/src/utilities/JoiValidationDecorator.js
+++ b/shared/src/utilities/JoiValidationDecorator.js
@@ -1,6 +1,6 @@
 const joi = require('@hapi/joi');
 const { InvalidEntityError } = require('../errors/errors');
-const { isEmpty } = require('lodash');
+const { isEmpty, pick } = require('lodash');
 
 /**
  *
@@ -134,13 +134,14 @@ exports.joiValidationDecorator = function (
 
   entityConstructor.prototype.validate = function validate() {
     if (!this.isValid()) {
-      const ids = Object.entries(this)
-        .filter(([key, value]) => value && key.endsWith('Id'))
-        .map(([key, value]) => `${key}: "${value}"`)
-        .join('; ');
+      const helpfulKeys = Object.keys(this).filter(key => key.endsWith('Id'));
+      helpfulKeys.push(
+        'docketNumber',
+        ...Object.keys(this.getFormattedValidationErrors()),
+      );
       throw new InvalidEntityError(
         entityConstructor.validationName,
-        `ID: ${ids}; DocketNumber: ${this.docketNumber || ''}`,
+        JSON.stringify(pick(this, helpfulKeys)),
         JSON.stringify(this.getFormattedValidationErrors()),
       );
     }

--- a/shared/src/utilities/JoiValidationDecorator.test.js
+++ b/shared/src/utilities/JoiValidationDecorator.test.js
@@ -57,7 +57,23 @@ const MockEntity3Schema = joi.object().keys({
   anotherItem: joi.string().required(),
 });
 
-joiValidationDecorator(MockEntity3, MockEntity3Schema, {
+joiValidationDecorator(MockEntity3, MockEntity3Schema, {});
+
+const MockCase = function (raw) {
+  this.caseId = raw.caseId;
+  this.docketNumber = raw.docketNumber;
+  this.somethingId = raw.somethingId;
+  this.title = raw.title;
+};
+
+const MockCaseSchema = joi.object().keys({
+  caseId: joi.string().required(),
+  docketNumber: joi.string().required(),
+  somethingId: joi.string().required(),
+  title: joi.string().required(),
+});
+
+joiValidationDecorator(MockCase, MockCaseSchema, {
   anotherItem: 'Another item is required',
 });
 
@@ -130,6 +146,25 @@ describe('Joi Validation Decorator', () => {
   it('should have access to the schema', () => {
     const obj = new MockEntity2({});
     expect(obj.getSchema()).toEqual(MockEntity2Schema);
+  });
+
+  it('should throw a detailed "InvalidEntityError" when `validate` fails including all keys ending in `Id`, `docketNumber` if it exists, and key/value pairs that failed validation', () => {
+    const obj1 = new MockCase({
+      caseId: 'abc',
+      docketNumber: '123-20',
+      title: 'some title',
+    });
+    let error;
+    try {
+      obj1.validate();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.message).toContain('\\"somethingId\\" is required');
+    expect(error.message).toContain('"caseId":"abc"');
+    expect(error.message).toContain('"somethingId":"<undefined>"');
+    expect(error.message).toContain('"docketNumber":"123-20"');
   });
 
   it('should have access to the schema without instantiating the entity', () => {


### PR DESCRIPTION
When a validation produces an exception, this code will produce a bit more debug information. It will dump a `JSON.stringified` map containing all key/value pairs which:
* keys end in `Id`
* property `docketNumber` if present
* actual value of each property which failed validation

So if `creationDate` says it fails validation, the above will also show you that `{creationDate: '2020-undefined-undefined'}` for example.