### PR TITLE
DevEx: use docketNumber instead of caseId 

### DIFF
--- a/shared/src/business/test/fileExternalDocumentInteractor.e2e.test.js
+++ b/shared/src/business/test/fileExternalDocumentInteractor.e2e.test.js
@@ -79,10 +79,9 @@ describe('fileExternalDocumentInteractor integration test', () => {
       ],
       documentMetadata: {
         attachments: false,
-        caseId,
         certificateOfService: false,
         certificateOfServiceDate: '2020-06-12T08:09:45.129Z',
-        docketNumber: '201-19',
+        docketNumber,
         documentTitle: 'Motion for Leave to File Brief in Support of Petition',
         documentType: 'Motion for Leave to File',
         eventCode: 'M115',
@@ -146,7 +145,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
         state: 'AL',
       },
       contactSecondary: {},
-      docketNumber: '101-19',
+      docketNumber,
       docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
       docketRecord: [
         {
@@ -185,7 +184,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
               assigneeId: null,
               assigneeName: null,
               caseStatus: CASE_STATUS_TYPES.new,
-              docketNumber: '101-19',
+              docketNumber,
               docketNumberWithSuffix: '101-19S',
               document: {
                 documentId: '92eac064-9ca5-4c56-80a0-c5852c752277',
@@ -218,7 +217,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
         {
           attachments: false,
           certificateOfService: false,
-          docketNumber: '201-19',
+          docketNumber,
           documentId: '12de0fac-f63c-464f-ac71-0f54fd248484',
           documentTitle:
             'Motion for Leave to File Brief in Support of Petition',
@@ -234,13 +233,13 @@ describe('fileExternalDocumentInteractor integration test', () => {
               assigneeId: null,
               assigneeName: null,
               caseStatus: CASE_STATUS_TYPES.new,
-              docketNumber: '101-19',
+              docketNumber,
               docketNumberWithSuffix: '101-19S',
               document: {
                 attachments: false,
                 certificateOfService: false,
                 certificateOfServiceDate: '2020-06-12T08:09:45.129Z',
-                docketNumber: '201-19',
+                docketNumber,
                 documentId: '12de0fac-f63c-464f-ac71-0f54fd248484',
                 documentTitle:
                   'Motion for Leave to File Brief in Support of Petition',
@@ -280,7 +279,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
               assigneeId: null,
               assigneeName: null,
               caseStatus: CASE_STATUS_TYPES.new,
-              docketNumber: '101-19',
+              docketNumber,
               docketNumberWithSuffix: '101-19S',
               document: {
                 documentId: '22de0fac-f63c-464f-ac71-0f54fd248484',
@@ -322,7 +321,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
               assigneeId: null,
               assigneeName: null,
               caseStatus: CASE_STATUS_TYPES.new,
-              docketNumber: '101-19',
+              docketNumber,
               docketNumberWithSuffix: '101-19S',
               document: {
                 documentId: '32de0fac-f63c-464f-ac71-0f54fd248484',
@@ -365,7 +364,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
               assigneeId: null,
               assigneeName: null,
               caseStatus: CASE_STATUS_TYPES.new,
-              docketNumber: '101-19',
+              docketNumber,
               docketNumberWithSuffix: '101-19S',
               document: {
                 documentId: '42de0fac-f63c-464f-ac71-0f54fd248484',
@@ -434,12 +433,12 @@ describe('fileExternalDocumentInteractor integration test', () => {
         assigneeId: null,
         assigneeName: null,
         caseStatus: CASE_STATUS_TYPES.new,
-        docketNumber: '101-19',
+        docketNumber,
         docketNumberWithSuffix: '101-19S',
         document: {
           attachments: false,
           certificateOfService: false,
-          docketNumber: '201-19',
+          docketNumber,
           documentId: '12de0fac-f63c-464f-ac71-0f54fd248484',
           documentTitle:
             'Motion for Leave to File Brief in Support of Petition',
@@ -465,7 +464,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
         assigneeId: null,
         assigneeName: null,
         caseStatus: CASE_STATUS_TYPES.new,
-        docketNumber: '101-19',
+        docketNumber,
         docketNumberWithSuffix: '101-19S',
         document: {
           documentId: '22de0fac-f63c-464f-ac71-0f54fd248484',
@@ -495,7 +494,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
         assigneeId: null,
         assigneeName: null,
         caseStatus: CASE_STATUS_TYPES.new,
-        docketNumber: '101-19',
+        docketNumber,
         docketNumberWithSuffix: '101-19S',
         document: {
           documentId: '32de0fac-f63c-464f-ac71-0f54fd248484',
@@ -523,7 +522,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
         assigneeId: null,
         assigneeName: null,
         caseStatus: CASE_STATUS_TYPES.new,
-        docketNumber: '101-19',
+        docketNumber,
         docketNumberWithSuffix: '101-19S',
         document: {
           documentId: '42de0fac-f63c-464f-ac71-0f54fd248484',
@@ -553,7 +552,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
   });
 
   it('should set partyPrimary to representingPrimary when partyPrimary is not provided', async () => {
-    const { caseId, docketNumber } = await createCaseInteractor({
+    const { docketNumber } = await createCaseInteractor({
       applicationContext,
       petitionFileId: '92eac064-9ca5-4c56-80a0-c5852c752277',
       petitionMetadata: {
@@ -600,10 +599,9 @@ describe('fileExternalDocumentInteractor integration test', () => {
       ],
       documentMetadata: {
         attachments: false,
-        caseId,
         certificateOfService: false,
         certificateOfServiceDate: '2020-06-12T08:09:45.129Z',
-        docketNumber: '201-19',
+        docketNumber,
         documentTitle: 'Motion for Leave to File Brief in Support of Petition',
         documentType: 'Motion for Leave to File',
         eventCode: 'M115',

--- a/shared/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.js
@@ -36,13 +36,13 @@ exports.fileCourtIssuedDocketEntryInteractor = async ({
     throw new UnauthorizedError('Unauthorized');
   }
 
-  const { caseId, documentId } = documentMeta;
+  const { docketNumber, documentId } = documentMeta;
 
   const caseToUpdate = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   let caseEntity = new Case(caseToUpdate, { applicationContext });

--- a/shared/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.test.js
@@ -26,7 +26,7 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(caseRecord);
+      .getCaseByDocketNumber.mockReturnValue(caseRecord);
 
     caseRecord = {
       caseCaption: 'Caption',
@@ -128,7 +128,7 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
       fileCourtIssuedDocketEntryInteractor({
         applicationContext,
         documentMeta: {
-          caseId: caseRecord.caseId,
+          docketNumber: caseRecord.docketNumber,
           documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335bc',
           documentType: 'Memorandum in Support',
         },
@@ -147,7 +147,7 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
       fileCourtIssuedDocketEntryInteractor({
         applicationContext,
         documentMeta: {
-          caseId: caseRecord.caseId,
+          docketNumber: caseRecord.docketNumber,
           documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335bd',
           documentType: 'Order',
         },
@@ -166,7 +166,7 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
     await fileCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
+        docketNumber: caseRecord.docketNumber,
         documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335ba',
         documentTitle: 'Order',
         documentType: 'Order',
@@ -197,7 +197,7 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
     await fileCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
+        docketNumber: caseRecord.docketNumber,
         documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335bc',
         documentTitle: 'Order to Show Cause',
         documentType: 'Order to Show Cause',
@@ -241,7 +241,7 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
     await fileCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
+        docketNumber: caseRecord.docketNumber,
         documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335bc',
         documentTitle: 'Order to Show Cause',
         documentType: 'Order to Show Cause',
@@ -278,8 +278,8 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
     await fileCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
         date: '2019-03-01T21:40:46.415Z',
+        docketNumber: caseRecord.docketNumber,
         documentId: '7f61161c-ede8-43ba-8fab-69e15d057012',
         documentTitle: 'Transcript of [anything] on [date]',
         documentType: 'Transcript',
@@ -307,8 +307,8 @@ describe('fileCourtIssuedDocketEntryInteractor', () => {
     await fileCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
         date: '2019-03-01T21:40:46.415Z',
+        docketNumber: caseRecord.docketNumber,
         documentId: '7f61161c-ede8-43ba-8fab-69e15d057012',
         documentTitle: 'Transcript of [anything] on [date]',
         documentType: 'Transcript',

--- a/shared/src/business/useCases/docketEntry/updateCourtIssuedDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateCourtIssuedDocketEntryInteractor.js
@@ -30,13 +30,13 @@ exports.updateCourtIssuedDocketEntryInteractor = async ({
     throw new UnauthorizedError('Unauthorized');
   }
 
-  const { caseId, documentId } = documentMeta;
+  const { docketNumber, documentId } = documentMeta;
 
   const caseToUpdate = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   const caseEntity = new Case(caseToUpdate, { applicationContext });

--- a/shared/src/business/useCases/docketEntry/updateCourtIssuedDocketEntryInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateCourtIssuedDocketEntryInteractor.test.js
@@ -104,7 +104,6 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
             {
               assigneeId: '8b4cd447-6278-461b-b62b-d9e357eea62c',
               assigneeName: 'bob',
-              caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
               caseStatus: CASE_STATUS_TYPES.new,
               docketNumber: '101-18',
               docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
@@ -132,7 +131,7 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(caseRecord);
+      .getCaseByDocketNumber.mockReturnValue(caseRecord);
   });
 
   it('should throw an error if not authorized', async () => {
@@ -142,7 +141,7 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
       updateCourtIssuedDocketEntryInteractor({
         applicationContext,
         documentMeta: {
-          caseId: caseRecord.caseId,
+          docketNumber: caseRecord.docketNumber,
           documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335bc',
           documentType: 'Memorandum in Support',
           eventCode: 'MISP',
@@ -162,7 +161,7 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
       updateCourtIssuedDocketEntryInteractor({
         applicationContext,
         documentMeta: {
-          caseId: caseRecord.caseId,
+          docketNumber: caseRecord.docketNumber,
           documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335bc',
           documentType: 'Order',
           eventCode: 'O',
@@ -184,7 +183,7 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
     await updateCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
+        docketNumber: caseRecord.docketNumber,
         documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335ba',
         documentType: 'Order',
         eventCode: 'O',
@@ -216,8 +215,8 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
     await updateCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
         date: '2019-03-01T21:40:46.415Z',
+        docketNumber: caseRecord.docketNumber,
         documentId: '7f61161c-ede8-43ba-8fab-69e15d057012',
         documentTitle: 'Transcript of [anything] on [date]',
         documentType: 'Transcript',
@@ -248,7 +247,7 @@ describe('updateCourtIssuedDocketEntryInteractor', () => {
     await updateCourtIssuedDocketEntryInteractor({
       applicationContext,
       documentMeta: {
-        caseId: caseRecord.caseId,
+        docketNumber: caseRecord.docketNumber,
         documentId: 'c54ba5a9-b37b-479d-9201-067ec6e335ba',
         documentType: 'Order',
         eventCode: 'O',

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
@@ -12,15 +12,15 @@ const { UnauthorizedError } = require('../../../errors/errors');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {object} providers.caseId the caseId of the case to be updated
+ * @param {object} providers.docketNumber the docket number of the case to be updated
  * @param {object} providers.docketRecordIndex the index of the docket record entry to be updated
  * @param {object} providers.docketEntryMeta the docket entry metadata
  * @returns {object} the updated case after the documents are added
  */
 exports.updateDocketEntryMetaInteractor = async ({
   applicationContext,
-  caseId,
   docketEntryMeta,
+  docketNumber,
   docketRecordIndex,
 }) => {
   const user = applicationContext.getCurrentUser();
@@ -31,13 +31,13 @@ exports.updateDocketEntryMetaInteractor = async ({
 
   const caseToUpdate = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   if (!caseToUpdate) {
-    throw new NotFoundError(`Case ${caseId} was not found.`);
+    throw new NotFoundError(`Case ${docketNumber} was not found.`);
   }
 
   const caseEntity = new Case(caseToUpdate, { applicationContext });

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
@@ -68,10 +68,10 @@ describe('updateDocketEntryMetaInteractor', () => {
       },
     ];
 
-    const caseByCaseId = {
-      'cccba5a9-b37b-479d-9201-067ec6e33ccc': {
+    const caseByDocketNumber = {
+      '101-20': {
         ...MOCK_CASE,
-        caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
+        docketNumber: '101-20',
         docketRecord,
         documents,
       },
@@ -84,8 +84,8 @@ describe('updateDocketEntryMetaInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockImplementation(({ caseId }) => {
-        return caseByCaseId[caseId];
+      .getCaseByDocketNumber.mockImplementation(({ docketNumber }) => {
+        return caseByDocketNumber[docketNumber];
       });
   });
 
@@ -95,7 +95,7 @@ describe('updateDocketEntryMetaInteractor', () => {
     await expect(
       updateDocketEntryMetaInteractor({
         applicationContext,
-        caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
+        docketNumber: '101-20',
       }),
     ).rejects.toThrow(UnauthorizedError);
   });
@@ -112,28 +112,28 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should call the persistence method to load the case by its docket number', async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toHaveBeenCalled();
   });
 
   it('should update the docket record action', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         action: 'Updated Action',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -146,12 +146,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should update the docket record description', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         description: 'Updated Description',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -164,12 +164,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should update the docket record and document filedBy', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         partyPrimary: true,
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -186,12 +186,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should update the docket record filingDate', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         filingDate: '2020-01-01T00:01:00.000Z',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -204,12 +204,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should update the document servedAt', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         servedAt: '2020-01-01T00:01:00.000Z',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -225,13 +225,13 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should update the document hasOtherFilingParty and otherFilingParty values', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         hasOtherFilingParty: true,
         otherFilingParty: 'Brianna Noble',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -248,12 +248,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should update a non-required field to undefined if undefined value is passed in', async () => {
     const result = await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         freeText: undefined,
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -269,12 +269,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should generate a new coversheet for the document if the servedAt field is changed', async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         servedAt: '2020-01-01T00:01:00.000Z',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -286,12 +286,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should generate a new coversheet for the document if the filingDate field is changed', async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         filingDate: '2020-01-01T00:01:00.000Z',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -303,13 +303,13 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should NOT generate a new coversheet for the document if the servedAt and filingDate fields are NOT changed', async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         filingDate: '2019-01-01T00:01:00.000Z', // unchanged from current filingDate
         servedAt: '2019-01-01T00:01:00.000Z', // unchanged from current servedAt
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -321,12 +321,12 @@ describe('updateDocketEntryMetaInteractor', () => {
   it('should call the updateCase persistence method', async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
       docketEntryMeta: {
         ...docketRecord[0],
         ...documents[0],
         description: 'Updated Description',
       },
+      docketNumber: '101-20',
       docketRecordIndex: 0,
     });
 
@@ -339,7 +339,6 @@ describe('updateDocketEntryMetaInteractor', () => {
     await expect(
       updateDocketEntryMetaInteractor({
         applicationContext,
-        caseId: 'cccba5a9-b37b-479d-9201-067ec6e33ccc',
         docketEntryMeta: {
           ...docketRecord[0],
           ...documents[0],
@@ -349,6 +348,7 @@ describe('updateDocketEntryMetaInteractor', () => {
           eventCode: 'RQT',
           filingDate: '2020-02-03T08:06:07.539Z',
         },
+        docketNumber: '101-20',
         docketRecordIndex: 2,
       }),
     ).resolves.not.toThrow();

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
@@ -51,7 +51,11 @@ exports.completeDocketEntryQCInteractor = async ({
     throw new UnauthorizedError('Unauthorized');
   }
 
-  const { caseId, documentId, overridePaperServiceAddress } = entryMetadata;
+  const {
+    docketNumber,
+    documentId,
+    overridePaperServiceAddress,
+  } = entryMetadata;
 
   const user = await applicationContext
     .getPersistenceGateway()
@@ -59,9 +63,9 @@ exports.completeDocketEntryQCInteractor = async ({
 
   const caseToUpdate = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   let caseEntity = new Case(caseToUpdate, { applicationContext });
@@ -195,7 +199,6 @@ exports.completeDocketEntryQCInteractor = async ({
     });
 
     Object.assign(workItemToUpdate, {
-      caseId: caseId,
       caseIsInProgress: caseEntity.inProgress,
       caseStatus: caseToUpdate.status,
       docketNumber: caseToUpdate.docketNumber,

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
@@ -123,7 +123,7 @@ describe('completeDocketEntryQCInteractor', () => {
     });
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(caseRecord);
+      .getCaseByDocketNumber.mockReturnValue(caseRecord);
     applicationContext.getUniqueId.mockReturnValue(
       'b6f835aa-bf95-4996-b858-c8e94566db47',
     );
@@ -164,8 +164,8 @@ describe('completeDocketEntryQCInteractor', () => {
       completeDocketEntryQCInteractor({
         applicationContext,
         entryMetadata: {
-          caseId: caseRecord.caseId,
           description: 'Memorandum in Support',
+          docketNumber: caseRecord.docketNumber,
           documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
           documentTitle: 'Document Title',
           documentType: 'Memorandum in Support',
@@ -176,7 +176,7 @@ describe('completeDocketEntryQCInteractor', () => {
     ).resolves.not.toThrow();
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway()
@@ -203,8 +203,8 @@ describe('completeDocketEntryQCInteractor', () => {
     const result = await completeDocketEntryQCInteractor({
       applicationContext,
       entryMetadata: {
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Something Else',
         documentType: 'Memorandum in Support',
@@ -214,7 +214,7 @@ describe('completeDocketEntryQCInteractor', () => {
     });
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway()
@@ -234,8 +234,8 @@ describe('completeDocketEntryQCInteractor', () => {
       entryMetadata: {
         additionalInfo: '123',
         additionalInfo2: 'abc',
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Something Else',
         documentType: 'Memorandum in Support',
@@ -261,8 +261,8 @@ describe('completeDocketEntryQCInteractor', () => {
     await completeDocketEntryQCInteractor({
       applicationContext,
       entryMetadata: {
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Something Else',
         documentType: 'Memorandum in Support',
@@ -287,7 +287,7 @@ describe('completeDocketEntryQCInteractor', () => {
       entryMetadata: {
         additionalInfo: 'additional info',
         additionalInfo2: 'additional info 2',
-        caseId: caseRecord.caseId,
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Answer',
         documentType: 'Answer',
@@ -316,8 +316,8 @@ describe('completeDocketEntryQCInteractor', () => {
     const result = await completeDocketEntryQCInteractor({
       applicationContext,
       entryMetadata: {
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Something Else',
         documentType: 'Memorandum in Support',
@@ -327,7 +327,7 @@ describe('completeDocketEntryQCInteractor', () => {
     });
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway()
@@ -356,8 +356,8 @@ describe('completeDocketEntryQCInteractor', () => {
     const result = await completeDocketEntryQCInteractor({
       applicationContext,
       entryMetadata: {
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Notice of Change of Address',
         documentType: 'Notice of Change of Address',
@@ -367,7 +367,7 @@ describe('completeDocketEntryQCInteractor', () => {
     });
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway()
@@ -395,8 +395,8 @@ describe('completeDocketEntryQCInteractor', () => {
     const result = await completeDocketEntryQCInteractor({
       applicationContext,
       entryMetadata: {
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'Notice of Change of Address',
         documentType: 'Notice of Change of Address',
@@ -406,7 +406,7 @@ describe('completeDocketEntryQCInteractor', () => {
     });
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway()
@@ -424,8 +424,8 @@ describe('completeDocketEntryQCInteractor', () => {
     await completeDocketEntryQCInteractor({
       applicationContext,
       entryMetadata: {
-        caseId: caseRecord.caseId,
         description: 'Memorandum in Support',
+        docketNumber: caseRecord.docketNumber,
         documentId: 'fffba5a9-b37b-479d-9201-067ec6e335bb',
         documentTitle: 'My Edited Document',
         documentType: 'Notice of Change of Address',

--- a/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.js
+++ b/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.js
@@ -33,7 +33,7 @@ exports.fileExternalDocumentInteractor = async ({
   documentMetadata,
 }) => {
   const authorizedUser = applicationContext.getCurrentUser();
-  const { caseId } = documentMetadata;
+  const { docketNumber } = documentMetadata;
 
   if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.FILE_EXTERNAL_DOCUMENT)) {
     throw new UnauthorizedError('Unauthorized');
@@ -45,9 +45,9 @@ exports.fileExternalDocumentInteractor = async ({
 
   const caseToUpdate = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   let caseEntity = new Case(caseToUpdate, { applicationContext });
@@ -65,7 +65,6 @@ exports.fileExternalDocumentInteractor = async ({
     'partySecondary',
     'partyIrsPractitioner',
     'practitioner',
-    'caseId',
     'docketNumber',
   ]);
 

--- a/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.test.js
+++ b/shared/src/business/useCases/externalDocument/fileExternalDocumentInteractor.test.js
@@ -93,7 +93,7 @@ describe('fileExternalDocumentInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(caseRecord);
+      .getCaseByDocketNumber.mockReturnValue(caseRecord);
   });
 
   it('should throw an error when not authorized', async () => {
@@ -104,7 +104,7 @@ describe('fileExternalDocumentInteractor', () => {
         applicationContext,
         documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
         documentMetadata: {
-          caseId: caseRecord.caseId,
+          docketNumber: caseRecord.docketNumber,
           documentType: 'Memorandum in Support',
           filedBy: 'Test Petitioner',
         },
@@ -117,8 +117,7 @@ describe('fileExternalDocumentInteractor', () => {
       applicationContext,
       documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
       documentMetadata: {
-        caseId: caseRecord.caseId,
-        docketNumber: '45678-18',
+        docketNumber: caseRecord.docketNumber,
         documentTitle: 'Memorandum in Support',
         documentType: 'Memorandum in Support',
         eventCode: 'A',
@@ -127,7 +126,7 @@ describe('fileExternalDocumentInteractor', () => {
     });
 
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
@@ -149,8 +148,7 @@ describe('fileExternalDocumentInteractor', () => {
         'c54ba5a9-b37b-479d-9201-067ec6e335be',
       ],
       documentMetadata: {
-        caseId: caseRecord.caseId,
-        docketNumber: '45678-18',
+        docketNumber: caseRecord.docketNumber,
         documentTitle: 'Motion for Leave to File',
         documentType: 'Motion for Leave to File',
         eventCode: 'M115',
@@ -213,8 +211,7 @@ describe('fileExternalDocumentInteractor', () => {
         applicationContext,
         documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
         documentMetadata: {
-          caseId: caseRecord.caseId,
-          docketNumber: '45678-18',
+          docketNumber: caseRecord.docketNumber,
           documentTitle: 'Simultaneous Memoranda of Law',
           documentType: 'Simultaneous Memoranda of Law',
           eventCode: 'A',
@@ -226,7 +223,7 @@ describe('fileExternalDocumentInteractor', () => {
     }
     expect(error).toBeUndefined();
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toBeCalled();
     expect(
       applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
@@ -247,8 +244,7 @@ describe('fileExternalDocumentInteractor', () => {
       applicationContext,
       documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
       documentMetadata: {
-        caseId: caseRecord.caseId,
-        docketNumber: '45678-18',
+        docketNumber: caseRecord.docketNumber,
         documentTitle: 'Simultaneous Memoranda of Law',
         documentType: 'Simultaneous Memoranda of Law',
         eventCode: 'A',
@@ -274,8 +270,7 @@ describe('fileExternalDocumentInteractor', () => {
       applicationContext,
       documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
       documentMetadata: {
-        caseId: caseRecord.caseId,
-        docketNumber: '45678-18',
+        docketNumber: caseRecord.docketNumber,
         documentTitle: 'Simultaneous Memoranda of Law',
         documentType: 'Simultaneous Memoranda of Law',
         eventCode: 'A',
@@ -299,9 +294,8 @@ describe('fileExternalDocumentInteractor', () => {
       applicationContext,
       documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
       documentMetadata: {
-        caseId: caseRecord.caseId,
         category: 'Application',
-        docketNumber: '45678-18',
+        docketNumber: caseRecord.docketNumber,
         documentTitle: 'Application for Waiver of Filing Fee',
         documentType: 'Application for Waiver of Filing Fee',
         eventCode: 'APPW',
@@ -336,9 +330,8 @@ describe('fileExternalDocumentInteractor', () => {
       applicationContext,
       documentIds: ['c54ba5a9-b37b-479d-9201-067ec6e335bb'],
       documentMetadata: {
-        caseId: caseRecord.caseId,
         category: 'Application',
-        docketNumber: '45678-18',
+        docketNumber: caseRecord.docketNumber,
         documentTitle: 'Application for Waiver of Filing Fee',
         documentType: 'Application for Waiver of Filing Fee',
         eventCode: 'APPW',

--- a/shared/src/proxies/documents/fileCourtIssuedDocketEntryProxy.js
+++ b/shared/src/proxies/documents/fileCourtIssuedDocketEntryProxy.js
@@ -12,12 +12,12 @@ exports.fileCourtIssuedDocketEntryInteractor = ({
   applicationContext,
   documentMeta,
 }) => {
-  const { caseId } = documentMeta;
+  const { docketNumber } = documentMeta;
   return post({
     applicationContext,
     body: {
       documentMeta,
     },
-    endpoint: `/case-documents/${caseId}/court-issued-docket-entry`,
+    endpoint: `/case-documents/${docketNumber}/court-issued-docket-entry`,
   });
 };

--- a/shared/src/proxies/documents/fileExternalDocumentProxy.js
+++ b/shared/src/proxies/documents/fileExternalDocumentProxy.js
@@ -15,13 +15,13 @@ exports.fileExternalDocumentInteractor = ({
   documentIds,
   documentMetadata,
 }) => {
-  const { caseId } = documentMetadata;
+  const { docketNumber } = documentMetadata;
   return post({
     applicationContext,
     body: {
       documentIds,
       documentMetadata,
     },
-    endpoint: `/case-documents/${caseId}/external-document`,
+    endpoint: `/case-documents/${docketNumber}/external-document`,
   });
 };

--- a/shared/src/proxies/documents/updateCourtIssuedDocketEntryProxy.js
+++ b/shared/src/proxies/documents/updateCourtIssuedDocketEntryProxy.js
@@ -12,12 +12,12 @@ exports.updateCourtIssuedDocketEntryInteractor = ({
   applicationContext,
   documentMeta,
 }) => {
-  const { caseId } = documentMeta;
+  const { docketNumber } = documentMeta;
   return put({
     applicationContext,
     body: {
       documentMeta,
     },
-    endpoint: `/case-documents/${caseId}/court-issued-docket-entry`,
+    endpoint: `/case-documents/${docketNumber}/court-issued-docket-entry`,
   });
 };

--- a/shared/src/proxies/documents/updateDocketEntryMetaProxy.js
+++ b/shared/src/proxies/documents/updateDocketEntryMetaProxy.js
@@ -5,15 +5,15 @@ const { put } = require('../requests');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {object} providers.caseId the caseId of the case to be updated
+ * @param {object} providers.docketNumber the docket number of the case to be updated
  * @param {object} providers.docketRecordIndex the index of the docket record entry to be updated
  * @param {object} providers.docketEntryMeta the docket entry metadata
  * @returns {Promise<*>} the promise of the api call
  */
 exports.updateDocketEntryMetaInteractor = ({
   applicationContext,
-  caseId,
   docketEntryMeta,
+  docketNumber,
   docketRecordIndex,
 }) => {
   return put({
@@ -22,6 +22,6 @@ exports.updateDocketEntryMetaInteractor = ({
       docketEntryMeta,
       docketRecordIndex,
     },
-    endpoint: `/case-documents/${caseId}/docket-entry-meta`,
+    endpoint: `/case-documents/${docketNumber}/docket-entry-meta`,
   });
 };

--- a/shared/src/proxies/editDocketEntry/completeDocketEntryQCProxy.js
+++ b/shared/src/proxies/editDocketEntry/completeDocketEntryQCProxy.js
@@ -12,12 +12,12 @@ exports.completeDocketEntryQCInteractor = ({
   applicationContext,
   entryMetadata,
 }) => {
-  const { caseId } = entryMetadata;
+  const { docketNumber } = entryMetadata;
   return put({
     applicationContext,
     body: {
       entryMetadata,
     },
-    endpoint: `/case-documents/${caseId}/docket-entry-complete`,
+    endpoint: `/case-documents/${docketNumber}/docket-entry-complete`,
   });
 };

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -480,11 +480,11 @@ app.put(
   lambdaWrapper(completeDocketEntryQCLambda),
 );
 app.post(
-  '/case-documents/:caseId/court-issued-docket-entry',
+  '/case-documents/:docketNumber/court-issued-docket-entry',
   lambdaWrapper(fileCourtIssuedDocketEntryLambda),
 );
 app.put(
-  '/case-documents/:caseId/court-issued-docket-entry',
+  '/case-documents/:docketNumber/court-issued-docket-entry',
   lambdaWrapper(updateCourtIssuedDocketEntryLambda),
 );
 app.post(

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -456,7 +456,7 @@ app.put(
   lambdaWrapper(updateCourtIssuedOrderToCaseLambda),
 );
 app.post(
-  '/case-documents/:caseId/external-document',
+  '/case-documents/:docketNumber/external-document',
   lambdaWrapper(fileExternalDocumentToCaseLambda),
 );
 app.post(

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -472,7 +472,7 @@ app.put(
   lambdaWrapper(updateDocketEntryOnCaseLambda),
 );
 app.put(
-  '/case-documents/:caseId/docket-entry-meta',
+  '/case-documents/:docketNumber/docket-entry-meta',
   lambdaWrapper(updateDocketEntryMetaLambda),
 );
 app.put(

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -476,7 +476,7 @@ app.put(
   lambdaWrapper(updateDocketEntryMetaLambda),
 );
 app.put(
-  '/case-documents/:caseId/docket-entry-complete',
+  '/case-documents/:docketNumber/docket-entry-complete',
   lambdaWrapper(completeDocketEntryQCLambda),
 );
 app.post(

--- a/web-api/src/documents/updateDocketEntryMetaLambda.js
+++ b/web-api/src/documents/updateDocketEntryMetaLambda.js
@@ -11,8 +11,8 @@ exports.updateDocketEntryMetaLambda = event =>
     return await applicationContext
       .getUseCases()
       .updateDocketEntryMetaInteractor({
-        ...JSON.parse(event.body),
         applicationContext,
-        caseId: event.pathParameters.caseId,
+        ...JSON.parse(event.body),
+        ...event.pathParameters,
       });
   });

--- a/web-api/swagger.json
+++ b/web-api/swagger.json
@@ -1869,10 +1869,10 @@
         }
       }
     },
-    "/case-documents/{caseId}/external-document": {
+    "/case-documents/{docketNumber}/external-document": {
       "parameters": [
         {
-          "name": "caseId",
+          "name": "docketNumber",
           "in": "path",
           "required": true,
           "type": "string"

--- a/web-api/swagger.json
+++ b/web-api/swagger.json
@@ -2096,10 +2096,10 @@
         }
       }
     },
-    "/case-documents/{caseId}/docket-entry-complete": {
+    "/case-documents/{docketNumber}/docket-entry-complete": {
       "parameters": [
         {
-          "name": "caseId",
+          "name": "docketNumber",
           "in": "path",
           "required": true,
           "type": "string"

--- a/web-api/swagger.json
+++ b/web-api/swagger.json
@@ -4545,10 +4545,10 @@
         }
       }
     },
-    "/case-documents/{caseId}/court-issued-docket-entry": {
+    "/case-documents/{docketNumber}/court-issued-docket-entry": {
       "parameters": [
         {
-          "name": "caseId",
+          "name": "docketNumber",
           "in": "path",
           "required": true,
           "type": "string"

--- a/web-api/swagger.json
+++ b/web-api/swagger.json
@@ -1992,10 +1992,10 @@
         }
       }
     },
-    "/case-documents/{caseId}/docket-entry-meta": {
+    "/case-documents/{docketNumber}/docket-entry-meta": {
       "parameters": [
         {
-          "name": "caseId",
+          "name": "docketNumber",
           "in": "path",
           "required": true,
           "type": "string"

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/submitCourtIssuedDocketEntryAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/submitCourtIssuedDocketEntryAction.js
@@ -13,7 +13,7 @@ export const submitCourtIssuedDocketEntryAction = async ({
   get,
 }) => {
   const documentId = get(state.documentId);
-  const { caseId, docketNumber } = get(state.caseDetail);
+  const { docketNumber } = get(state.caseDetail);
   const form = get(state.form);
 
   const {
@@ -22,7 +22,7 @@ export const submitCourtIssuedDocketEntryAction = async ({
 
   const documentMeta = {
     ...form,
-    caseId,
+    docketNumber,
     documentId,
   };
 

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/submitCourtIssuedDocketEntryAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/submitCourtIssuedDocketEntryAction.test.js
@@ -17,7 +17,7 @@ describe('submitCourtIssuedDocketEntryAction', () => {
       },
       state: {
         caseDetail: {
-          caseId: '123',
+          docketNumber: '123-20',
         },
         documentId: 'abc',
         form: {
@@ -45,7 +45,7 @@ describe('submitCourtIssuedDocketEntryAction', () => {
       },
       state: {
         caseDetail: {
-          caseId: '123',
+          docketNumber: '123-20',
         },
         documentId: 'abc',
         form: {
@@ -73,7 +73,7 @@ describe('submitCourtIssuedDocketEntryAction', () => {
       },
       state: {
         caseDetail: {
-          caseId: '123',
+          docketNumber: '123-20',
         },
         documentId: 'abc',
         form: {

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/updateCourtIssuedDocketEntryAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/updateCourtIssuedDocketEntryAction.js
@@ -13,12 +13,12 @@ export const updateCourtIssuedDocketEntryAction = async ({
   get,
 }) => {
   const documentId = get(state.documentId);
-  const caseId = get(state.caseDetail.caseId);
+  const docketNumber = get(state.caseDetail.docketNumber);
   const form = get(state.form);
 
   const documentMeta = {
     ...form,
-    caseId,
+    docketNumber,
     documentId,
   };
 

--- a/web-client/src/presenter/actions/EditDocketRecord/completeDocketEntryQCAction.js
+++ b/web-client/src/presenter/actions/EditDocketRecord/completeDocketEntryQCAction.js
@@ -16,7 +16,7 @@ export const completeDocketEntryQCAction = async ({
   get,
   props,
 }) => {
-  const { caseId, docketNumber } = get(state.caseDetail);
+  const docketNumber = get(state.caseDetail.docketNumber);
   const documentId = get(state.documentId);
   const { overridePaperServiceAddress } = props;
 
@@ -29,7 +29,6 @@ export const completeDocketEntryQCAction = async ({
 
   entryMetadata = {
     ...entryMetadata,
-    caseId,
     createdAt: entryMetadata.dateReceived,
     docketNumber,
     documentId,
@@ -57,7 +56,6 @@ export const completeDocketEntryQCAction = async ({
       title: 'QC Completed',
     },
     caseDetail,
-    caseId,
     docketNumber,
     paperServiceDocumentTitle,
     paperServiceParties,

--- a/web-client/src/presenter/actions/EditDocketRecord/completeDocketEntryQCAction.test.js
+++ b/web-client/src/presenter/actions/EditDocketRecord/completeDocketEntryQCAction.test.js
@@ -45,7 +45,6 @@ describe('completeDocketEntryQCAction', () => {
         title: 'QC Completed',
       },
       caseDetail,
-      caseId: caseDetail.caseId,
       docketNumber: caseDetail.docketNumber,
       updatedDocument: {
         documentId: '123-456-789-abc',

--- a/web-client/src/presenter/actions/EditDocketRecordEntry/updateDocketEntryMetaAction.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/updateDocketEntryMetaAction.js
@@ -14,15 +14,15 @@ export const updateDocketEntryMetaAction = async ({
   get,
   path,
 }) => {
-  const { caseId } = get(state.caseDetail);
+  const docketNumber = get(state.caseDetail.docketNumber);
   const docketRecordEntry = get(state.form);
   const docketRecordIndex = get(state.docketRecordIndex);
 
   try {
     await applicationContext.getUseCases().updateDocketEntryMetaInteractor({
       applicationContext,
-      caseId,
       docketEntryMeta: docketRecordEntry,
+      docketNumber,
       docketRecordIndex,
     });
     return path.success();

--- a/web-client/src/presenter/actions/EditDocketRecordEntry/updateDocketEntryMetaAction.test.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/updateDocketEntryMetaAction.test.js
@@ -24,7 +24,7 @@ describe('updateDocketEntryMetaAction', () => {
       modules: { presenter },
       state: {
         caseDetail: {
-          caseId: '123-45',
+          docketNumber: '123-45',
         },
         docketRecordEntry: {
           servedParties: [],
@@ -50,7 +50,7 @@ describe('updateDocketEntryMetaAction', () => {
       modules: { presenter },
       state: {
         caseDetail: {
-          caseId: '123-45',
+          docketNumber: '123-45',
         },
         docketRecordEntry: {
           description: 'Test Description',


### PR DESCRIPTION
* fileExternalDocumentToCaseLambda
* updateDocketEntryMetaLambda
* completeDocketEntryQCLambda
* fileCourtIssuedDocketEntryLambda
* updateCourtIssuedDocketEntryLambda