### PR TITLE
Minify deployed api to reduce size

### DIFF
--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -25,7 +25,7 @@ npm run build:assets
 
 # build the cognito authorizer, api, and api-public with parcel
 pushd ../template/lambdas
-npx parcel build websockets.js cron.js streams.js log-forwarder.js cognito-authorizer.js cognito-triggers.js api-public.js api.js --target node --bundle-node-modules --no-minify
+npx parcel build websockets.js cron.js streams.js log-forwarder.js cognito-authorizer.js cognito-triggers.js api-public.js api.js --target node --bundle-node-modules
 popd
 
 # exit on any failure


### PR DESCRIPTION
This is to resolve this error when deploying to a new environment: 

```
Error: Error modifying Lambda Function Code api_clamav_exp2: InvalidParameterValueException: Unzipped size must be smaller than 24543054 bytes
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "2ead7038-b38e-479e-aca0-60572121fba6"
  },
  Message_: "Unzipped size must be smaller than 24543054 bytes",
  Type: "User"
}
  on ../template/api.tf line 27, in resource "aws_lambda_function" "api_clamav_lambda":
  27: resource "aws_lambda_function" "api_clamav_lambda" {
 ```