### PR TITLE
Only process dynamo stream once when running the api locally

### DIFF
--- a/run-local.sh
+++ b/run-local.sh
@@ -59,7 +59,7 @@ if [[ -z "${RUN_DIR}" ]]; then
   RUN_DIR="src"
 fi
 
-nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/streams-local.js" &
+node -r esm web-api/streams-local.js &
 nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/websockets-local.js" &
 nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/src/app-local.js" &
 nodemon -e js --ignore web-client/ --ignore dist/ --exec "node -r esm web-api/src/app-public-local.js"


### PR DESCRIPTION
The full dynamo table was being reprocessed by the processStreamRecordsInteractor each time a change was made to the API code locally. 