### PR TITLE
4375 Update coversheet for court issued documents

### DIFF
--- a/shared/src/business/useCases/addCoversheetInteractor.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.js
@@ -102,6 +102,7 @@ exports.generateCoverSheetData = ({
     coverSheetData = omit(coverSheetData, [
       'dateReceived',
       'electronicallyFiled',
+      'dateServed',
     ]);
   }
 

--- a/shared/src/business/useCases/addCoversheetInteractor.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.js
@@ -1,4 +1,8 @@
+const {
+  COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET,
+} = require('../entities/EntityConstants');
 const { Case } = require('../entities/cases/Case');
+const { omit } = require('lodash');
 
 /**
  * a helper function which assembles the correct data to be used in the generation of a PDF
@@ -76,7 +80,7 @@ exports.generateCoverSheetData = ({
   const docketNumberWithSuffix =
     caseEntity.docketNumber + (docketNumberSuffixToUse || '');
 
-  const coverSheetData = {
+  let coverSheetData = {
     caseCaptionExtension,
     caseTitle,
     certificateOfService,
@@ -89,6 +93,18 @@ exports.generateCoverSheetData = ({
     electronicallyFiled: !documentEntity.isPaper,
     mailingDate: documentEntity.mailingDate || '',
   };
+
+  if (
+    COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET.includes(
+      documentEntity.eventCode,
+    )
+  ) {
+    coverSheetData = omit(coverSheetData, [
+      'dateReceived',
+      'electronicallyFiled',
+    ]);
+  }
+
   return coverSheetData;
 };
 /**

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -758,5 +758,34 @@ describe('addCoversheetInteractor', () => {
       expect(result.docketNumberWithSuffix).toEqual('102-19Z');
       expect(result.caseTitle).toEqual('Janie and Jackie Petitioner, ');
     });
+
+    it('does NOT display dateRecieved and electronicallyFiled when the coversheet is being generated for a court issued document', () => {
+      const result = generateCoverSheetData({
+        applicationContext,
+        caseEntity: {
+          ...caseData,
+          caseCaption: 'Janie Petitioner, Petitioner',
+          docketNumberSuffix: 'S',
+          initialCaption: 'Janie and Jackie Petitioner, Petitioners',
+          initialDocketNumberSuffix: 'Z',
+        },
+        documentEntity: {
+          ...testingCaseData.documents[0],
+          addToCoversheet: true,
+          additionalInfo: 'Additional Info Something',
+          certificateOfService: true,
+          documentId: 'b6b81f4d-1e47-423a-8caf-6d2fdc3d3858',
+          documentType:
+            'Motion for Entry of Order that Undenied Allegations be Deemed Admitted Pursuant to Rule 37(c)',
+          eventCode: 'USCA',
+          isPaper: false,
+          lodged: true,
+        },
+        useInitialData: true,
+      });
+
+      expect(result.dateReceived).toBeUndefined();
+      expect(result.electronicallyFiled).toBeUndefined();
+    });
   });
 });

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -759,7 +759,7 @@ describe('addCoversheetInteractor', () => {
       expect(result.caseTitle).toEqual('Janie and Jackie Petitioner, ');
     });
 
-    it('does NOT display dateRecieved, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', () => {
+    it('does NOT display dateReceived, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', () => {
       const result = generateCoverSheetData({
         applicationContext,
         caseEntity: {

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -759,7 +759,7 @@ describe('addCoversheetInteractor', () => {
       expect(result.caseTitle).toEqual('Janie and Jackie Petitioner, ');
     });
 
-    it('does NOT display dateRecieved and electronicallyFiled when the coversheet is being generated for a court issued document', () => {
+    it('does NOT display dateRecieved, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', () => {
       const result = generateCoverSheetData({
         applicationContext,
         caseEntity: {
@@ -780,12 +780,14 @@ describe('addCoversheetInteractor', () => {
           eventCode: 'USCA',
           isPaper: false,
           lodged: true,
+          servedAt: '2019-04-20T14:45:15.595Z',
         },
         useInitialData: true,
       });
 
       expect(result.dateReceived).toBeUndefined();
       expect(result.electronicallyFiled).toBeUndefined();
+      expect(result.dateServed).toBeUndefined();
     });
   });
 });

--- a/shared/src/business/utilities/documentGenerators.test.js
+++ b/shared/src/business/utilities/documentGenerators.test.js
@@ -203,6 +203,32 @@ describe('documentGenerators', () => {
       expect(applicationContext.getNodeSass).toHaveBeenCalled();
       expect(applicationContext.getPug).toHaveBeenCalled();
     });
+
+    it('Generates a CoverSheet document for court issued documents that require a coversheet', async () => {
+      const pdf = await coverSheet({
+        applicationContext,
+        data: {
+          caseCaptionExtension: PARTY_TYPES.petitioner,
+          caseTitle: 'Test Person',
+          dateFiledLodged: '01/01/20',
+          dateFiledLodgedLabel: 'Filed',
+          docketNumberWithSuffix: '123-45S',
+          documentTitle: 'Petition',
+        },
+      });
+
+      // Do not write PDF when running on CircleCI
+      if (process.env.PDF_OUTPUT) {
+        writePdfFile('CourtIssuedDocumentCoverSheet', pdf);
+        expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
+      }
+
+      expect(
+        applicationContext.getUseCases().generatePdfFromHtmlInteractor,
+      ).toHaveBeenCalled();
+      expect(applicationContext.getNodeSass).toHaveBeenCalled();
+      expect(applicationContext.getPug).toHaveBeenCalled();
+    });
   });
 
   describe('docketRecord', () => {

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.jsx
@@ -19,10 +19,14 @@ export const CoverSheet = ({
           <div className="width-half float-left">
             <div className="us-tax-court-seal"></div>
           </div>
-          <div className="width-half float-right" id="date-received">
-            <b>Received</b>
-            <br />
-            {dateReceived}
+          <div className="width-half float-right">
+            {dateReceived && (
+              <div id="date-received">
+                <b>Received</b>
+                <br />
+                {dateReceived}
+              </div>
+            )}
           </div>
           <div className="clear"></div>
         </div>

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.test.js
@@ -22,12 +22,19 @@ describe('CoverSheet', () => {
     );
   });
 
-  it('renders the received date', () => {
+  it('renders the received date when received date is available', () => {
     const wrapper = shallow(<CoverSheet dateReceived="01/01/2020" />);
     const text = wrapper.find('#date-received').text();
 
     expect(text).toContain('Received');
     expect(text).toContain('01/01/2020');
+  });
+
+  it('does not render the received date when it is not available', () => {
+    const wrapper = shallow(<CoverSheet />);
+    const dateReceivedDiv = wrapper.find('#date-received');
+
+    expect(dateReceivedDiv).toEqual({});
   });
 
   it('renders a filed or lodged label along with the associated date', () => {


### PR DESCRIPTION
- Populate case caption, docket number, document title and filed date
- Don't need received date; doesn't need "electronically filed" or paper icon on docket record
- Doesn't need served stamp

![image](https://user-images.githubusercontent.com/20249233/87173889-40b3f680-c28b-11ea-9dcb-d9d2d1a40080.png)
