### PR TITLE
correctly fetch searchClient index

### DIFF
--- a/shared/src/persistence/elasticsearch/getIndexMappingLimit.js
+++ b/shared/src/persistence/elasticsearch/getIndexMappingLimit.js
@@ -1,3 +1,4 @@
+const { get } = require('lodash');
 /**
  * @param {object} params deconstructed arguments
  * @param {object} params.applicationContext the application context
@@ -10,6 +11,12 @@ exports.getIndexMappingLimit = async ({ applicationContext, index }) => {
   const indexSettings = await searchClient.indices.getSettings({
     index,
   });
-
-  return indexSettings.efcms.settings.index.mapping.total_fields.limit;
+  const mappingLimit = get(
+    indexSettings,
+    `${index}.settings.index.mapping.total_fields.limit`,
+  );
+  if (!mappingLimit) {
+    throw new Error(`Search client index "${index}" settings not found`);
+  }
+  return mappingLimit;
 };

--- a/shared/src/persistence/elasticsearch/getindexMappingLimit.test.js
+++ b/shared/src/persistence/elasticsearch/getindexMappingLimit.test.js
@@ -26,7 +26,7 @@ describe('getIndexMappingLimit', () => {
     expect(results).toEqual(479);
   });
 
-  it('returns a default index mapping limit if index info cannot be found', async () => {
+  it('throws an error if index info cannot be found', async () => {
     await expect(
       getIndexMappingLimit({
         applicationContext,

--- a/shared/src/persistence/elasticsearch/getindexMappingLimit.test.js
+++ b/shared/src/persistence/elasticsearch/getindexMappingLimit.test.js
@@ -8,18 +8,30 @@ describe('getIndexMappingLimit', () => {
     applicationContext.getSearchClient.mockReturnValue({
       indices: {
         getSettings: () => ({
-          efcms: {
-            settings: { index: { mapping: { total_fields: { limit: 479 } } } },
+          'efcms-documents': {
+            settings: {
+              index: { mapping: { total_fields: { limit: 479 } } },
+            },
           },
         }),
       },
     });
   });
 
-  it('returns index mapping limit', async () => {
+  it('returns index mapping limit of an index which is present in settings ', async () => {
     const results = await getIndexMappingLimit({
       applicationContext,
+      index: 'efcms-documents',
     });
     expect(results).toEqual(479);
+  });
+
+  it('returns a default index mapping limit if index info cannot be found', async () => {
+    await expect(
+      getIndexMappingLimit({
+        applicationContext,
+        index: 'bbq',
+      }),
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
throw exception if not found.  Index names have changed and can not be hard-coded in this function (formerly 'efcms').
Addresses index-querying errors caught by HB: `"Cannot read property 'settings' of undefined"`
cc: @rachaelparris 