### PR TITLE
650: trello case id to docket number / serveToIrs

### DIFF
--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
@@ -66,10 +66,13 @@ exports.deleteStinIfAvailable = async ({ applicationContext, caseEntity }) => {
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {string} providers.caseId the id of the case
+ * @param {string} providers.docketNumber the docket number of the case
  * @returns {Buffer} paper service pdf if the case is a paper case
  */
-exports.serveCaseToIrsInteractor = async ({ applicationContext, caseId }) => {
+exports.serveCaseToIrsInteractor = async ({
+  applicationContext,
+  docketNumber,
+}) => {
   const user = applicationContext.getCurrentUser();
 
   if (!isAuthorized(user, ROLE_PERMISSIONS.UPDATE_CASE)) {
@@ -78,9 +81,9 @@ exports.serveCaseToIrsInteractor = async ({ applicationContext, caseId }) => {
 
   const caseToBatch = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId: caseId,
+      docketNumber,
     });
 
   const caseEntity = new Case(caseToBatch, { applicationContext });

--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
@@ -80,7 +80,7 @@ describe('serveCaseToIrsInteractor', () => {
     await expect(
       serveCaseToIrsInteractor({
         applicationContext,
-        caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+        docketNumber: MOCK_CASE.docketNumber,
       }),
     ).rejects.toThrow('Unauthorized');
   });
@@ -100,11 +100,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(mockCase);
+      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     expect(
@@ -127,11 +127,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(MOCK_CASE);
+      .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
 
     await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     expect(
@@ -154,11 +154,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(MOCK_CASE);
+      .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
 
     await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     expect(
@@ -186,11 +186,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(mockCase);
+      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     expect(
@@ -213,11 +213,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(mockCase);
+      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     const result = await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     expect(result).toBeUndefined();
@@ -238,11 +238,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(mockCase);
+      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     const result = await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     expect(result).toBeDefined();
@@ -290,11 +290,11 @@ describe('serveCaseToIrsInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(mockCase);
+      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     const result = await serveCaseToIrsInteractor({
       applicationContext,
-      caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      docketNumber: MOCK_CASE.docketNumber,
     });
 
     const documentWithServedParties = applicationContext

--- a/shared/src/proxies/serveCaseToIrs/serveCaseToIrsProxy.js
+++ b/shared/src/proxies/serveCaseToIrs/serveCaseToIrsProxy.js
@@ -5,12 +5,12 @@ const { post } = require('../requests');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {string} providers.caseId caseId for serving a case
+ * @param {string} providers.docketNumber docket number for serving a case
  * @returns {Promise<*>} the promise of the api call
  */
-exports.serveCaseToIrsInteractor = ({ applicationContext, caseId }) => {
+exports.serveCaseToIrsInteractor = ({ applicationContext, docketNumber }) => {
   return post({
     applicationContext,
-    endpoint: `/cases/${caseId}/serve-to-irs`,
+    endpoint: `/cases/${docketNumber}/serve-to-irs`,
   });
 };

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -633,7 +633,10 @@ app.get(
   '/cases/:caseId/consolidated-cases',
   lambdaWrapper(getConsolidatedCasesByCaseLambda),
 );
-app.post('/cases/:caseId/serve-to-irs', lambdaWrapper(serveCaseToIrsLambda));
+app.post(
+  '/cases/:docketNumber/serve-to-irs',
+  lambdaWrapper(serveCaseToIrsLambda),
+);
 app.put('/cases/:caseId/', lambdaWrapper(saveCaseDetailInternalEditLambda));
 app.get('/cases/:docketNumber', lambdaWrapper(getCaseLambda));
 app.post('/cases', lambdaWrapper(createCaseLambda));

--- a/web-api/src/cases/serveCaseToIrsLambda.js
+++ b/web-api/src/cases/serveCaseToIrsLambda.js
@@ -11,8 +11,8 @@ exports.serveCaseToIrsLambda = event =>
     event,
     async ({ applicationContext }) => {
       return await applicationContext.getUseCases().serveCaseToIrsInteractor({
+        ...event.pathParameters,
         applicationContext,
-        caseId: event.pathParameters.caseId,
       });
     },
     { logResults: false },

--- a/web-client/src/presenter/actions/StartCaseInternal/serveCaseToIrsAction.js
+++ b/web-client/src/presenter/actions/StartCaseInternal/serveCaseToIrsAction.js
@@ -7,7 +7,6 @@ import { state } from 'cerebral';
  * @param {object} providers.applicationContext the application context
  * @param {Function} providers.get the cerebral get helper function
  * @param {object} providers.path the cerebral path which contains the next path in the sequence (path of success or error)
- * @param {object} providers.router the riot.router object that is used for changing the route
  * @param {object} providers.props the cerebral props object
  * @returns {object} the next path based upon if there was any paper service or all electronic service
  */
@@ -17,13 +16,13 @@ export const serveCaseToIrsAction = async ({
   path,
   props,
 }) => {
-  const caseId = props.caseId || get(state.caseDetail.caseId);
+  const docketNumber = props.docketNumber || get(state.caseDetail.docketNumber);
 
   const pdfUrl = await applicationContext
     .getUseCases()
     .serveCaseToIrsInteractor({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   if (pdfUrl) {

--- a/web-client/src/presenter/actions/StartCaseInternal/serveCaseToIrsAction.test.js
+++ b/web-client/src/presenter/actions/StartCaseInternal/serveCaseToIrsAction.test.js
@@ -34,7 +34,7 @@ describe('serveCaseToIrsAction', () => {
       },
       state: {
         caseDetail: {
-          caseId: 'abc-123',
+          docketNumber: '101-19',
         },
       },
     });


### PR DESCRIPTION
targeting just one code path which serves to IRS -- from sequence, action, proxy, lambda, interactor -- all to use docketNumber instead of caseId.