### PR TITLE
DevEx: content security policy - remove unsafe-inline

### DIFF
--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -42,7 +42,7 @@ exports.handler = (event, context, callback) => {
     `default-src ${applicationUrl} ${s3Url} data: blob:`,
     `form-action ${applicationUrl}`,
     "object-src 'none'",
-    `script-src 'self' ${dynamsoftUrl} 'unsafe-inline' resource://pdf.js`,
+    `script-src 'self' ${dynamsoftUrl} resource://pdf.js`,
     `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
   ];
   headers['content-security-policy'] = [


### PR DESCRIPTION
Deployed to `exp1` and I haven't seen any issues. 

https://trello.com/c/1izjTbPs/531-refine-content-security-policy