### PR TITLE
honeybadger error fixes

### DIFF
--- a/shared/src/persistence/elasticsearch/getIndexNameForRecord.js
+++ b/shared/src/persistence/elasticsearch/getIndexNameForRecord.js
@@ -9,7 +9,7 @@ exports.getIndexNameForRecord = record => {
   ];
 
   const isRecordOfType = (record, type) => {
-    if (record.entityName && record.entityName.S) {
+    if (record && record.entityName && record.entityName.S) {
       if (type === 'User' && userEntityNames.includes(record.entityName.S)) {
         return true;
       }

--- a/shared/src/persistence/elasticsearch/getIndexNameForRecord.test.js
+++ b/shared/src/persistence/elasticsearch/getIndexNameForRecord.test.js
@@ -2,10 +2,14 @@ const { getIndexNameForRecord } = require('./getIndexNameForRecord');
 
 describe('getIndexNameForRecord', () => {
   it('returns null as a default', () => {
-    const record = {};
+    let record, result;
 
-    const result = getIndexNameForRecord(record);
+    record = undefined;
+    result = getIndexNameForRecord(record);
+    expect(result).toEqual(null);
 
+    record = {};
+    result = getIndexNameForRecord(record);
     expect(result).toEqual(null);
   });
 

--- a/web-client/src/presenter/actions/chooseWorkQueueAction.js
+++ b/web-client/src/presenter/actions/chooseWorkQueueAction.js
@@ -1,15 +1,20 @@
 import { state } from 'cerebral';
 
+const DEFAULT_QUEUE_PREFS = {
+  box: 'inbox',
+  queue: 'my',
+  workQueueIsInternal: true,
+};
 /**
  * Used for changing which work queue (myself, section) and box (inbox, outbox).
  *
  * @param {object} providers the providers object
- * @param {object} providers.store the cerebral store object used for setting workQueueToDisplay
+ * @param {Function} providers.get the cerebral get function
+ * @param {object} providers.path the next object in the path (this is defined in the sequence right after this action is invoked)
  * @param {object} providers.props the cerebral props object
  * @param {object} providers.props.queue the queue to display
  * @param {object} providers.props.box the inbox / output in the queue to display
- * @param {object} providers.path the next object in the path (this is defined in the sequence right after this action is invoked)
- * @param {Function} providers.get the cerebral get function
+ * @param {object} providers.store the cerebral store object used for setting workQueueToDisplay
  * @returns {*} returns the next action in the sequence's path
  */
 export const chooseWorkQueueAction = ({ get, path, props, store }) => {
@@ -28,8 +33,11 @@ export const chooseWorkQueueAction = ({ get, path, props, store }) => {
     store.set(state.workQueueToDisplay.box, props.box);
   }
 
-  const defaultQueue = { box: 'inbox', queue: 'my', workQueueIsInternal: true };
-  const queuePrefs = { ...defaultQueue, ...get(state.workQueueToDisplay) };
+  const queuePrefs = {
+    ...DEFAULT_QUEUE_PREFS,
+    ...get(state.workQueueToDisplay),
+  };
+
   let workQueuePath = `${
     queuePrefs.workQueueIsInternal ? 'messages' : 'documentqc'
   }${queuePrefs.queue}${queuePrefs.box}`;

--- a/web-client/src/presenter/actions/chooseWorkQueueAction.js
+++ b/web-client/src/presenter/actions/chooseWorkQueueAction.js
@@ -28,7 +28,8 @@ export const chooseWorkQueueAction = ({ get, path, props, store }) => {
     store.set(state.workQueueToDisplay.box, props.box);
   }
 
-  let queuePrefs = get(state.workQueueToDisplay);
+  const defaultQueue = { box: 'inbox', queue: 'my', workQueueIsInternal: true };
+  const queuePrefs = { ...defaultQueue, ...get(state.workQueueToDisplay) };
   let workQueuePath = `${
     queuePrefs.workQueueIsInternal ? 'messages' : 'documentqc'
   }${queuePrefs.queue}${queuePrefs.box}`;

--- a/web-client/src/presenter/actions/chooseWorkQueueAction.test.js
+++ b/web-client/src/presenter/actions/chooseWorkQueueAction.test.js
@@ -1,0 +1,59 @@
+import { chooseWorkQueueAction } from './chooseWorkQueueAction';
+import { runAction } from 'cerebral/test';
+
+describe('chooseWorkQueueAction', () => {
+  let providers;
+  beforeAll(() => {
+    providers = {
+      path: {
+        documentqcmycardboard: jest.fn(),
+        documentqcmyoutbox: jest.fn(),
+        messagesmyinbox: jest.fn(),
+        messagessomethinginbox: jest.fn(),
+      },
+    };
+  });
+  it('sets the workQueueIsInternal to value from props if provided and executes default work queue path', async () => {
+    const result = await runAction(chooseWorkQueueAction, {
+      props: {
+        workQueueIsInternal: true,
+      },
+      providers,
+      state: {},
+    });
+
+    expect(result.state.workQueueToDisplay.workQueueIsInternal).toEqual(true);
+    expect(providers.path.messagesmyinbox).toHaveBeenCalled();
+  });
+
+  it('combines provided props.queue with defaults to select correct work queue path', async () => {
+    const result = await runAction(chooseWorkQueueAction, {
+      props: {
+        queue: 'something',
+      },
+      providers,
+      state: {},
+    });
+
+    expect(result.state.workQueueToDisplay.queue).toEqual('something');
+    expect(providers.path.messagessomethinginbox).toHaveBeenCalled();
+  });
+
+  it('combines provided props.box with defaults and state to select correct work queue path', async () => {
+    const result = await runAction(chooseWorkQueueAction, {
+      props: {
+        box: 'cardboard',
+      },
+      providers,
+      state: {
+        workQueueToDisplay: {
+          box: 'something',
+          workQueueIsInternal: false,
+        },
+      },
+    });
+
+    expect(result.state.workQueueToDisplay.box).toEqual('cardboard');
+    expect(providers.path.documentqcmycardboard).toHaveBeenCalled();
+  });
+});

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -43,7 +43,7 @@ exports.handler = (event, context, callback) => {
     "manifest-src 'self'",
     `form-action ${applicationUrl}`,
     "object-src 'none'",
-    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${dynamsoftUrl} resource://pdf.js`,
+    `script-src 'self' 'unsafe-inline' ${dynamsoftUrl} resource://pdf.js`,
     `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
     `img-src ${applicationUrl} data:`,
     `font-src ${applicationUrl}`,

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -40,6 +40,7 @@ exports.handler = (event, context, callback) => {
     'base-uri resource://pdf.js',
     `connect-src ${applicationUrl} ${cognitoUrl} ${s3Url} ${dynamsoftUrl} ${localUrl} ${websocketUrl} ${localWebsocketUrl} ${honeybadgerApiUrl}`,
     "default-src 'none'",
+    "manifest-src 'self'",
     `form-action ${applicationUrl}`,
     "object-src 'none'",
     `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${dynamsoftUrl} resource://pdf.js`,

--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -42,7 +42,7 @@ exports.handler = (event, context, callback) => {
     "default-src 'none'",
     `form-action ${applicationUrl}`,
     "object-src 'none'",
-    `script-src 'self' 'unsafe-inline' ${dynamsoftUrl} resource://pdf.js`,
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${dynamsoftUrl} resource://pdf.js`,
     `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
     `img-src ${applicationUrl} data:`,
     `font-src ${applicationUrl}`,


### PR DESCRIPTION
[deleted block about CSP and `unsafe-eval`]

These changes address errors I've seen in the browser; refusal to load `site.manifest`, work queue state variables unset which result in `messages` page being blank, and then one not in the browser -- a missing null-check.
