### PR TITLE
docker is built on a previous circle ci step

### DIFF
--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -56,14 +56,6 @@ pushd ../template/websockets
 npx parcel build index.js --target node --bundle-node-modules --no-minify
 popd
 
-pushd ../../runtimes/puppeteer
-./build.sh 
-popd
-
-pushd ../../runtimes/clamav
-./build.sh 
-popd
-
 # exit on any failure
 set -eo pipefail
 


### PR DESCRIPTION
There is an error printing out when trying to run the web-api terraform deploy-app.sh script

```
/home/app/web-api/runtimes/puppeteer /home/app/web-api/terraform/main
 
./build.sh: line 2: docker: command not found
 
./build.sh: line 3: docker: command not found
 
./build.sh: line 4: docker: command not found
 
./build.sh: line 5: docker: command not found
 
/home/app/web-api/terraform/main
 
/home/app/web-api/runtimes/clamav /home/app/web-api/terraform/main
 
./build.sh: line 3: docker: command not found
 
./build.sh: line 4: docker: command not found
 
./build.sh: line 5: docker: command not found
 
./build.sh: line 6: docker: command not found
 
/home/app/web-api/terraform/main
 
```

We build the docker packages at an earlier step in the circle ci deploy process, so running these should not be needed