### PR TITLE
Bug fix: trial session planning report term

### DIFF
--- a/shared/src/business/useCases/trialSessions/runTrialSessionPlanningReportInteractor.js
+++ b/shared/src/business/useCases/trialSessions/runTrialSessionPlanningReportInteractor.js
@@ -17,8 +17,11 @@ const getPreviousTerm = (currentTerm, currentYear) => {
   const termsReversed = terms.reverse();
   const termI = terms.findIndex(t => `${currentTerm} ${currentYear}` === t);
   const [term, year] = termsReversed[termI + 1].split(' ');
+
+  const termDisplay = `${capitalize(term)} ${year}`;
   return {
     term,
+    termDisplay,
     year,
   };
 };

--- a/shared/src/business/useCases/trialSessions/runTrialSessionPlanningReportInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/runTrialSessionPlanningReportInteractor.test.js
@@ -168,15 +168,27 @@ describe('run trial session planning report', () => {
   describe('get previous term', () => {
     it('returns previous term and previous year if the previous term is winter', () => {
       const result = getPreviousTerm('winter', '2020');
-      expect(result).toEqual({ term: 'fall', year: '2019' });
+      expect(result).toEqual({
+        term: 'fall',
+        termDisplay: 'Fall 2019',
+        year: '2019',
+      });
     });
     it('returns previous term and same year if the previous term is fall', () => {
       const result = getPreviousTerm('fall', '2020');
-      expect(result).toEqual({ term: 'spring', year: '2020' });
+      expect(result).toEqual({
+        term: 'spring',
+        termDisplay: 'Spring 2020',
+        year: '2020',
+      });
     });
     it('returns previous term and same year if the previous term is spring', () => {
       const result = getPreviousTerm('spring', '2020');
-      expect(result).toEqual({ term: 'winter', year: '2020' });
+      expect(result).toEqual({
+        term: 'winter',
+        termDisplay: 'Winter 2020',
+        year: '2020',
+      });
     });
   });
 });

--- a/shared/src/business/utilities/documentGenerators.test.js
+++ b/shared/src/business/utilities/documentGenerators.test.js
@@ -811,15 +811,18 @@ describe('documentGenerators', () => {
           ],
           previousTerms: [
             {
-              name: 'Fall',
+              name: 'fall',
+              termDisplay: 'Fall 2019',
               year: '2019',
             },
             {
-              name: 'Spring',
+              name: 'spring',
+              termDisplay: 'Spring 2019',
               year: '2019',
             },
             {
-              name: 'Winter',
+              name: 'winter',
+              termDisplay: 'Winter 2019',
               year: '2019',
             },
           ],

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/TrialSessionPlanningReport.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/TrialSessionPlanningReport.jsx
@@ -3,11 +3,7 @@ const { PrimaryHeader } = require('../components/PrimaryHeader.jsx');
 const { ReportsHeader } = require('../components/ReportsHeader.jsx');
 
 const getTermHeaders = (termData, idx) => {
-  return (
-    <th key={`th-${idx}`}>
-      {termData.name} {termData.year}
-    </th>
-  );
+  return <th key={`th-${idx}`}>{termData.termDisplay}</th>;
 };
 
 const parseTermData = data =>

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/TrialSessionPlanningReport.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/TrialSessionPlanningReport.test.js
@@ -7,15 +7,18 @@ const { mount } = require('enzyme');
 describe('TrialSessionPlanningReport', () => {
   const previousTerms = [
     {
-      name: 'Fall',
+      name: 'fall',
+      termDisplay: 'Fall 2019',
       year: '2019',
     },
     {
-      name: 'Spring',
+      name: 'spring',
+      termDisplay: 'Spring 2019',
       year: '2019',
     },
     {
-      name: 'Winter',
+      name: 'winter',
+      termDisplay: 'Winter 2019',
       year: '2019',
     },
   ];


### PR DESCRIPTION
https://trello.com/c/wmk1pnSD/703-trial-session-planning-report-not-displaying-past-sessions-correctly

<img width="876" alt="Screen Shot 2020-07-22 at 3 03 52 PM" src="https://user-images.githubusercontent.com/43251054/88234651-20424f80-cc2e-11ea-9808-b1f44d0727ed.png">
