### PR TITLE
DevEx: refine content security policy - remove unsafe-inline from style-src

### DIFF
--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -43,7 +43,7 @@ exports.handler = (event, context, callback) => {
     `form-action ${applicationUrl}`,
     "object-src 'none'",
     `script-src 'self' ${dynamsoftUrl} resource://pdf.js`,
-    `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
+    `style-src 'self' ${dynamsoftUrl}`,
   ];
   headers['content-security-policy'] = [
     {


### PR DESCRIPTION
Deployed to `exp1` and checked things over, all looks fine. I'm doing these one at a time to help identify the cause if something starts failing.

https://trello.com/c/1izjTbPs/531-refine-content-security-policy