### PR TITLE
Ux pain points

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14450,9 +14450,9 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "swagger-cli": "^4.0.3",
     "tmp": "^0.2.1",
     "umzug": "^2.3.0",
-    "uswds": "^2.7.1",
+    "uswds": "^2.8.0",
     "uuid": "^8.2.0",
     "webpack": "^4.42.1",
     "websocket": "^1.0.31",
@@ -247,5 +247,10 @@
   },
   "resolutions": {
     "minimist": "^1.2.5"
+  },
+  "postcss": {
+    "plugins": {
+      "autoprefixer": {}
+    }
   }
 }

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
@@ -28,7 +28,7 @@ const RenderAddress = ({ contact, countryTypes }) => {
 const RenderContact = ({ contact, countryTypes }) => {
   return (
     <div className="party-details">
-      <p>{contact.name}</p>
+      <p className="margin-bottom-0">{contact.name}</p>
       <RenderAddress contact={contact} countryTypes={countryTypes} />
     </div>
   );
@@ -47,7 +47,9 @@ const RenderPractitioner = ({
 
   return (
     <div className="party-details">
-      <p>{practitioner.formattedName || practitioner.name}</p>
+      <p className="margin-bottom-0">
+        {practitioner.formattedName || practitioner.name}
+      </p>
       <RenderAddress
         contact={{
           ...practitioner.contact,

--- a/web-client/src/views/CaseDetail/AddressDisplay.jsx
+++ b/web-client/src/views/CaseDetail/AddressDisplay.jsx
@@ -21,12 +21,7 @@ export const AddressDisplay = connect(
   }) {
     return (
       <>
-        <p
-          className={classNames(
-            noMargin ? 'no-margin' : 'margin-top-0',
-            'address-name',
-          )}
-        >
+        <p className="no-margin">
           {nameOverride || contact.name}{' '}
           {contact.barNumber && `(${contact.barNumber})`}
           {contact.secondaryName && (
@@ -43,7 +38,7 @@ export const AddressDisplay = connect(
             </span>
           )}
         </p>
-        <p className={classNames(noMargin && 'no-margin')}>
+        <p className="no-margin">
           <span className="address-line">{contact.address1}</span>
           {contact.address2 && (
             <span className="address-line">{contact.address2}</span>

--- a/web-client/src/views/CaseDetail/OtherPetitionerDisplay.jsx
+++ b/web-client/src/views/CaseDetail/OtherPetitionerDisplay.jsx
@@ -11,13 +11,12 @@ const OtherPetitionerDisplay = connect(
   function OtherPetitionerDisplay({ constants, petitioner }) {
     return (
       <>
-        <p className="margin-top-0 address-name">
+        <p className="no-margin address-name">
           {petitioner.name}
-          <br />
-          {petitioner.secondaryName}
+          {petitioner.secondaryName && <div>{petitioner.secondaryName}</div>}
           {petitioner.title && <span>, {petitioner.title}</span>}
         </p>
-        <p>
+        <p className="margin-top-0">
           <span className="address-line">{petitioner.address1}</span>
           {petitioner.address2 && (
             <span className="address-line">{petitioner.address2}</span>


### PR DESCRIPTION
- Add autoprefixer config in package.json to address vendor prefixes missing from uswds styles.
<img width="194" alt="Screen Shot 2020-07-14 at 1 00 33 PM" src="https://user-images.githubusercontent.com/1891789/87465822-81d14100-c5d2-11ea-99e1-83a3f24a1eca.png">
<img width="353" alt="Screen Shot 2020-07-14 at 1 00 50 PM" src="https://user-images.githubusercontent.com/1891789/87465827-8564c800-c5d2-11ea-96ac-f10df0249d08.png">



- Remove space between party name and address
### Petitioner Information ###
<img width="368" alt="Screen Shot 2020-07-14 at 1 00 09 PM" src="https://user-images.githubusercontent.com/1891789/87465905-9dd4e280-c5d2-11ea-9069-b9230100a1ff.png">

### Other Petitioners ###
<img width="614" alt="Screen Shot 2020-07-14 at 1 00 15 PM" src="https://user-images.githubusercontent.com/1891789/87465965-b7762a00-c5d2-11ea-85fd-49c20ec2476f.png">

### Printable Docket Record ###
<img width="298" alt="Screen Shot 2020-07-14 at 1 00 25 PM" src="https://user-images.githubusercontent.com/1891789/87466017-cd83ea80-c5d2-11ea-897e-3913514c381f.png">
