### PR TITLE
Adding `blob:` sources to frame src policy

### DIFF
--- a/web-client/terraform/common/cloudfront-edge/index.js
+++ b/web-client/terraform/common/cloudfront-edge/index.js
@@ -47,7 +47,7 @@ exports.handler = (event, context, callback) => {
     `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
     `img-src ${applicationUrl} data:`,
     `font-src ${applicationUrl}`,
-    `frame-src ${s3Url}`,
+    `frame-src ${s3Url} blob:`,
     "frame-ancestors 'none'",
   ];
   headers['content-security-policy'] = [


### PR DESCRIPTION
addresses bug seen in dev -- when attempting to "add docket entry" from actions menu and selecting "upload document".

![Screen Shot 2020-07-13 at 10 29 41 AM](https://user-images.githubusercontent.com/2445917/87323118-f6817e00-c4f3-11ea-9e06-cf2e7e08ceaa.png)
