### PR TITLE
Bug fix when editing draft notice

### DIFF
--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.js
@@ -79,8 +79,10 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
       showApplyRemoveSignatureButtonForRole &&
       showApplySignatureButtonForDocument,
     showDocumentNotSignedAlert,
-    showEditButtonNotSigned: showEditButtonForRole && !documentIsSigned,
-    showEditButtonSigned: showEditButtonForRole && documentIsSigned,
+    showEditButtonNotSigned:
+      showEditButtonForRole && (!documentIsSigned || isNotice),
+    showEditButtonSigned:
+      showEditButtonForRole && documentIsSigned && !isNotice,
     showRemoveSignatureButton:
       showApplyRemoveSignatureButtonForRole &&
       showRemoveSignatureButtonForDocument,

--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
@@ -535,6 +535,35 @@ describe('draftDocumentViewerHelper', () => {
     expect(result.showEditButtonSigned).toEqual(false);
   });
 
+  it('return showEditButtonNotSigned true and showEditButtonSigned false for a Notice document', () => {
+    applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
+
+    const result = runCompute(draftDocumentViewerHelper, {
+      state: {
+        ...getBaseState(docketClerkUser),
+        caseDetail: {
+          docketRecord: [],
+          documents: [
+            {
+              documentId: 'abc',
+              documentTitle: 'Notice',
+              documentType: 'NOT',
+              isDraft: true,
+              signedAt: '2020-06-25T20:49:28.192Z',
+            },
+          ],
+        },
+        viewerDraftDocumentToDisplay: {
+          documentId: 'abc',
+          eventCode: 'NOT',
+        },
+      },
+    });
+
+    expect(result.showEditButtonNotSigned).toEqual(true);
+    expect(result.showEditButtonSigned).toEqual(false);
+  });
+
   it('should return showDocumentNotSignedAlert false if document is not signed and the event code does not require a signature', () => {
     const result = runCompute(draftDocumentViewerHelper, {
       state: {

--- a/web-client/src/presenter/computeds/messageDocumentHelper.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.js
@@ -109,9 +109,14 @@ export const messageDocumentHelper = (get, applicationContext) => {
       showApplySignatureButtonForDocument,
     showDocumentNotSignedAlert,
     showEditButtonNotSigned:
-      showEditButtonForRole && showEditButtonForDocument && !documentIsSigned,
+      showEditButtonForRole &&
+      showEditButtonForDocument &&
+      (!documentIsSigned || isNotice),
     showEditButtonSigned:
-      showEditButtonForRole && showEditButtonForDocument && documentIsSigned,
+      showEditButtonForRole &&
+      showEditButtonForDocument &&
+      documentIsSigned &&
+      !isNotice,
     showEditCorrespondenceButton:
       showEditButtonForRole && showEditButtonForCorrespondenceDocument,
     showNotServed,

--- a/web-client/src/presenter/computeds/messageDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.test.js
@@ -667,6 +667,40 @@ describe('messageDocumentHelper', () => {
     expect(result.showEditButtonSigned).toEqual(false);
   });
 
+  it('return showEditButtonNotSigned true and showEditButtonSigned false for Notice document', () => {
+    applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
+
+    const result = runCompute(messageDocumentHelper, {
+      state: {
+        ...getBaseState(docketClerkUser),
+        caseDetail: {
+          correspondence: [],
+          docketRecord: [
+            {
+              documentId: '123',
+            },
+          ],
+          documents: [
+            {
+              documentId: '123',
+              entityName: 'Document',
+              eventCode: 'NOT',
+              isDraft: true,
+              signedAt: '2020-06-25T20:49:28.192Z',
+            },
+          ],
+        },
+        viewerDocumentToDisplay: {
+          documentId: '123',
+          eventCode: 'NOT',
+        },
+      },
+    });
+
+    expect(result.showEditButtonNotSigned).toEqual(true);
+    expect(result.showEditButtonSigned).toEqual(false);
+  });
+
   it('return showEditCorrespondenceButton true for a correspondence document', () => {
     applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
 


### PR DESCRIPTION
Because the Notice is implicitly signed by CotC, we don't need to use the remove signature flow.