### PR TITLE
Husky pre-commit for entity docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,10 @@
     "*.{css,scss}": [
       "stylelint"
     ],
+    "**/entities/**/*.js": [
+      "npm run build:entity:docs",
+      "git add **/*md"
+    ],
     "swagger.json": [
       "swagger-cli validate"
     ]


### PR DESCRIPTION
The proof is in the pudding.
If this works correctly, any changes to entity JS files will trigger rebuild of markdown, and any updated files will get added to your current commit.