### PR TITLE
Add some HB logging for pdf scraping fails

### DIFF
--- a/shared/src/business/utilities/scrapePdfContents.js
+++ b/shared/src/business/utilities/scrapePdfContents.js
@@ -7,8 +7,12 @@ const { isEmpty } = require('lodash');
  * @returns {Promise} the template with the brackets replaced with replacement values
  */
 const scrapePdfContents = async ({ applicationContext, pdfBuffer }) => {
+  let pdfjsVersion;
+
   try {
     const pdfjsLib = await applicationContext.getPdfJs();
+    pdfjsVersion = pdfjsLib && pdfjsLib.version;
+
     const document = await pdfjsLib.getDocument(pdfBuffer).promise;
 
     let scrapedText = '';
@@ -39,6 +43,7 @@ const scrapePdfContents = async ({ applicationContext, pdfBuffer }) => {
 
     return scrapedText;
   } catch (e) {
+    await applicationContext.notifyHoneybadger(e, { pdfjsVersion });
     throw new Error('error scraping PDF');
   }
 };


### PR DESCRIPTION
There is an error being thrown while trying to scrape pdf contents on an uploaded pdf document in `dev`. With the actual error being suppressed, it's hard to tell what's actually going on, and it isn't reproducible locally. I'd like to see what the error is before downgrading back to the previous version of `pdf.js`.