### PR TITLE
Throw errors if user not found in persistence

### DIFF
--- a/shared/src/business/useCases/getUserInteractor.js
+++ b/shared/src/business/useCases/getUserInteractor.js
@@ -1,3 +1,4 @@
+const { NotFoundError } = require('../../errors/errors');
 const { User } = require('../entities/User');
 
 /**
@@ -12,6 +13,12 @@ exports.getUserInteractor = async ({ applicationContext }) => {
   const user = await applicationContext
     .getPersistenceGateway()
     .getUserById({ applicationContext, userId: authorizedUser.userId });
+
+  if (!user) {
+    throw new NotFoundError(
+      `User id ${authorizedUser.userId}" not found in persistence.`,
+    );
+  }
 
   return new User(user).validate().toRawObject();
 };


### PR DESCRIPTION
If user manages to authenticate BUT their record is not found in persistence, throw a useful error rather than blowing up in the User constructor with 
`"Cannot read property 'barNumber' of undefined"`

This addresses the situation where perhaps old data is in cognito for an account which is not listed in dynamo (esp with setup/teardown of environments) and "should never happen".  But if it does, this will give us more detail in honeybadger errors.

I discovered this when attempting to log into our staging environment as `practitioner1`; the user existed in cognito, but not in dynamo.