### PR TITLE
4295 - the processed link was not previewing the correct document

### DIFF
--- a/web-client/src/presenter/actions/getDefaultAttachmentViewerDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/getDefaultAttachmentViewerDocumentToDisplayAction.test.js
@@ -30,7 +30,7 @@ describe('getDefaultAttachmentViewerDocumentToDisplayAction', () => {
       },
     );
     expect(result.output).toEqual({
-      viewerDocumentToDisplay: undefined,
+      viewerDocumentToDisplay: null,
     });
   });
 });

--- a/web-client/src/presenter/actions/getDefaultAttachmentViewerDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/getDefaultAttachmentViewerDocumentToDisplayAction.test.js
@@ -30,7 +30,7 @@ describe('getDefaultAttachmentViewerDocumentToDisplayAction', () => {
       },
     );
     expect(result.output).toEqual({
-      viewerDocumentToDisplay: null,
+      viewerDocumentToDisplay: undefined,
     });
   });
 });

--- a/web-client/src/presenter/actions/getDefaultDocketViewerDocumentToDisplayAction.js
+++ b/web-client/src/presenter/actions/getDefaultDocketViewerDocumentToDisplayAction.js
@@ -6,17 +6,18 @@ import { state } from 'cerebral';
  *
  * @param {object} providers the providers object
  * @param {Function} providers.get the cerebral get method
- * @param {object} providers.props the cerebral props object
  * @returns {object} object containing viewerDocumentToDisplay
  */
 export const getDefaultDocketViewerDocumentToDisplayAction = ({
   applicationContext,
   get,
-  props,
 }) => {
-  const { documentId } = props;
+  const documentId = get(state.documentId);
+  let viewerDocumentToDisplay = null;
 
-  let viewerDocumentToDisplay = get(state.viewerDocumentToDisplay) || null;
+  if (!documentId) {
+    viewerDocumentToDisplay = get(state.viewerDocumentToDisplay);
+  }
 
   if (viewerDocumentToDisplay) return { viewerDocumentToDisplay };
 

--- a/web-client/src/presenter/actions/getDefaultDocketViewerDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/getDefaultDocketViewerDocumentToDisplayAction.test.js
@@ -108,18 +108,17 @@ describe('getDefaultDocketViewerDocumentToDisplayAction', () => {
       },
     );
     expect(result.output).toEqual({
-      viewerDocumentToDisplay: null,
+      viewerDocumentToDisplay: undefined,
     });
   });
 
-  it('returns the correct docket record entry if props.documentId is set', async () => {
+  it('returns the correct docket record entry if state.documentId is set', async () => {
     const result = await runAction(
       getDefaultDocketViewerDocumentToDisplayAction,
       {
         modules: {
           presenter,
         },
-        props: { documentId: '234' },
         state: {
           caseDetail: {
             docketRecord: [
@@ -144,6 +143,7 @@ describe('getDefaultDocketViewerDocumentToDisplayAction', () => {
               },
             ],
           },
+          documentId: '234',
         },
       },
     );

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -18,6 +18,7 @@ import { setConsolidatedCasesForCaseAction } from '../actions/caseConsolidation/
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setDefaultCaseDetailTabAction } from '../actions/setDefaultCaseDetailTabAction';
 import { setDefaultDocketRecordSortAction } from '../actions/DocketRecord/setDefaultDocketRecordSortAction';
+import { setDocumentIdAction } from '../actions/setDocumentIdAction';
 import { setIsPrimaryTabAction } from '../actions/setIsPrimaryTabAction';
 import { setJudgesCaseNoteOnCaseDetailAction } from '../actions/TrialSession/setJudgesCaseNoteOnCaseDetailAction';
 import { showModalFromQueryAction } from '../actions/showModalFromQueryAction';
@@ -27,6 +28,7 @@ import { takePathForRoles } from './takePathForRoles';
 const { USER_ROLES } = getConstants();
 
 const gotoCaseDetailInternal = [
+  setDocumentIdAction,
   showModalFromQueryAction,
   getCaseDeadlinesForCaseAction,
   getCaseMessagesForCaseAction,
@@ -40,6 +42,7 @@ const gotoCaseDetailExternal = [
 ];
 
 const gotoCaseDetailInternalWithNotes = [
+  setDocumentIdAction,
   getJudgesCaseNoteForCaseAction,
   setJudgesCaseNoteOnCaseDetailAction,
   gotoCaseDetailInternal,


### PR DESCRIPTION
- Clicking the processed work item link would redirect you to the case detail -> document viewer tab, but the incorrect document would be displayed.  This PR instead sets the documentId onto state and uses that to figure out which document to display in the viewer.