### PR TITLE
DevEx: document CSP unsafe-inline

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,13 @@
+# Security
+
+We use a strict Content Security Policy to protect the site against attacks. Parts of the CSP are not as strict as we would like and can possibly be improved on later with dependency upgrades. 
+
+`script-src` and `style-src` both allow `unsafe-inline` due to the Dynamsoft library used by internal users for scanning paper documents.
+
+Dynamsoft has documented the issue:
+
+https://developer.dynamsoft.com/dwt/kb/distribution-deployment/dynamic-web-twain-content-security-policy
+
+https://developer.dynamsoft.com/dwt/kb/distribution-deployment/dynamic-web-twain-content-security-policy-violated
+
+If Dynamsoft provides developers with an option to disable inline scripts and styles, `unsafe-inline` can be removed from our CSP.

--- a/web-client/src/app.jsx
+++ b/web-client/src/app.jsx
@@ -88,8 +88,8 @@ import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
 import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
 import { faUserCheck } from '@fortawesome/free-solid-svg-icons/faUserCheck';
 
+import { config, library } from '@fortawesome/fontawesome-svg-core';
 import { isFunction, mapValues } from 'lodash';
-import { library } from '@fortawesome/fontawesome-svg-core';
 import { presenter } from './presenter/presenter';
 import { socketProvider } from './providers/socket';
 import { socketRouter } from './providers/socketRouter';
@@ -147,6 +147,7 @@ const app = {
 
     presenter.state.constants = applicationContext.getConstants();
 
+    config.autoAddCss = false;
     library.add(
       faArrowAltCircleLeftRegular,
       faArrowAltCircleLeftSolid,

--- a/web-client/src/index.pug
+++ b/web-client/src/index.pug
@@ -6,6 +6,7 @@ html(lang="en")
     meta(name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no")
     title U.S. Tax Court Electronic Filing and Case Management System
     link(rel="stylesheet" href="index.scss")
+    link(rel="stylesheet" href="../../node_modules/@fortawesome/fontawesome-svg-core/styles.css")
     link(rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png")
     link(rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png")
     link(rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png")

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -42,8 +42,8 @@ exports.handler = (event, context, callback) => {
     `default-src ${applicationUrl} ${s3Url} data: blob:`,
     `form-action ${applicationUrl}`,
     "object-src 'none'",
-    `script-src 'self' ${dynamsoftUrl} resource://pdf.js`,
-    `style-src 'self' ${dynamsoftUrl}`,
+    `script-src 'self' 'unsafe-inline' ${dynamsoftUrl} resource://pdf.js`,
+    `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
   ];
   headers['content-security-policy'] = [
     {

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -42,8 +42,8 @@ exports.handler = (event, context, callback) => {
     `default-src ${applicationUrl} ${s3Url} data: blob:`,
     `form-action ${applicationUrl}`,
     "object-src 'none'",
-    `script-src 'self' 'unsafe-inline' ${dynamsoftUrl} resource://pdf.js`,
-    `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
+    `script-src 'self' ${dynamsoftUrl} resource://pdf.js`,
+    `style-src 'self' ${dynamsoftUrl}`,
   ];
   headers['content-security-policy'] = [
     {


### PR DESCRIPTION
Dynamsoft does not work without `unsafe-inline` in our CSP, so it can't be removed. Added a description of this to our documentation.

Fontawesome also uses inline styles, so I updated those to be pulled in from a CSS file instead in case Dynamsoft resolves this and we can remove `unsafe-inline` later.