### PR TITLE
Like changes to getIndexMappingLimit

### DIFF
--- a/shared/src/persistence/elasticsearch/getIndexMappingFields.js
+++ b/shared/src/persistence/elasticsearch/getIndexMappingFields.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+const { get } = require('lodash');
 /**
  * @param {object} arguments deconstructed arguments
  * @param {object} arguments.applicationContext the application context

--- a/shared/src/persistence/elasticsearch/getIndexMappingFields.js
+++ b/shared/src/persistence/elasticsearch/getIndexMappingFields.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 /**
  * @param {object} arguments deconstructed arguments
  * @param {object} arguments.applicationContext the application context
@@ -11,8 +12,7 @@ exports.getIndexMappingFields = async ({ applicationContext, index }) => {
     const indexMapping = await searchClient.indices.getMapping({
       index,
     });
-
-    return indexMapping.efcms.mappings.properties;
+    return get(indexMapping, `${index}.mappings.properties`);
   } catch (e) {
     await applicationContext.notifyHoneybadger(e, { index });
   }

--- a/shared/src/persistence/elasticsearch/getindexMappingFields.test.js
+++ b/shared/src/persistence/elasticsearch/getindexMappingFields.test.js
@@ -5,11 +5,14 @@ const { getIndexMappingFields } = require('./getIndexMappingFields');
 
 describe('getIndexMappingFields', () => {
   beforeAll(() => {
-    const mockIndexes = { baz: { quux: 'quux!' }, foo: { bar: 'bar!' } };
+    const mockIndexes = {
+      'efcms-documents': { quux: 'quux!' },
+      foo: { bar: 'bar!' },
+    };
     applicationContext.getSearchClient.mockReturnValue({
       indices: {
         getMapping: ({ index }) => ({
-          efcms: { mappings: { properties: mockIndexes[index] } },
+          'efcms-documents': { mappings: { properties: mockIndexes[index] } },
         }),
       },
     });
@@ -18,8 +21,16 @@ describe('getIndexMappingFields', () => {
   it('returns index mapping properties', async () => {
     const results = await getIndexMappingFields({
       applicationContext,
-      index: 'foo',
+      index: 'efcms-documents',
     });
-    expect(results).toMatchObject({ bar: 'bar!' });
+    expect(results).toMatchObject({ quux: 'quux!' });
+  });
+
+  it('returns undefined index mapping properties', async () => {
+    const results = await getIndexMappingFields({
+      applicationContext,
+      index: 'this-index-does-not-exist',
+    });
+    expect(results).toBeUndefined();
   });
 });


### PR DESCRIPTION
...dynamically fetch setting according to index name, safely return undefined.

Addresses legit Honeybadger report at 
https://app.honeybadger.io/projects/69132/faults/65240234/3b5ddf3e-bb60-11ea-99d2-9487ac596fea?page=0