### PR TITLE
5384: show "Sealed in Blackstone"

### DIFF
--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -42,6 +42,7 @@ const formatDocument = (applicationContext, document) => {
       .formatDateString(result.certificateOfServiceDate, 'MMDDYY');
   }
 
+  result.showLegacySealed = !!result.isLegacySealed;
   result.showServedAt = !!result.servedAt;
   result.isStatusServed = !!result.servedAt;
   result.isPetition =

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -70,6 +70,7 @@ describe('formatCase', () => {
           documentId: 'd-1-2-3',
           documentType: 'Petition',
           eventCode: 'P',
+          isLegacySealed: true,
           servedAt: getDateISO(),
           workItems: [
             {
@@ -103,7 +104,9 @@ describe('formatCase', () => {
     expect(result.documents[0]).toHaveProperty('isStatusServed');
     expect(result.documents[0]).toHaveProperty('isPetition');
     expect(result.documents[0]).toHaveProperty('servedPartiesCode');
+    expect(result.documents[0].showLegacySealed).toBeTruthy();
 
+    expect(result.documents[1].showLegacySealed).toBeFalsy();
     expect(result.documents[1].qcWorkItemsUntouched).toEqual(false);
   });
 

--- a/web-client/src/views/DocumentDetail/DocumentDetailHeader.jsx
+++ b/web-client/src/views/DocumentDetail/DocumentDetailHeader.jsx
@@ -47,6 +47,9 @@ export const DocumentDetailHeader = connect(
               Served {documentDetailHelper.formattedDocument.servedAtFormatted}
             </div>
           )}
+          {documentDetailHelper.formattedDocument.showLegacySealed && (
+            <div>Sealed in Blackstone</div>
+          )}
         </div>
         <div>
           {documentDetailHelper.isDraftDocument && (


### PR DESCRIPTION
<img width="602" alt="Screen Shot 2020-06-25 at 11 12 44 AM" src="https://user-images.githubusercontent.com/2445917/85766646-dde42c00-b6dc-11ea-9ade-ba4bafd2172b.png">

Depends upon seeing an attribute on the Document (yet to be created) called `isLegacySealed`, a property which affirms that this legacy case was sealed _prior_ to migration.