### PR TITLE
3580: update document links in qc processed box and pending report

### DIFF
--- a/web-client/integration-tests/docketClerkViewsCaseDetailMessagesInProgress.test.js
+++ b/web-client/integration-tests/docketClerkViewsCaseDetailMessagesInProgress.test.js
@@ -5,14 +5,7 @@ import {
   uploadPetition,
   viewDocumentDetailMessage,
 } from './helpers';
-import { extractedPendingMessagesFromCaseDetail as extractedPendingMessagesFromCaseDetailComputed } from '../src/presenter/computeds/extractPendingMessagesFromCaseDetail';
 import { petitionsClerkCreateOrder } from './journey/petitionsClerkCreateOrder';
-import { runCompute } from 'cerebral/test';
-import { withAppContextDecorator } from '../src/withAppContext';
-
-const extractedPendingMessagesFromCaseDetail = withAppContextDecorator(
-  extractedPendingMessagesFromCaseDetailComputed,
-);
 
 const test = setupTest({
   useCases: {
@@ -45,17 +38,5 @@ describe('a docket clerk views case detail messages in progress with a message o
       message: 'this is a test message for docket clerk',
       test,
     });
-  });
-
-  loginAs(test, 'docketclerk');
-  it('docket clerk views case detail in progress messages with a message about a draft order', async () => {
-    await test.runSequence('gotoCaseDetailSequence', {
-      docketNumber: test.docketNumber,
-    });
-    let result = runCompute(extractedPendingMessagesFromCaseDetail, {
-      state: test.getState(),
-    });
-    expect(result[0].editLink).not.toContain('/edit');
-    expect(result[0].editLink).toContain('/messages/');
   });
 });

--- a/web-client/src/presenter/actions/setDefaultCaseDetailTabAction.js
+++ b/web-client/src/presenter/actions/setDefaultCaseDetailTabAction.js
@@ -24,5 +24,9 @@ export const setDefaultCaseDetailTabAction = ({ get, props, store }) => {
       state.currentViewMetadata.caseDetail.caseInformationTab,
       'overview',
     );
+    store.set(
+      state.currentViewMetadata.caseDetail.docketRecordTab,
+      props.docketRecordTab || 'docketRecord',
+    );
   }
 };

--- a/web-client/src/presenter/actions/setDefaultCaseDetailTabAction.test.js
+++ b/web-client/src/presenter/actions/setDefaultCaseDetailTabAction.test.js
@@ -7,6 +7,7 @@ describe('setDefaultCaseDetailTabAction', () => {
 
     expect(state.currentViewMetadata.caseDetail).toMatchObject({
       caseInformationTab: 'overview',
+      docketRecordTab: 'docketRecord',
       inProgressTab: 'draftDocuments',
       primaryTab: 'docketRecord',
     });
@@ -26,15 +27,32 @@ describe('setDefaultCaseDetailTabAction', () => {
     });
   });
 
+  it('should set the docketRecordTab to passed in prop value', async () => {
+    const { state } = await runAction(setDefaultCaseDetailTabAction, {
+      props: {
+        docketRecordTab: 'documentView',
+      },
+    });
+
+    expect(state.currentViewMetadata.caseDetail).toMatchObject({
+      caseInformationTab: 'overview',
+      docketRecordTab: 'documentView',
+      inProgressTab: 'draftDocuments',
+      primaryTab: 'docketRecord',
+    });
+  });
+
   it('should not set anything if currentViewMetadata.caseDetail.frozen is true', async () => {
     const { state } = await runAction(setDefaultCaseDetailTabAction, {
       props: {
+        docketRecordTab: 'documentView',
         primaryTab: 'caseInformation',
       },
       state: {
         currentViewMetadata: {
           caseDetail: {
             caseInformationTab: 'petitioner',
+            docketRecordTab: 'docketRecord',
             frozen: true,
             inProgressTab: 'messages',
             primaryTab: 'caseInformation',
@@ -45,6 +63,7 @@ describe('setDefaultCaseDetailTabAction', () => {
 
     expect(state.currentViewMetadata.caseDetail).toMatchObject({
       caseInformationTab: 'petitioner',
+      docketRecordTab: 'docketRecord',
       frozen: true,
       inProgressTab: 'messages',
       primaryTab: 'caseInformation',

--- a/web-client/src/presenter/actions/setIsPrimaryTabAction.js
+++ b/web-client/src/presenter/actions/setIsPrimaryTabAction.js
@@ -8,8 +8,8 @@ import { state } from 'cerebral';
  * @param {object} providers.get the cerebral get function used for getting state from store
  */
 export const setIsPrimaryTabAction = ({ get, store }) => {
-  let primaryTab = get(state.currentViewMetadata.caseDetail.primaryTab);
-  let caseDetailInternalTabs = get(
+  const primaryTab = get(state.currentViewMetadata.caseDetail.primaryTab);
+  const caseDetailInternalTabs = get(
     state.currentViewMetadata.caseDetail.caseDetailInternalTabs,
   );
 

--- a/web-client/src/presenter/computeds/formattedWorkQueue.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.js
@@ -202,6 +202,8 @@ export const getWorkItemDocumentLink = ({
       });
       if (editLinkExtension) {
         editLink += editLinkExtension;
+      } else {
+        editLink = `/case-detail/${workItem.docketNumber}/document-view?documentId=${workItem.document.documentId}`;
       }
     } else if (formattedDocument.isPetition && !formattedDocument.servedAt) {
       if (result.caseIsInProgress) {

--- a/web-client/src/presenter/computeds/formattedWorkQueue.test.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.test.js
@@ -887,6 +887,45 @@ describe('formatted work queue computed', () => {
       expect(result).toEqual(`${baseWorkItemEditLink}/complete`);
     });
 
+    it('should return case detail link if document is processed and user is docketclerk', () => {
+      const { permissions } = getBaseState(docketClerkUser);
+
+      const result = getWorkItemDocumentLink({
+        applicationContext,
+        permissions,
+        workItem: {
+          ...baseWorkItem,
+          completedAt: '2019-03-01T21:40:46.415Z',
+          document: {
+            ...baseDocument,
+            category: 'Miscellaneous',
+            documentTitle: 'Administrative Record',
+            documentType: 'Administrative Record',
+            eventCode: 'ADMR',
+            isFileAttached: true,
+            isPaper: true,
+            pending: false,
+            receivedAt: '2018-01-01',
+            relationship: 'primaryDocument',
+            scenario: 'Standard',
+          },
+          isInitializeCase: false,
+          isQC: true,
+          isRead: true,
+          messages: [baseMessage],
+          section: 'docket',
+        },
+        workQueueToDisplay: {
+          box: 'outbox',
+          queue: 'section',
+          workQueueIsInternal: false,
+        },
+      });
+      expect(result).toEqual(
+        `/case-detail/${baseWorkItem.docketNumber}/document-view?documentId=${baseDocument.documentId}`,
+      );
+    });
+
     it('should return default edit link if document is in progress and user is petitionsClerk', () => {
       const { permissions } = getBaseState(petitionsClerkUser);
 

--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -159,6 +159,20 @@ const router = {
     );
 
     registerRoute(
+      '/case-detail/*/document-view?..',
+      ifHasAccess(docketNumber => {
+        const { documentId } = route.query();
+        window.history.replaceState(null, null, `/case-detail/${docketNumber}`);
+        setPageTitle(`Docket ${docketNumber}`);
+        return app.getSequence('gotoCaseDetailSequence')({
+          docketNumber,
+          docketRecordTab: 'documentView',
+          documentId,
+        });
+      }),
+    );
+
+    registerRoute(
       '/case-detail/*/edit-petitioner-information',
       ifHasAccess(docketNumber => {
         setPageTitle(`Docket ${docketNumber}`);

--- a/web-client/src/views/PendingReport/PendingReportList.jsx
+++ b/web-client/src/views/PendingReport/PendingReportList.jsx
@@ -65,7 +65,7 @@ export const PendingReportList = connect(
                 <td>{item.caseTitle}</td>
                 <td>
                   <a
-                    href={`/case-detail/${item.docketNumber}/documents/${item.documentId}`}
+                    href={`/case-detail/${item.docketNumber}/document-view?documentId=${item.documentId}`}
                   >
                     {item.formattedName}
                   </a>


### PR DESCRIPTION
Displaying the correct document when going to the page still needs to be completed after the view is ready.