### PR TITLE
Bug fix: increase editState max string length

### DIFF
--- a/docs/entities/DocketRecord.md
+++ b/docs/entities/DocketRecord.md
@@ -59,7 +59,7 @@
         - 
           name: "max"
           args: 
-            limit: 3000
+            limit: 4000
       allow: 
         - null
       metas: 

--- a/shared/src/business/entities/DocketRecord.js
+++ b/shared/src/business/entities/DocketRecord.js
@@ -66,7 +66,7 @@ joiValidationDecorator(
       .description('ID of the associated PDF document in the S3 bucket.'),
     editState: joi
       .string()
-      .max(3000)
+      .max(4000)
       .allow(null)
       .optional()
       .meta({ tags: ['Restricted'] })


### PR DESCRIPTION
https://trello.com/c/Z8xDZmWY/697-some-document-types-can-not-be-created-from-add-docket-entry-action