### PR TITLE
5314 served date and served parties required

### DIFF
--- a/docs/entities/Document.md
+++ b/docs/entities/Document.md
@@ -1070,17 +1070,57 @@
         presence: "optional"
         description: "A secondary date associated with the document, typically related to time-restricted availability."
     servedAt: 
-      type: "date"
+      type: "alternatives"
       flags: 
-        format: 
-          - "YYYY-MM-DDTHH:mm:ss.SSSZ"
-          - "YYYY-MM-DD"
-        presence: "optional"
         description: "When the document is served on the parties."
+      matches: 
+        - 
+          ref: 
+            path: 
+              - "servedParties"
+          is: 
+            type: "any"
+            flags: 
+              presence: "required"
+            invalid: 
+              - null
+          then: 
+            type: "date"
+            flags: 
+              format: 
+                - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+                - "YYYY-MM-DD"
+              presence: "required"
+          otherwise: 
+            type: "date"
+            flags: 
+              format: 
+                - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+                - "YYYY-MM-DD"
+              presence: "optional"
     servedParties: 
       type: "array"
       flags: 
-        presence: "optional"
+        description: "The parties to whom the document has been served."
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "servedAt"
+          is: 
+            type: "any"
+            flags: 
+              presence: "required"
+            invalid: 
+              - null
+          then: 
+            type: "any"
+            flags: 
+              presence: "required"
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
       items: 
         - 
           type: "object"

--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -275,13 +275,23 @@ joiValidationDecorator(
       .description(
         'A secondary date associated with the document, typically related to time-restricted availability.',
       ),
-    servedAt: joiStrictTimestamp
-      .optional()
+    servedAt: joi
+      .alternatives()
+      .conditional('servedParties', {
+        is: joi.exist().not(null),
+        otherwise: joiStrictTimestamp.optional(),
+        then: joiStrictTimestamp.required(),
+      })
       .description('When the document is served on the parties.'),
     servedParties: joi
       .array()
       .items({ name: joi.string().max(500).required() })
-      .optional(),
+      .when('servedAt', {
+        is: joi.exist().not(null),
+        otherwise: joi.optional(),
+        then: joi.required(),
+      })
+      .description('The parties to whom the document has been served.'),
     serviceDate: joiStrictTimestamp
       .max('now')
       .optional()

--- a/shared/src/business/entities/Document.test.js
+++ b/shared/src/business/entities/Document.test.js
@@ -313,6 +313,52 @@ describe('Document entity', () => {
       );
       expect(document.isValid()).toBeTruthy();
     });
+
+    it('should fail validation when the document has a servedAt date and servedParties is not defined', () => {
+      const document = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          documentType: ORDER_TYPES[0].documentType,
+          eventCode: 'TRAN',
+          isOrder: true,
+          secondaryDate: '2019-03-01T21:40:46.415Z',
+          servedAt: '2019-03-01T21:40:46.415Z',
+          signedAt: '2019-03-01T21:40:46.415Z',
+          signedByUserId: mockUserId,
+          signedJudgeName: 'Dredd',
+        },
+        { applicationContext },
+      );
+
+      expect(document.isValid()).toBeFalsy();
+      expect(document.getFormattedValidationErrors()).toMatchObject({
+        servedParties: '"servedParties" is required',
+      });
+    });
+
+    it('should fail validation when the document has servedParties and servedAt is not defined', () => {
+      const document = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          documentType: ORDER_TYPES[0].documentType,
+          eventCode: 'TRAN',
+          isOrder: true,
+          secondaryDate: '2019-03-01T21:40:46.415Z',
+          servedParties: 'Test Petitioner',
+          signedAt: '2019-03-01T21:40:46.415Z',
+          signedByUserId: mockUserId,
+          signedJudgeName: 'Dredd',
+        },
+        { applicationContext },
+      );
+
+      expect(document.isValid()).toBeFalsy();
+      expect(document.getFormattedValidationErrors()).toMatchObject({
+        servedAt: '"servedAt" is required',
+      });
+    });
   });
 
   describe('generate filed by string', () => {

--- a/web-api/storage/fixtures/seed/107-19.json
+++ b/web-api/storage/fixtures/seed/107-19.json
@@ -423,6 +423,12 @@
     "documentId": "5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c",
     "numberOfPages": 1,
     "servedAt": "2019-08-16T17:30:10.526Z",
+    "servedParties": [
+      {
+        "name": "Tatum Craig",
+        "email": "petitioner"
+      }
+    ],
     "pk": "case|58c1f7a3-8062-42f0-a73e-8bd69b419878",
     "status": "served"
   },

--- a/web-api/storage/fixtures/seed/108-19.json
+++ b/web-api/storage/fixtures/seed/108-19.json
@@ -317,6 +317,12 @@
     "documentId": "3c777b95-f7fa-4826-9a69-9e2c0ab7fa9c",
     "numberOfPages": 1,
     "servedAt": "2019-08-16T19:22:13.925Z",
+    "servedParties": [
+      {
+        "email": "petitioner",
+        "name": "Garrett Carpenter, Leslie Bullock"
+      }
+    ],
     "pk": "case|46c4064f-b44a-4ac3-9dfb-9ce9f00e43f5",
     "status": "served"
   }


### PR DESCRIPTION
Document that the served date and served party (R, P, or B) is required for all documents that have been served. 
Updated entity docs.
Fixed tests and seed data.