### PR TITLE
devex-pdf Try and force explicit matching of numbus_roman bold on h1

### DIFF
--- a/shared/src/business/utilities/htmlGenerator/index.scss
+++ b/shared/src/business/utilities/htmlGenerator/index.scss
@@ -138,6 +138,7 @@ th {
   h1 {
     font-family: 'nimbus_roman', serif;
     font-size: 16px;
+    font-weight: bold;
   }
 }
 


### PR DESCRIPTION
<img width="256" alt="Screen Shot 2020-06-29 at 9 50 07 AM" src="https://user-images.githubusercontent.com/1891789/86027425-ecd52200-b9ed-11ea-858b-2df22cf163f9.png">
