### PR TITLE
Bug: Docket QC form not retaining secondary document type in select

### DIFF
--- a/shared/src/business/entities/Document.js
+++ b/shared/src/business/entities/Document.js
@@ -99,6 +99,7 @@ function Document(rawDocument, { applicationContext, filtered = false }) {
   this.relationship = rawDocument.relationship;
   this.scenario = rawDocument.scenario;
   this.secondaryDate = rawDocument.secondaryDate;
+  this.secondaryDocument = rawDocument.secondaryDocument;
   this.servedAt = rawDocument.servedAt;
   this.numberOfPages = rawDocument.numberOfPages;
   this.servedParties = rawDocument.servedParties;
@@ -335,6 +336,31 @@ joiValidationDecorator(
       .description(
         'A secondary date associated with the document, typically related to time-restricted availability.',
       ),
+    secondaryDocument: joi
+      .object()
+      .keys({
+        documentTitle: joi
+          .string()
+          .max(500)
+          .optional()
+          .description('The title of the secondary document.'),
+        documentType: joi
+          .string()
+          .valid(...ALL_DOCUMENT_TYPES)
+          .required()
+          .description('The type of the secondary document.'),
+        eventCode: joi
+          .string()
+          .valid(...ALL_EVENT_CODES)
+          .required()
+          .description('The event code of the secondary document.'),
+      })
+      .when('scenario', {
+        is: 'Nonstandard H',
+        otherwise: joi.forbidden(),
+        then: joi.optional(),
+      })
+      .description('The secondary document.'),
     servedAt: joi
       .alternatives()
       .conditional('servedParties', {

--- a/shared/src/business/entities/Document.test.js
+++ b/shared/src/business/entities/Document.test.js
@@ -1490,4 +1490,86 @@ describe('Document entity', () => {
       );
     });
   });
+
+  describe('secondaryDocument validation', () => {
+    it('should not be valid if secondaryDocument is present and the scenario is not Nonstandard H', () => {
+      const createdDocument = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          scenario: 'Standard',
+          secondaryDocument: {},
+        },
+        { applicationContext },
+      );
+
+      expect(createdDocument.isValid()).toEqual(false);
+      expect(
+        Object.keys(createdDocument.getFormattedValidationErrors()),
+      ).toEqual(['secondaryDocument']);
+    });
+
+    it('should be valid if secondaryDocument is undefined and the scenario is not Nonstandard H', () => {
+      const createdDocument = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          scenario: 'Standard',
+          secondaryDocument: undefined,
+        },
+        { applicationContext },
+      );
+
+      expect(createdDocument.isValid()).toEqual(true);
+    });
+
+    it('should be valid if secondaryDocument is not present and the scenario is Nonstandard H', () => {
+      const createdDocument = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          scenario: 'Nonstandard H',
+          secondaryDocument: undefined,
+        },
+        { applicationContext },
+      );
+
+      expect(createdDocument.isValid()).toEqual(true);
+    });
+
+    it('should be valid if secondaryDocument is present and its contents are valid and the scenario is Nonstandard H', () => {
+      const createdDocument = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          scenario: 'Nonstandard H',
+          secondaryDocument: {
+            documentTitle: 'Petition',
+            documentType: 'Petition',
+            eventCode: 'P',
+          },
+        },
+        { applicationContext },
+      );
+
+      expect(createdDocument.isValid()).toEqual(true);
+    });
+
+    it('should not be valid if secondaryDocument is present and it is missing fields and the scenario is Nonstandard H', () => {
+      const createdDocument = new Document(
+        {
+          ...A_VALID_DOCUMENT,
+          documentId: '777afd4b-1408-4211-a80e-3e897999861a',
+          scenario: 'Nonstandard H',
+          secondaryDocument: {},
+        },
+        { applicationContext },
+      );
+
+      expect(createdDocument.isValid()).toEqual(false);
+      expect(
+        Object.keys(createdDocument.getFormattedValidationErrors()),
+      ).toEqual(['documentType', 'eventCode']);
+    });
+  });
 });

--- a/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.test.js
+++ b/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.test.js
@@ -150,6 +150,7 @@ describe('fileExternalDocumentInteractor', () => {
         documentType: 'Motion for Leave to File',
         eventCode: 'M115',
         filedBy: 'Test Petitioner',
+        scenario: 'Nonstandard H',
         secondaryDocument: {
           documentTitle: 'Motion for Judgment on the Pleadings',
           documentType: 'Motion for Judgment on the Pleadings',

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -292,7 +292,6 @@ export const uploadExternalDecisionDocument = async test => {
     primaryDocumentFileSize: 115022,
     scenario: 'Standard',
     searchError: false,
-    secondaryDocument: {},
     serviceDate: null,
     supportingDocument: null,
     supportingDocumentFile: null,
@@ -319,7 +318,6 @@ export const uploadProposedStipulatedDecision = async test => {
     privatePractitioners: [],
     scenario: 'Standard',
     searchError: false,
-    secondaryDocument: { certificateOfServiceDate: null },
     serviceDate: null,
   });
   await test.runSequence('submitExternalDocumentSequence');

--- a/web-client/src/presenter/actions/FileDocument/defaultSecondaryDocumentAction.js
+++ b/web-client/src/presenter/actions/FileDocument/defaultSecondaryDocumentAction.js
@@ -4,20 +4,26 @@ import { state } from 'cerebral';
  * default secondary document.
  *
  * @param {object} providers the providers object
- * @param {object} providers.store the cerebral store object used for clearing secondaryDocument
  * @param {object} providers.get the cerebral get function
+ * @param {object} providers.store the cerebral store object
  */
 export const defaultSecondaryDocumentAction = ({ get, store }) => {
-  const secondaryDocument = get(state.form.secondaryDocument);
+  const primaryDocumentScenario = get(state.form.scenario);
 
-  if (!secondaryDocument) {
-    store.set(state.form.secondaryDocument, {});
+  if (primaryDocumentScenario === 'Nonstandard H') {
+    const secondaryDocument = get(state.form.secondaryDocument);
+
+    if (!secondaryDocument) {
+      store.set(state.form.secondaryDocument, {});
+    } else {
+      if (!secondaryDocument.attachments) {
+        store.set(state.form.secondaryDocument.attachments, false);
+      }
+      if (!secondaryDocument.certificateOfService) {
+        store.set(state.form.secondaryDocument.certificateOfService, false);
+      }
+    }
   } else {
-    if (!secondaryDocument.attachments) {
-      store.set(state.form.secondaryDocument.attachments, false);
-    }
-    if (!secondaryDocument.certificateOfService) {
-      store.set(state.form.secondaryDocument.certificateOfService, false);
-    }
+    store.unset(state.form.secondaryDocument);
   }
 };

--- a/web-client/src/presenter/actions/FileDocument/defaultSecondaryDocumentAction.test.js
+++ b/web-client/src/presenter/actions/FileDocument/defaultSecondaryDocumentAction.test.js
@@ -2,16 +2,34 @@ import { defaultSecondaryDocumentAction } from './defaultSecondaryDocumentAction
 import { runAction } from 'cerebral/test';
 
 describe('defaultSecondaryDocumentAction', () => {
-  it('sets the default form values for a secondary document', async () => {
+  it('sets the default form values for a secondary document if the scenario is Nonstandard H', async () => {
     const result = await runAction(defaultSecondaryDocumentAction, {
       state: {
-        form: {},
+        form: {
+          scenario: 'Nonstandard H',
+        },
       },
     });
 
     expect(result.state).toMatchObject({
       form: {
         secondaryDocument: {},
+      },
+    });
+  });
+
+  it('unsets the secondary document if the scenario is not Nonstandard H', async () => {
+    const result = await runAction(defaultSecondaryDocumentAction, {
+      state: {
+        form: {
+          scenario: 'Standard',
+        },
+      },
+    });
+
+    expect(result.state).toEqual({
+      form: {
+        scenario: 'Standard',
       },
     });
   });

--- a/web-client/src/presenter/computeds/fileDocumentHelper.js
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.js
@@ -48,6 +48,9 @@ export const fileDocumentHelper = (get, applicationContext) => {
       .formatDateString(certificateOfServiceDate, 'MMDDYY');
   }
 
+  const showSecondaryDocument =
+    form.secondaryDocument && form.secondaryDocument.documentTitle;
+
   const secondaryDocumentCertificateOfServiceDate =
     form.secondaryDocument && form.secondaryDocument.certificateOfServiceDate;
   let secondaryDocumentCertificateOfServiceDateFormatted;
@@ -167,6 +170,7 @@ export const fileDocumentHelper = (get, applicationContext) => {
     showFilingIncludes,
     showMultiDocumentFilingPartyForm: !!form.selectedCases,
     showPrimaryDocumentValid: !!form.primaryDocumentFile,
+    showSecondaryDocument,
     showSecondaryDocumentInclusionsForm,
     showSecondaryDocumentValid: !!form.secondaryDocumentFile,
     showSecondaryFilingIncludes,

--- a/web-client/src/views/FileDocument/FileDocument.jsx
+++ b/web-client/src/views/FileDocument/FileDocument.jsx
@@ -14,7 +14,6 @@ import React from 'react';
 export const FileDocument = connect(
   {
     fileDocumentHelper: state.fileDocumentHelper,
-    form: state.form,
     formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
     navigateBackSequence: sequences.navigateBackSequence,
     reviewExternalDocumentInformationSequence:
@@ -23,7 +22,6 @@ export const FileDocument = connect(
   },
   function FileDocument({
     fileDocumentHelper,
-    form,
     formCancelToggleCancelSequence,
     navigateBackSequence,
     reviewExternalDocumentInformationSequence,
@@ -49,7 +47,7 @@ export const FileDocument = connect(
 
         <SupportingDocuments />
 
-        {form.secondaryDocument.documentTitle && (
+        {fileDocumentHelper.showSecondaryDocument && (
           <>
             <SecondaryDocumentForm />
             <SecondarySupportingDocuments />

--- a/web-client/src/views/FileDocument/FileDocumentReview.jsx
+++ b/web-client/src/views/FileDocument/FileDocumentReview.jsx
@@ -166,7 +166,7 @@ export const FileDocumentReview = connect(
                       </React.Fragment>
                     ))}
 
-                  {form.secondaryDocument.documentTitle && (
+                  {fileDocumentHelper.showSecondaryDocument && (
                     <div className="grid-row grid-gap overline padding-top-105 margin-top-105">
                       <div className="tablet:grid-col-6 margin-bottom-1">
                         <div className="tablet:margin-bottom-0 margin-bottom-205">


### PR DESCRIPTION
* Added secondaryDocument to Document entity with validation

Continuation of #5624 

https://trello.com/c/vhDUQQhe/560-docket-qc-form-not-retaining-document-type-for-secondary-document