### PR TITLE
5811 DoD button a11y

### DIFF
--- a/web-client/src/ustc-ui/Button/Button.jsx
+++ b/web-client/src/ustc-ui/Button/Button.jsx
@@ -11,6 +11,7 @@ export const Button = props => {
     iconColor, // e.g. blue
     iconRight = false,
     iconSize = '1x',
+    isActive = false,
     link,
     marginDirection = 'right',
     overrideMargin = false,
@@ -19,7 +20,11 @@ export const Button = props => {
     ...remainingProps
   } = props;
 
-  const Element = href ? 'a' : 'button';
+  const isLink = Boolean(href);
+  const Element = isLink ? 'a' : 'button';
+  if (isActive && !isLink && remainingProps['aria-pressed'] === undefined) {
+    remainingProps['aria-pressed'] = true;
+  }
 
   const classes = classNames(
     className,

--- a/web-client/src/views/DocketRecord/DocumentViewer.jsx
+++ b/web-client/src/views/DocketRecord/DocumentViewer.jsx
@@ -39,6 +39,7 @@ export const DocumentViewer = connect(
                         'usa-button--unstyled attachment-viewer-button',
                         viewDocumentId === entry.documentId && 'active',
                       )}
+                      isActive={viewDocumentId === entry.documentId}
                       key={idx}
                       onClick={() => {
                         setViewerDocumentToDisplaySequence({

--- a/web-client/src/views/DocketRecord/DraftDocumentViewer.jsx
+++ b/web-client/src/views/DocketRecord/DraftDocumentViewer.jsx
@@ -40,6 +40,10 @@ export const DraftDocumentViewer = connect(
                         viewerDraftDocumentIdToDisplay ===
                           draftDocument.documentId && 'active',
                       )}
+                      isActive={
+                        viewerDraftDocumentIdToDisplay ===
+                        draftDocument.documentId
+                      }
                       key={index}
                       onClick={() => {
                         setViewerDraftDocumentToDisplaySequence({

--- a/web-client/src/views/Messages/MessageDetail.jsx
+++ b/web-client/src/views/Messages/MessageDetail.jsx
@@ -222,6 +222,7 @@ export const MessageDetail = connect(
                           'usa-button--unstyled attachment-viewer-button',
                           viewerDocumentToDisplay === attachment && 'active',
                         )}
+                        isActive={viewerDocumentToDisplay === attachment}
                         key={idx}
                         onClick={() => {
                           setViewerDocumentToDisplaySequence({


### PR DESCRIPTION
Adding `aria-pressed="true"` to `Button` components which render as `button` elements in the capacity of "toggle-buttons". This will help SR users determine which of a list of buttons is actually the active one.