### PR TITLE
Upgrade to latest pdfjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,11 +1251,14 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -6661,7 +6664,7 @@
         "listr": "0.14.3",
         "lodash": "4.17.15",
         "log-symbols": "3.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "1.2.5",
         "moment": "2.26.0",
         "ospath": "1.2.2",
         "pretty-bytes": "5.3.0",
@@ -6696,7 +6699,10 @@
           "dev": true
         },
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "moment": {
           "version": "2.26.0",
@@ -10254,7 +10260,10 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -14131,7 +14140,10 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -14425,19 +14437,23 @@
           "dev": true
         },
         "minimist": {
-          "dev": true,
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
-              "version": "^1.2.5"
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
             }
           }
         },
@@ -15316,11 +15332,14 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.0"
           },
           "dependencies": {
             "minimist": {
-              "version": "^1.2.5"
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
             }
           }
         }
@@ -16048,7 +16067,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.1.3",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -16080,7 +16099,10 @@
           }
         },
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
@@ -16270,10 +16292,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "dev": true,
-      "version": "^1.2.5"
-    },
     "minimist-options": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
@@ -16348,7 +16366,10 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -16551,12 +16572,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "dev": true
-    },
-    "node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=",
       "dev": true
     },
     "node-fetch": {
@@ -18210,11 +18225,14 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.0"
           },
           "dependencies": {
             "minimist": {
-              "version": "^1.2.5"
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
             }
           }
         },
@@ -18662,14 +18680,10 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.3.200",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.3.200.tgz",
-      "integrity": "sha512-+8wBjU5h8LPZOIvR9X2uCrp/8xWQG1DRDKMLg5lzGN1qyIAZlYUxA0KQyy12Nw5jN7ozulC6v97PMaDcLgAcFg==",
-      "dev": true,
-      "requires": {
-        "node-ensure": "^0.0.0",
-        "worker-loader": "^2.0.0"
-      }
+      "version": "2.5.207",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz",
+      "integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw==",
+      "dev": true
     },
     "pend": {
       "version": "1.2.0",
@@ -20486,12 +20500,15 @@
       "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.1.3",
         "through2": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -20571,12 +20588,15 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -21520,12 +21540,15 @@
         "execa": "^1.0.0",
         "fb-watchman": "^2.0.0",
         "micromatch": "^3.1.4",
-        "minimist": "^1.2.5",
+        "minimist": "^1.1.1",
         "walker": "~1.0.5"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -21677,16 +21700,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "schema-utils": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-      "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0"
       }
     },
     "scss-tokenizer": {
@@ -24104,7 +24117,7 @@
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
@@ -24114,16 +24127,22 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.0"
           },
           "dependencies": {
             "minimist": {
-              "version": "^1.2.5"
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
             }
           }
         },
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -25538,16 +25557,6 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
-      }
-    },
-    "worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "parcel-plugin-bundle-visualiser": "^1.2.0",
     "parcel-plugin-static-files-copy": "^2.4.3",
     "pdf-lib": "^1.8.0",
-    "pdfjs-dist": "2.3.200",
+    "pdfjs-dist": "^2.5.207",
     "pixelmatch": "^5.2.1",
     "pngjs": "^5.0.0",
     "prettier": "^2.0.4",

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1193,9 +1193,10 @@ module.exports = appContextUser => {
     getNotificationGateway: () => ({
       sendNotificationToUser,
     }),
-    getPdfJs: () => {
-      const pdfjsLib = require('pdfjs-dist');
-      pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
+    getPdfJs: async () => {
+      const pdfjsLib = require('pdfjs-dist/es5/build/pdf.js');
+      pdfjsLib.disableWorker = true;
+
       return pdfjsLib;
     },
     getPdfLib: () => {

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -492,7 +492,8 @@ const applicationContext = {
   getHttpClient: () => axios,
   getPdfJs: async () => {
     const pdfjsLib = await import('pdfjs-dist');
-    pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
+    const pdfjsWorker = await import('pdfjs-dist/build/pdf.worker.entry');
+    pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
     return pdfjsLib;
   },
   getPdfLib: () => {


### PR DESCRIPTION
This has been a bit of a thorny problem for a number of reasons.

Changes under the hood with this library broke the configuration (as we were implementing it). Most of the issues revolve around the worker. It appears this has been addressed with some webpack specific config, but it doesn't help us mutch. It still has trouble properly loading the worker on the frontend and claims to fall back to the "fake worker" - though everything is working as expected.

As far as the backend, numerous permutations were attempted in regards to configuring the worker, but disabling ended up being the thing that made everything work. Theoretically there is a an impact to speed without the worker, but I'm unsure if we ever got any of the benefits on the node side anyway.

It _appears_ there are also some additional config options for setting web workers in parcel 2 that we could explore, but that's a whole other can of worms.