### PR TITLE
DevEx: use docketNumber instead of caseId

### DIFF
--- a/shared/src/business/useCases/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlInteractor.js
@@ -10,7 +10,7 @@ const { UnauthorizedError } = require('../../../errors/errors');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {string} providers.caseId the case id where the order is generated
+ * @param {string} providers.docketNumber the docket number of the case where the order is generated
  * @param {string} providers.contentHtml the html string for the pdf content
  * @param {string} providers.documentTitle the title of the document
  * @param {string} providers.signatureText (optional) text to be used as the signatory of the document
@@ -18,8 +18,8 @@ const { UnauthorizedError } = require('../../../errors/errors');
  */
 exports.createCourtIssuedOrderPdfFromHtmlInteractor = async ({
   applicationContext,
-  caseId,
   contentHtml,
+  docketNumber,
   documentTitle,
   signatureText,
 }) => {
@@ -31,9 +31,9 @@ exports.createCourtIssuedOrderPdfFromHtmlInteractor = async ({
 
   const caseDetail = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   const { caseCaptionExtension, caseTitle } = getCaseCaptionMeta(caseDetail);

--- a/shared/src/business/useCases/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlInteractor.test.js
+++ b/shared/src/business/useCases/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlInteractor.test.js
@@ -10,11 +10,13 @@ describe('createCourtIssuedOrderPdfFromHtmlInteractor', () => {
   const mockPdfUrl = 'www.example.com';
 
   beforeAll(() => {
-    applicationContext.getPersistenceGateway().getCaseByCaseId.mockReturnValue({
-      caseCaption: 'Dr. Leo Marvin, Petitioner',
-      caseId: '123',
-      docketNumberWithSuffix: '123-45W',
-    });
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue({
+        caseCaption: 'Dr. Leo Marvin, Petitioner',
+        docketNumber: '123-45',
+        docketNumberWithSuffix: '123-45W',
+      });
 
     applicationContext
       .getUseCaseHelpers()
@@ -46,7 +48,7 @@ describe('createCourtIssuedOrderPdfFromHtmlInteractor', () => {
       applicationContext,
     });
     expect(
-      applicationContext.getPersistenceGateway().getCaseByCaseId,
+      applicationContext.getPersistenceGateway().getCaseByDocketNumber,
     ).toHaveBeenCalled();
   });
 

--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
@@ -7,20 +7,20 @@ const { getCaseCaptionMeta } = require('../utilities/getCaseCaptionMeta');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {string} providers.caseId the id of the case the documents were filed in
+ * @param {string} providers.docketNumber the docket number of the case the documents were filed in
  * @param {object} providers.documentsFiled object containing the caseId and documents for the filing receipt to be generated
  * @returns {string} url for the generated document on the storage client
  */
 exports.generatePrintableFilingReceiptInteractor = async ({
   applicationContext,
-  caseId,
+  docketNumber,
   documentsFiled,
 }) => {
   const caseSource = await applicationContext
     .getPersistenceGateway()
-    .getCaseByCaseId({
+    .getCaseByDocketNumber({
       applicationContext,
-      caseId,
+      docketNumber,
     });
 
   const caseEntity = new Case(caseSource, { applicationContext }).validate();

--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
@@ -17,7 +17,7 @@ describe('generatePrintableFilingReceiptInteractor', () => {
     );
     applicationContext
       .getPersistenceGateway()
-      .getCaseByCaseId.mockReturnValue(MOCK_CASE);
+      .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
     applicationContext
       .getPersistenceGateway()
       .getDownloadPolicyUrl.mockReturnValue({
@@ -28,7 +28,7 @@ describe('generatePrintableFilingReceiptInteractor', () => {
   it('Calls the Receipt of Filing document generator', async () => {
     await generatePrintableFilingReceiptInteractor({
       applicationContext,
-      caseId: MOCK_CASE.caseId,
+      docketNumber: MOCK_CASE.docketNumber,
       documentsFiled: {
         primaryDocumentFile: {},
       },
@@ -48,7 +48,7 @@ describe('generatePrintableFilingReceiptInteractor', () => {
   it('acquires document information', async () => {
     await generatePrintableFilingReceiptInteractor({
       applicationContext,
-      caseId: MOCK_CASE.caseId,
+      docketNumber: MOCK_CASE.docketNumber,
       documentsFiled: {
         hasSecondarySupportingDocuments: true,
         hasSupportingDocuments: true,

--- a/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.js
@@ -22,12 +22,12 @@ const { UnauthorizedError } = require('../../../errors/errors');
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the applicationContext
  * @param {string} providers.trialSessionId the trial session id
- * @param {string} providers.caseId optional caseId to explicitly set the notice on the ONE specified case
+ * @param {string} providers.docketNumber optional docketNumber to explicitly set the notice on the ONE specified case
  * @returns {Promise} the promises for the updateCase calls
  */
 exports.setNoticesForCalendaredTrialSessionInteractor = async ({
   applicationContext,
-  caseId,
+  docketNumber,
   trialSessionId,
 }) => {
   let shouldSetNoticesIssued = true;
@@ -48,12 +48,12 @@ exports.setNoticesForCalendaredTrialSessionInteractor = async ({
 
   // opting to pull from the set of calendared cases rather than load the
   // case individually to add an additional layer of validation
-  if (caseId) {
+  if (docketNumber) {
     // Do not set when sending notices for a single case
     shouldSetNoticesIssued = false;
 
     const singleCase = calendaredCases.find(
-      caseRecord => caseRecord.caseId === caseId,
+      caseRecord => caseRecord.docketNumber === docketNumber,
     );
 
     calendaredCases = [singleCase];
@@ -120,7 +120,6 @@ exports.setNoticesForCalendaredTrialSessionInteractor = async ({
 
     const noticeOfTrialDocument = new Document(
       {
-        caseId: caseEntity.caseId,
         documentId: newNoticeOfTrialIssuedDocumentId,
         documentTitle: noticeOfTrialDocumentTitle,
         documentType: NOTICE_OF_TRIAL.documentType,
@@ -176,7 +175,6 @@ exports.setNoticesForCalendaredTrialSessionInteractor = async ({
 
     const standingPretrialDocument = new Document(
       {
-        caseId: caseEntity.caseId,
         documentId: newStandingPretrialDocumentId,
         documentTitle: standingPretrialDocumentTitle,
         documentType: standingPretrialDocumentTitle,

--- a/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.test.js
@@ -46,7 +46,6 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     const case0 = {
       // should get electronic service
       ...MOCK_CASE,
-      caseId: '000aa3f7-e2e3-43e6-885d-4ce341588000',
       contactPrimary: {
         ...MOCK_CASE.contactPrimary,
         email: 'petitioner@example.com',
@@ -58,7 +57,6 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     const case1 = {
       // should get paper service
       ...MOCK_CASE,
-      caseId: '111aa3f7-e2e3-43e6-885d-4ce341588111',
       contactPrimary: {
         ...MOCK_CASE.contactPrimary,
       },
@@ -114,7 +112,7 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
       .getPersistenceGateway()
       .updateCase.mockImplementation(({ caseToUpdate }) => {
         calendaredCases.some((caseRecord, index) => {
-          if (caseRecord.caseId === caseToUpdate.caseId) {
+          if (caseRecord.docketNumber === caseToUpdate.docketNumber) {
             calendaredCases[index] = caseToUpdate;
             return true;
           }
@@ -303,13 +301,13 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     ).toHaveBeenCalled();
   });
 
-  it('Should NOT overwrite the noticeIssuedDate on the trial session NOR call updateTrialSession if a caseId is set', async () => {
+  it('Should NOT overwrite the noticeIssuedDate on the trial session NOR call updateTrialSession if a docketNumber is set', async () => {
     const oldDate = '2019-12-01T00:00:00.000Z';
     trialSession.noticeIssuedDate = oldDate;
 
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '111aa3f7-e2e3-43e6-885d-4ce341588111',
+      docketNumber: '102-20',
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 
@@ -319,10 +317,10 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('Should only generate a Notice of Trial for a single case if a caseId is set', async () => {
+  it('Should only generate a Notice of Trial for a single case if a docketNumber is set', async () => {
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '111aa3f7-e2e3-43e6-885d-4ce341588111',
+      docketNumber: '103-20',
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 
@@ -337,10 +335,10 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     expect(findNoticeOfTrial(calendaredCases[1])).toBeTruthy();
   });
 
-  it('Should only set the notice for a single case if a caseId is set', async () => {
+  it('Should only set the notice for a single case if a docketNumber is set', async () => {
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '000aa3f7-e2e3-43e6-885d-4ce341588000',
+      docketNumber: '102-20',
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 
@@ -348,10 +346,10 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     expect(calendaredCases[1]).not.toHaveProperty('noticeOfTrialDate');
   });
 
-  it('Should only create a docket entry for a single case if a caseId is set', async () => {
+  it('Should only create a docket entry for a single case if a docketNumber is set', async () => {
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '111aa3f7-e2e3-43e6-885d-4ce341588111',
+      docketNumber: '103-20',
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 
@@ -365,10 +363,10 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
     expect(findNoticeOfTrialDocketEntry(calendaredCases[1])).toBeTruthy();
   });
 
-  it('Should set the status of the Notice of Trial as served for a single case if a caseId is set', async () => {
+  it('Should set the status of the Notice of Trial as served for a single case if a docketNumber is set', async () => {
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '111aa3f7-e2e3-43e6-885d-4ce341588111',
+      docketNumber: '103-20',
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 
@@ -386,7 +384,7 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
   it('Should generate a Standing Pretrial Order for REGULAR cases', async () => {
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '000aa3f7-e2e3-43e6-885d-4ce341588000', // MOCK_CASE with procedureType: 'Regular'
+      docketNumber: '102-20', // MOCK_CASE with procedureType: 'Regular'
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 
@@ -398,7 +396,7 @@ describe('setNoticesForCalendaredTrialSessionInteractor', () => {
   it('Should generate a Standing Pretrial Notice for SMALL cases', async () => {
     await setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId: '111aa3f7-e2e3-43e6-885d-4ce341588111', // MOCK_CASE with procedureType: 'Small'
+      docketNumber: '103-20', // MOCK_CASE with procedureType: 'Small'
       trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
     });
 

--- a/shared/src/proxies/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlProxy.js
+++ b/shared/src/proxies/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlProxy.js
@@ -13,16 +13,16 @@ const { post } = require('../requests');
  */
 exports.createCourtIssuedOrderPdfFromHtmlInteractor = ({
   applicationContext,
-  caseId,
   contentHtml,
+  docketNumber,
   documentTitle,
   signatureText,
 }) => {
   return post({
     applicationContext,
     body: {
-      caseId,
       contentHtml,
+      docketNumber,
       documentTitle,
       signatureText,
     },

--- a/shared/src/proxies/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlProxy.js
+++ b/shared/src/proxies/courtIssuedOrder/createCourtIssuedOrderPdfFromHtmlProxy.js
@@ -5,7 +5,7 @@ const { post } = require('../requests');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {string} providers.caseId the case id where the order is generated
+ * @param {string} providers.docketNumber the docket number where the order is generated
  * @param {string} providers.contentHtml the html string for the pdf content
  * @param {string} providers.documentTitle the title of the document
  * @param {string} providers.signatureText (optional) text to be used as the signatory of the document

--- a/shared/src/proxies/generatePrintableFilingReceiptProxy.js
+++ b/shared/src/proxies/generatePrintableFilingReceiptProxy.js
@@ -5,19 +5,19 @@ const { post } = require('./requests');
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
- * @param {string} providers.caseId the id of the case in which the documents were filed
+ * @param {string} providers.docketNumber the docket number of the case in which the documents were filed
  * @param {object} providers.documentsFiled the documents filed
  * @returns {Promise<*>} the promise of the api call
  */
 exports.generatePrintableFilingReceiptInteractor = ({
   applicationContext,
-  caseId,
+  docketNumber,
   documentsFiled,
 }) => {
   return post({
     applicationContext,
     body: {
-      caseId,
+      docketNumber,
       documentsFiled,
     },
     endpoint: '/documents/filing-receipt-pdf',

--- a/shared/src/proxies/trialSessions/setNoticesForCalendaredTrialSessionProxy.js
+++ b/shared/src/proxies/trialSessions/setNoticesForCalendaredTrialSessionProxy.js
@@ -6,18 +6,18 @@ const { post } = require('../requests');
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
  * @param {string} providers.trialSessionId the trial session id
- * @param {string} providers.caseId optional caseId for setting a single case
+ * @param {string} providers.docketNumber optional docketNumber for setting a single case
  * @returns {Promise<*>} the promise of the api call
  */
 exports.setNoticesForCalendaredTrialSessionInteractor = ({
   applicationContext,
-  caseId = null, // because sending undefined in an http request breaks lambda
+  docketNumber = null, // because sending undefined in an http request breaks lambda
   trialSessionId,
 }) => {
   return post({
     applicationContext,
     body: {
-      caseId,
+      docketNumber,
     },
     endpoint: `/trial-sessions/${trialSessionId}/generate-notices`,
   });

--- a/web-client/src/presenter/actions/CourtIssuedOrder/getPdfUrlAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/getPdfUrlAction.js
@@ -10,7 +10,7 @@ import { state } from 'cerebral';
  */
 export const getPdfUrlAction = async ({ applicationContext, get, props }) => {
   const { contentHtml, documentTitle, signatureText } = props;
-  const caseDetail = get(state.caseDetail);
+  const docketNumber = get(state.caseDetail.docketNumber);
 
   const {
     url,
@@ -18,8 +18,8 @@ export const getPdfUrlAction = async ({ applicationContext, get, props }) => {
     .getUseCases()
     .createCourtIssuedOrderPdfFromHtmlInteractor({
       applicationContext,
-      caseId: caseDetail.caseId,
       contentHtml,
+      docketNumber,
       documentTitle,
       signatureText,
     });

--- a/web-client/src/presenter/actions/CourtIssuedOrder/getPdfUrlAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/getPdfUrlAction.test.js
@@ -33,7 +33,7 @@ describe('getPdfUrlAction', () => {
       },
       state: {
         caseDetail: {
-          caseId: '123',
+          docketNumber: '123-20',
         },
       },
     });
@@ -49,8 +49,8 @@ describe('getPdfUrlAction', () => {
 
     expect(args).toEqual(
       expect.objectContaining({
-        caseId: '123',
         contentHtml: '<p>hi</p>',
+        docketNumber: '123-20',
         documentTitle: 'Test Title',
         signatureText: 'Test Signature',
       }),

--- a/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.js
+++ b/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.js
@@ -17,13 +17,13 @@ export const generatePrintableFilingReceiptAction = async ({
   props,
 }) => {
   const { documentsFiled } = props;
-  const caseId = get(state.caseDetail.caseId);
+  const docketNumber = get(state.caseDetail.docketNumber);
 
   const filingReceiptUrl = await applicationContext
     .getUseCases()
     .generatePrintableFilingReceiptInteractor({
       applicationContext,
-      caseId,
+      docketNumber,
       documentsFiled,
     });
 

--- a/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.test.js
+++ b/web-client/src/presenter/actions/FileDocument/generatePrintableFilingReceiptAction.test.js
@@ -13,7 +13,6 @@ describe('generatePrintableFilingReceiptAction', () => {
       },
       props: {
         documentsFiled: {
-          caseId: '123',
           docketNumber: '123-19',
           primaryDocumentFile: {},
         },

--- a/web-client/src/presenter/actions/TrialSession/setNoticesForCalendaredTrialSessionAction.js
+++ b/web-client/src/presenter/actions/TrialSession/setNoticesForCalendaredTrialSessionAction.js
@@ -16,13 +16,13 @@ export const setNoticesForCalendaredTrialSessionAction = async ({
 }) => {
   const trialSessionId =
     props.trialSessionId || get(state.trialSession.trialSessionId);
-  const { caseId } = props;
+  const { docketNumber } = props;
 
   await applicationContext
     .getUseCases()
     .setNoticesForCalendaredTrialSessionInteractor({
       applicationContext,
-      caseId,
+      docketNumber,
       trialSessionId,
     });
 };

--- a/web-client/src/presenter/actions/TrialSessionWorkingCopy/setAddEditUserCaseNoteModalStateFromDetailAction.test.js
+++ b/web-client/src/presenter/actions/TrialSessionWorkingCopy/setAddEditUserCaseNoteModalStateFromDetailAction.test.js
@@ -15,7 +15,7 @@ describe('setAddEditUserCaseNoteModalStateFromDetailAction', () => {
         modules: {
           presenter,
         },
-        props: { caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb' },
+        props: { docketNumber: '101-19' },
         state: {
           caseDetail: {
             caseCaption: 'Sisqo, Petitioner',
@@ -28,9 +28,6 @@ describe('setAddEditUserCaseNoteModalStateFromDetailAction', () => {
     );
 
     expect(result.state.modal.caseTitle).toEqual('Sisqo');
-    expect(result.state.modal.caseId).toEqual(
-      'c54ba5a9-b37b-479d-9201-067ec6e335bb',
-    );
     expect(result.state.modal.docketNumber).toEqual('101-19L');
     expect(result.state.modal.notes).toEqual('i got some notes');
   });
@@ -42,7 +39,7 @@ describe('setAddEditUserCaseNoteModalStateFromDetailAction', () => {
         modules: {
           presenter,
         },
-        props: { caseId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb' },
+        props: { docketNumber: '101-19' },
         state: {
           caseDetail: {
             docketNumber: '101-19',
@@ -53,9 +50,6 @@ describe('setAddEditUserCaseNoteModalStateFromDetailAction', () => {
     );
 
     expect(result.state.modal.caseTitle).toEqual('');
-    expect(result.state.modal.caseId).toEqual(
-      'c54ba5a9-b37b-479d-9201-067ec6e335bb',
-    );
     expect(result.state.modal.docketNumber).toEqual('101-19');
     expect(result.state.modal.notes).toEqual('i got some notes');
   });

--- a/web-client/src/presenter/actions/TrialSessionWorkingCopy/setDeleteUserCaseNoteModalStateAction.js
+++ b/web-client/src/presenter/actions/TrialSessionWorkingCopy/setDeleteUserCaseNoteModalStateAction.js
@@ -8,5 +8,5 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  */
 export const setDeleteUserCaseNoteModalStateAction = ({ props, store }) => {
-  store.set(state.modal.caseId, props.caseId);
+  store.set(state.modal.docketNumber, props.docketNumber);
 };

--- a/web-client/src/presenter/actions/TrialSessionWorkingCopy/unsetSessionNoteFromTrialSessionWorkingCopyAction.test.js
+++ b/web-client/src/presenter/actions/TrialSessionWorkingCopy/unsetSessionNoteFromTrialSessionWorkingCopyAction.test.js
@@ -3,7 +3,7 @@ import { runAction } from 'cerebral/test';
 import { unsetSessionNoteFromTrialSessionWorkingCopyAction } from './unsetSessionNoteFromTrialSessionWorkingCopyAction';
 
 describe('unsetSessionNoteFromTrialSessionWorkingCopyAction', () => {
-  it('should set the modal caseId state', async () => {
+  it('should set the modal state', async () => {
     const result = await runAction(
       unsetSessionNoteFromTrialSessionWorkingCopyAction,
       {

--- a/web-client/src/presenter/actions/TrialSessionWorkingCopy/updateNotePropsFromModalStateAction.test.js
+++ b/web-client/src/presenter/actions/TrialSessionWorkingCopy/updateNotePropsFromModalStateAction.test.js
@@ -3,7 +3,7 @@ import { runAction } from 'cerebral/test';
 import { updateNotePropsFromModalStateAction } from './updateNotePropsFromModalStateAction';
 
 describe('updateNotePropsFromModalStateAction', () => {
-  it('should set the modal caseId state', async () => {
+  it('should set the modal state', async () => {
     const result = await runAction(updateNotePropsFromModalStateAction, {
       modules: {
         presenter,

--- a/web-client/src/presenter/actions/TrialSessionWorkingCopy/updateSessionNoteInTrialSessionWorkingCopyAction.test.js
+++ b/web-client/src/presenter/actions/TrialSessionWorkingCopy/updateSessionNoteInTrialSessionWorkingCopyAction.test.js
@@ -3,7 +3,7 @@ import { runAction } from 'cerebral/test';
 import { updateSessionNoteInTrialSessionWorkingCopyAction } from './updateSessionNoteInTrialSessionWorkingCopyAction';
 
 describe('updateSessionNoteInTrialSessionWorkingCopyAction', () => {
-  it('should set the modal caseId state', async () => {
+  it('should set the modal state', async () => {
     const result = await runAction(
       updateSessionNoteInTrialSessionWorkingCopyAction,
       {

--- a/web-client/src/presenter/actions/resetArchiveDraftDocumentAction.js
+++ b/web-client/src/presenter/actions/resetArchiveDraftDocumentAction.js
@@ -1,12 +1,13 @@
 import { state } from 'cerebral';
 
 /**
- * clears archive draft document state properties (documentId, caseId, and documentTitle)
+ * clears archive draft document state properties (documentId, docketNumber, and documentTitle)
  *
  * @param {object} providers the providers object
  * @param {object} providers.store the cerebral store
  */
 export const resetArchiveDraftDocumentAction = ({ store }) => {
+  store.unset(state.archiveDraftDocument.docketNumber);
   store.unset(state.archiveDraftDocument.documentId);
   store.unset(state.archiveDraftDocument.documentTitle);
 };

--- a/web-client/src/presenter/actions/resetArchiveDraftDocumentAction.js
+++ b/web-client/src/presenter/actions/resetArchiveDraftDocumentAction.js
@@ -7,7 +7,6 @@ import { state } from 'cerebral';
  * @param {object} providers.store the cerebral store
  */
 export const resetArchiveDraftDocumentAction = ({ store }) => {
-  store.unset(state.archiveDraftDocument.caseId);
   store.unset(state.archiveDraftDocument.documentId);
   store.unset(state.archiveDraftDocument.documentTitle);
 };

--- a/web-client/src/presenter/actions/setArchiveDraftDocumentAction.js
+++ b/web-client/src/presenter/actions/setArchiveDraftDocumentAction.js
@@ -8,10 +8,15 @@ import { state } from 'cerebral';
  * @param {object} providers.props incoming cerebral props
  */
 export const setArchiveDraftDocumentAction = ({ props, store }) => {
-  const { caseId, documentId, documentTitle, redirectToCaseDetail } = props;
+  const {
+    docketNumber,
+    documentId,
+    documentTitle,
+    redirectToCaseDetail,
+  } = props;
 
   store.set(state.archiveDraftDocument, {
-    caseId,
+    docketNumber,
     documentId,
     documentTitle,
     redirectToCaseDetail,

--- a/web-client/src/presenter/actions/setArchiveDraftDocumentAction.js
+++ b/web-client/src/presenter/actions/setArchiveDraftDocumentAction.js
@@ -1,7 +1,7 @@
 import { state } from 'cerebral';
 
 /**
- * sets archive draft document state properties (documentId, caseId, and documentTitle)
+ * sets archive draft document state properties (documentId, docketNumber, and documentTitle)
  *
  * @param {object} providers the providers object
  * @param {object} providers.store the cerebral store

--- a/web-client/src/presenter/actions/setArchiveDraftDocumentAction.test.js
+++ b/web-client/src/presenter/actions/setArchiveDraftDocumentAction.test.js
@@ -5,14 +5,14 @@ describe('setArchiveDraftDocumentAction', () => {
   it('sets the archive draft document state object to incoming props', async () => {
     const result = await runAction(setArchiveDraftDocumentAction, {
       props: {
-        caseId: 'abc-123',
+        docketNumber: '123-20',
         documentId: 'def-123',
         documentTitle: 'Stipulated Decision',
       },
     });
 
     expect(result.state.archiveDraftDocument).toMatchObject({
-      caseId: 'abc-123',
+      docketNumber: '123-20',
       documentId: 'def-123',
       documentTitle: 'Stipulated Decision',
     });

--- a/web-client/src/presenter/actions/setConfirmEditModalStateAction.js
+++ b/web-client/src/presenter/actions/setConfirmEditModalStateAction.js
@@ -10,6 +10,5 @@ import { state } from 'cerebral';
 export const setConfirmEditModalStateAction = ({ props, store }) => {
   store.set(state.modal.docketNumber, props.docketNumber);
   store.set(state.modal.documentIdToEdit, props.documentIdToEdit);
-  store.set(state.modal.caseId, props.caseId);
   store.set(state.modal.parentMessageId, props.parentMessageId);
 };

--- a/web-client/src/presenter/actions/setConfirmEditModalStateAction.test.js
+++ b/web-client/src/presenter/actions/setConfirmEditModalStateAction.test.js
@@ -5,7 +5,6 @@ describe('setConfirmEditModalStateAction', () => {
   it('sets the case and document to display in the modal', async () => {
     const result = await runAction(setConfirmEditModalStateAction, {
       props: {
-        caseId: 'abc-123',
         docketNumber: 'abc-123',
         documentIdToEdit: 'abc-123',
         parentMessageId: '987',
@@ -14,7 +13,6 @@ describe('setConfirmEditModalStateAction', () => {
 
     expect(result.state).toMatchObject({
       modal: {
-        caseId: 'abc-123',
         docketNumber: 'abc-123',
         documentIdToEdit: 'abc-123',
         parentMessageId: '987',

--- a/web-client/src/presenter/actions/setupConfirmWithPropsAction.js
+++ b/web-client/src/presenter/actions/setupConfirmWithPropsAction.js
@@ -4,14 +4,12 @@ import { state } from 'cerebral';
  * @returns {Promise} async action
  */
 export const setupConfirmWithPropsAction = async ({ get }) => {
-  const caseId = get(state.modal.caseId);
   const documentIdToEdit = get(state.modal.documentIdToEdit);
   const docketNumber = get(state.modal.docketNumber);
   const parentMessageId = get(state.modal.parentMessageId);
   const redirectUrl = get(state.redirectUrl);
 
   return {
-    caseId,
     docketNumber,
     documentIdToEdit,
     parentMessageId,

--- a/web-client/src/presenter/actions/setupConfirmWithPropsAction.test.js
+++ b/web-client/src/presenter/actions/setupConfirmWithPropsAction.test.js
@@ -6,7 +6,6 @@ describe('setupConfirmWithPropsAction', () => {
     const result = await runAction(setupConfirmWithPropsAction, {
       state: {
         modal: {
-          caseId: 'abc-123',
           docketNumber: 'abc-123',
           documentIdToEdit: 'abc-123',
           parentMessageId: '987',
@@ -16,7 +15,6 @@ describe('setupConfirmWithPropsAction', () => {
     });
 
     expect(result.output).toMatchObject({
-      caseId: 'abc-123',
       docketNumber: 'abc-123',
       documentIdToEdit: 'abc-123',
       parentMessageId: '987',

--- a/web-client/src/presenter/computeds/Dashboard/externalUserCasesHelper.test.js
+++ b/web-client/src/presenter/computeds/Dashboard/externalUserCasesHelper.test.js
@@ -9,7 +9,7 @@ const externalUserCasesHelper = withAppContextDecorator(
     ...applicationContext,
     getUtilities: () => ({
       formatCase: () => ({
-        caseId: 'case-id-123',
+        docketNumber: '123-20',
       }),
     }),
   },
@@ -69,8 +69,8 @@ describe('externalUserCasesHelper', () => {
     const result = runCompute(externalUserCasesHelper, {
       state: {
         ...baseState,
-        closedCases: [{ caseId: 'hey' }],
-        openCases: [{ caseId: 'hey' }, { caseId: 'bye' }],
+        closedCases: [{ docketNumber: '101-20' }],
+        openCases: [{ docketNumber: '102-20' }, { docketNumber: '103-20' }],
       },
     });
 

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
@@ -29,9 +29,9 @@ describe('blockedCasesReportHelper', () => {
     const result = runCompute(blockedCasesReportHelper, {
       state: {
         blockedCases: [
-          { caseId: '1', docketNumber: '101-19' },
-          { caseId: '2', docketNumber: '102-19' },
-          { caseId: '3', docketNumber: '103-19' },
+          { docketNumber: '101-19' },
+          { docketNumber: '102-19' },
+          { docketNumber: '103-19' },
         ],
       },
     });
@@ -46,7 +46,6 @@ describe('blockedCasesReportHelper', () => {
             blocked: true,
             blockedDate: '2019-03-01T21:42:29.073Z',
             caseCaption: 'Brett Osborne, Petitioner',
-            caseId: '1',
             docketNumber: '105-19',
             docketNumberWithSuffix: '105-19',
           },
@@ -56,7 +55,6 @@ describe('blockedCasesReportHelper', () => {
             blocked: true,
             blockedDate: '2019-07-01T21:42:29.073Z',
             caseCaption: 'Selma Horn & Cairo Harris, Petitioners',
-            caseId: '2',
             docketNumber: '102-19',
             docketNumberWithSuffix: '102-19',
           },
@@ -67,7 +65,6 @@ describe('blockedCasesReportHelper', () => {
             blockedDate: '2018-03-05T21:42:29.073Z',
             caseCaption:
               'Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s)',
-            caseId: '3',
             docketNumber: '103-18',
             docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
             docketNumberWithSuffix: '103-18S',
@@ -76,7 +73,6 @@ describe('blockedCasesReportHelper', () => {
             automaticBlocked: true,
             automaticBlockedDate: '2019-03-05T21:42:29.073Z',
             caseCaption: 'Bob Barker, Petitioner',
-            caseId: '4',
             docketNumber: '104-19',
             docketNumberWithSuffix: '104-19',
           },
@@ -94,7 +90,6 @@ describe('blockedCasesReportHelper', () => {
           blockedDateEarliest: '03/05/18',
           caseCaption:
             'Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s)',
-          caseId: '3',
           caseTitle: 'Tatum Craig, Wayne Obrien, Partnership Representative',
           docketNumber: '103-18',
           docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
@@ -107,7 +102,6 @@ describe('blockedCasesReportHelper', () => {
           blockedDate: '2019-07-01T21:42:29.073Z',
           blockedDateEarliest: '03/05/18',
           caseCaption: 'Selma Horn & Cairo Harris, Petitioners',
-          caseId: '2',
           caseTitle: 'Selma Horn & Cairo Harris',
           docketNumber: '102-19',
           docketNumberWithSuffix: '102-19',
@@ -117,7 +111,6 @@ describe('blockedCasesReportHelper', () => {
           automaticBlockedDate: '2019-03-05T21:42:29.073Z',
           blockedDateEarliest: '03/05/19',
           caseCaption: 'Bob Barker, Petitioner',
-          caseId: '4',
           caseTitle: 'Bob Barker',
           docketNumber: '104-19',
           docketNumberWithSuffix: '104-19',
@@ -127,7 +120,6 @@ describe('blockedCasesReportHelper', () => {
           blockedDate: '2019-03-01T21:42:29.073Z',
           blockedDateEarliest: '03/01/19',
           caseCaption: 'Brett Osborne, Petitioner',
-          caseId: '1',
           caseTitle: 'Brett Osborne',
           docketNumber: '105-19',
           docketNumberWithSuffix: '105-19',

--- a/web-client/src/presenter/computeds/completeDocumentTypeSectionHelper.test.js
+++ b/web-client/src/presenter/computeds/completeDocumentTypeSectionHelper.test.js
@@ -32,7 +32,7 @@ describe('completeDocumentTypeSectionHelper', () => {
     const result = runCompute(completeDocumentTypeSectionHelper, {
       state: {
         caseDetail: {
-          caseId: 'case-id-123',
+          docketNumber: '101-20',
         },
         form: {
           category,
@@ -56,7 +56,7 @@ describe('completeDocumentTypeSectionHelper', () => {
     const result = runCompute(completeDocumentTypeSectionHelper, {
       state: {
         caseDetail: {
-          caseId: 'case-id-123',
+          docketNumber: '101-20',
         },
         form: {
           category,

--- a/web-client/src/presenter/computeds/filterWorkItems.test.js
+++ b/web-client/src/presenter/computeds/filterWorkItems.test.js
@@ -109,7 +109,6 @@ const generateWorkItem = (data, document) => {
   const baseWorkItem = {
     assigneeId: null,
     assigneeName: null,
-    caseId: '123',
     caseStatus: CASE_STATUS_TYPES.new,
     createdAt: '2018-12-27T18:05:54.166Z',
     docketNumber: '100-01',

--- a/web-client/src/presenter/computeds/formattedMessageDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedMessageDetail.test.js
@@ -22,8 +22,8 @@ describe('formattedMessageDetail', () => {
             attachments: [
               { documentId: '98065bac-b35c-423c-b649-122a09bb65b9' },
             ],
-            caseId: '78fb798f-66c3-42fa-bb5a-c14fac735b61',
             createdAt: '2019-03-01T21:40:46.415Z',
+            docketNumber: '101-20',
             messageId: '60e129bf-b8ec-4e0c-93c7-9633ab69f5df',
           },
           {
@@ -31,8 +31,8 @@ describe('formattedMessageDetail', () => {
               { documentId: '98065bac-b35c-423c-b649-122a09bb65b9' },
               { documentId: 'fee3958e-c738-4794-b0a1-bad711506685' },
             ],
-            caseId: '78fb798f-66c3-42fa-bb5a-c14fac735b61',
             createdAt: '2019-04-01T21:40:46.415Z',
+            docketNumber: '101-20',
             messageId: '98a9dbc4-a8d1-459b-98b2-30235b596d70',
           },
         ],
@@ -68,8 +68,8 @@ describe('formattedMessageDetail', () => {
             attachments: [
               { documentId: '98065bac-b35c-423c-b649-122a09bb65b9' },
             ],
-            caseId: '78fb798f-66c3-42fa-bb5a-c14fac735b61',
             createdAt: '2019-03-01T21:40:46.415Z',
+            docketNumber: '101-20',
             messageId: '60e129bf-b8ec-4e0c-93c7-9633ab69f5df',
           },
           {
@@ -77,12 +77,12 @@ describe('formattedMessageDetail', () => {
               { documentId: '98065bac-b35c-423c-b649-122a09bb65b9' },
               { documentId: 'fee3958e-c738-4794-b0a1-bad711506685' },
             ],
-            caseId: '78fb798f-66c3-42fa-bb5a-c14fac735b61',
             completedAt: '2019-05-01T21:40:46.415Z',
             completedBy: 'Test Petitioner',
             completedBySection: 'petitions',
             completedByUserId: '23869007-384d-464f-b079-cb1fcfb21e03',
             createdAt: '2019-04-01T21:40:46.415Z',
+            docketNumber: '101-20',
             isCompleted: true,
             messageId: '98a9dbc4-a8d1-459b-98b2-30235b596d70',
           },

--- a/web-client/src/presenter/computeds/formattedMessages.test.js
+++ b/web-client/src/presenter/computeds/formattedMessages.test.js
@@ -15,7 +15,6 @@ describe('formattedMessages', () => {
         applicationContext,
         messages: [
           {
-            caseId: 'c6b81f4d-1e47-423a-8caf-6d2fdc3d3859',
             caseStatus: 'Ready for trial',
             completedAt: '2019-05-01T17:29:13.122Z',
             createdAt: '2019-01-01T17:29:13.122Z',
@@ -43,18 +42,18 @@ describe('formattedMessages', () => {
         applicationContext,
         messages: [
           {
-            caseId: '1',
             createdAt: '2019-01-01T16:29:13.122Z',
+            docketNumber: '101-20',
             message: 'This is a test message',
           },
           {
-            caseId: '3',
             createdAt: '2019-01-02T17:29:13.122Z',
+            docketNumber: '103-20',
             message: 'This is a test message',
           },
           {
-            caseId: '2',
             createdAt: '2019-01-01T17:29:13.122Z',
+            docketNumber: '102-20',
             message: 'This is a test message',
           },
         ],
@@ -62,13 +61,13 @@ describe('formattedMessages', () => {
 
       expect(result.messages).toMatchObject([
         {
-          caseId: '1',
+          docketNumber: '101-20',
         },
         {
-          caseId: '2',
+          docketNumber: '102-20',
         },
         {
-          caseId: '3',
+          docketNumber: '103-20',
         },
       ]);
     });
@@ -78,21 +77,21 @@ describe('formattedMessages', () => {
         applicationContext,
         messages: [
           {
-            caseId: '1',
             completedAt: '2019-01-02T16:29:13.122Z',
             createdAt: '2019-01-01T16:29:13.122Z',
+            docketNumber: '101-20',
             isCompleted: true,
             message: 'This is a test message',
           },
           {
-            caseId: '3',
             createdAt: '2019-01-02T17:29:13.122Z',
+            docketNumber: '103-20',
             message: 'This is a test message',
           },
           {
-            caseId: '2',
             completedAt: '2019-01-03T16:29:13.122Z',
             createdAt: '2019-01-01T17:29:13.122Z',
+            docketNumber: '102-20',
             isCompleted: true,
             message: 'This is a test message',
           },
@@ -101,14 +100,14 @@ describe('formattedMessages', () => {
 
       expect(result.completedMessages).toMatchObject([
         {
-          caseId: '2',
           createdAt: '2019-01-01T17:29:13.122Z',
+          docketNumber: '102-20',
           isCompleted: true,
           message: 'This is a test message',
         },
         {
-          caseId: '1',
           createdAt: '2019-01-01T16:29:13.122Z',
+          docketNumber: '101-20',
           isCompleted: true,
           message: 'This is a test message',
         },
@@ -120,23 +119,26 @@ describe('formattedMessages', () => {
         applicationContext,
         messages: [
           {
-            caseId: '1',
-            completedAt: '2019-01-03T16:29:13.122Z', // completed third
+            completedAt: '2019-01-03T16:29:13.122Z',
+            // completed third
             createdAt: '2019-01-01T16:29:13.122Z',
+            docketNumber: '101-20',
             isCompleted: true,
             message: 'This is a test message',
           },
           {
-            caseId: '2',
-            completedAt: '2019-01-01T16:29:13.122Z', // completed first
+            completedAt: '2019-01-01T16:29:13.122Z',
+            // completed first
             createdAt: '2019-01-02T17:29:13.122Z',
+            docketNumber: '102-20',
             isCompleted: true,
             message: 'This is a test message',
           },
           {
-            caseId: '3',
-            completedAt: '2019-01-02T16:29:13.122Z', // completed second
+            completedAt: '2019-01-02T16:29:13.122Z',
+            // completed second
             createdAt: '2019-01-01T17:29:13.122Z',
+            docketNumber: '103-20',
             isCompleted: true,
             message: 'This is a test message',
           },
@@ -145,23 +147,23 @@ describe('formattedMessages', () => {
 
       expect(result.completedMessages).toMatchObject([
         {
-          caseId: '1',
           completedAt: '2019-01-03T16:29:13.122Z',
           createdAt: '2019-01-01T16:29:13.122Z',
+          docketNumber: '101-20',
           isCompleted: true,
           message: 'This is a test message',
         },
         {
-          caseId: '3',
           completedAt: '2019-01-02T16:29:13.122Z',
           createdAt: '2019-01-01T17:29:13.122Z',
+          docketNumber: '103-20',
           isCompleted: true,
           message: 'This is a test message',
         },
         {
-          caseId: '2',
           completedAt: '2019-01-01T16:29:13.122Z',
           createdAt: '2019-01-02T17:29:13.122Z',
+          docketNumber: '102-20',
           isCompleted: true,
           message: 'This is a test message',
         },
@@ -173,21 +175,21 @@ describe('formattedMessages', () => {
         applicationContext,
         messages: [
           {
-            caseId: '1',
             completedAt: '2019-01-02T16:29:13.122Z',
             createdAt: '2019-01-01T16:29:13.122Z',
+            docketNumber: '101-20',
             message: 'This is a test message',
           },
           {
-            caseId: '3',
             createdAt: '2019-01-02T17:29:13.122Z',
+            docketNumber: '103-20',
             isRepliedTo: true,
             message: 'This is a test message',
           },
           {
-            caseId: '2',
             completedAt: '2019-01-03T16:29:13.122Z',
             createdAt: '2019-01-01T17:29:13.122Z',
+            docketNumber: '102-20',
             message: 'This is a test message',
           },
         ],
@@ -195,13 +197,13 @@ describe('formattedMessages', () => {
 
       expect(result.inProgressMessages).toMatchObject([
         {
-          caseId: '1',
           createdAt: '2019-01-01T16:29:13.122Z',
+          docketNumber: '101-20',
           message: 'This is a test message',
         },
         {
-          caseId: '2',
           createdAt: '2019-01-01T17:29:13.122Z',
+          docketNumber: '102-20',
           message: 'This is a test message',
         },
       ]);
@@ -213,22 +215,22 @@ describe('formattedMessages', () => {
       state: {
         messages: [
           {
-            caseId: '1',
             completedAt: '2019-01-02T16:29:13.122Z',
             createdAt: '2019-01-01T16:29:13.122Z',
+            docketNumber: '101-20',
             message: 'This is a test message',
           },
           {
-            caseId: '3',
             completedAt: '2019-01-01T16:29:13.122Z',
             createdAt: '2019-01-02T17:29:13.122Z',
+            docketNumber: '103-20',
             isCompleted: true,
             message: 'This is a test message',
           },
           {
-            caseId: '2',
             completedAt: '2019-01-03T16:29:13.122Z',
             createdAt: '2019-01-01T17:29:13.122Z',
+            docketNumber: '102-20',
             message: 'This is a test message',
           },
         ],
@@ -238,28 +240,28 @@ describe('formattedMessages', () => {
     expect(result).toMatchObject({
       completedMessages: [
         {
-          caseId: '3',
           completedAt: '2019-01-01T16:29:13.122Z',
           createdAt: '2019-01-02T17:29:13.122Z',
+          docketNumber: '103-20',
           isCompleted: true,
           message: 'This is a test message',
         },
       ],
       messages: [
         {
-          caseId: '1',
           createdAt: '2019-01-01T16:29:13.122Z',
+          docketNumber: '101-20',
           message: 'This is a test message',
         },
         {
-          caseId: '2',
           createdAt: '2019-01-01T17:29:13.122Z',
+          docketNumber: '102-20',
           message: 'This is a test message',
         },
         {
-          caseId: '3',
           completedAt: '2019-01-01T16:29:13.122Z',
           createdAt: '2019-01-02T17:29:13.122Z',
+          docketNumber: '103-20',
           isCompleted: true,
           message: 'This is a test message',
         },

--- a/web-client/src/presenter/computeds/formattedPendingItems.test.js
+++ b/web-client/src/presenter/computeds/formattedPendingItems.test.js
@@ -20,7 +20,6 @@ describe('formattedPendingItems', () => {
     {
       associatedJudge: CHIEF_JUDGE,
       caseCaption: 'Brett Osborne, Petitioner',
-      caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
       caseStatus: STATUS_TYPES.new,
       category: 'Miscellaneous',
       certificateOfServiceDate: null,
@@ -46,7 +45,6 @@ describe('formattedPendingItems', () => {
         {
           assigneeId: '1805d1ab-18d0-43ec-bafb-654e83405416',
           assigneeName: 'Test Docketclerk',
-          caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
           caseStatus: STATUS_TYPES.new,
           completedAt: '2019-11-13T00:38:59.049Z',
           completedBy: 'Test Docketclerk',
@@ -56,7 +54,6 @@ describe('formattedPendingItems', () => {
           docketNumber: '101-19',
           docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
           document: {
-            caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
             category: 'Miscellaneous',
             certificateOfServiceDate: null,
             createdAt: '2019-01-10',
@@ -102,7 +99,6 @@ describe('formattedPendingItems', () => {
     {
       associatedJudge: CHIEF_JUDGE,
       caseCaption: 'Brett Osborne, Petitioner',
-      caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
       caseStatus: STATUS_TYPES.new,
       category: 'Supporting Document',
       certificateOfServiceDate: null,
@@ -131,7 +127,6 @@ describe('formattedPendingItems', () => {
         {
           assigneeId: '1805d1ab-18d0-43ec-bafb-654e83405416',
           assigneeName: 'Test Docketclerk',
-          caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
           caseStatus: STATUS_TYPES.new,
           completedAt: '2019-11-13T02:27:07.801Z',
           completedBy: 'Test Docketclerk',
@@ -141,7 +136,6 @@ describe('formattedPendingItems', () => {
           docketNumber: '101-19',
           docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
           document: {
-            caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
             category: 'Supporting Document',
             certificateOfServiceDate: null,
             createdAt: '2019-01-20',
@@ -189,7 +183,6 @@ describe('formattedPendingItems', () => {
     {
       associatedJudge: 'Judge A',
       caseCaption: 'Brett Osborne, Petitioner',
-      caseId: '421872dc-e87d-4214-8ad0-c861d9b76c88',
       caseStatus: STATUS_TYPES.new,
       category: 'Supporting Document',
       certificateOfServiceDate: null,
@@ -218,7 +211,6 @@ describe('formattedPendingItems', () => {
         {
           assigneeId: '1805d1ab-18d0-43ec-bafb-654e83405416',
           assigneeName: 'Test Docketclerk',
-          caseId: '421872dc-e87d-4214-8ad0-c861d9b76c88',
           caseStatus: STATUS_TYPES.new,
           completedAt: '2019-11-13T02:27:07.801Z',
           completedBy: 'Test Docketclerk',
@@ -228,7 +220,6 @@ describe('formattedPendingItems', () => {
           docketNumber: '101-19',
           docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
           document: {
-            caseId: '421872dc-e87d-4214-8ad0-c861d9b76c88',
             category: 'Supporting Document',
             certificateOfServiceDate: null,
             createdAt: '2019-01-20',
@@ -286,7 +277,6 @@ describe('formattedPendingItems', () => {
         {
           associatedJudge: CHIEF_JUDGE,
           associatedJudgeFormatted: CHIEF_JUDGE,
-          caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
           caseStatus: STATUS_TYPES.new,
           formattedFiledDate: '01/20/18',
           formattedName: 'Affidavit of Bob in Support of Petition',
@@ -295,7 +285,6 @@ describe('formattedPendingItems', () => {
         {
           associatedJudge: 'Judge A',
           associatedJudgeFormatted: 'A',
-          caseId: '421872dc-e87d-4214-8ad0-c861d9b76c88',
           caseStatus: STATUS_TYPES.new,
           formattedFiledDate: '01/20/18',
           formattedName: 'Affidavit of Bob in Support of Petition',
@@ -304,7 +293,6 @@ describe('formattedPendingItems', () => {
         {
           associatedJudge: CHIEF_JUDGE,
           associatedJudgeFormatted: CHIEF_JUDGE,
-          caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
           caseStatus: STATUS_TYPES.new,
           formattedFiledDate: '01/10/19',
           formattedName: 'Administrative Record',
@@ -328,7 +316,6 @@ describe('formattedPendingItems', () => {
         {
           associatedJudge: CHIEF_JUDGE,
           associatedJudgeFormatted: CHIEF_JUDGE,
-          caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
           caseStatus: STATUS_TYPES.new,
           formattedFiledDate: '01/20/18',
           formattedName: 'Affidavit of Bob in Support of Petition',
@@ -337,7 +324,6 @@ describe('formattedPendingItems', () => {
         {
           associatedJudge: CHIEF_JUDGE,
           associatedJudgeFormatted: CHIEF_JUDGE,
-          caseId: '2fa6da8d-4328-4a20-a5d7-b76637e1dc02',
           caseStatus: STATUS_TYPES.new,
           formattedFiledDate: '01/10/19',
           formattedName: 'Administrative Record',

--- a/web-client/src/presenter/computeds/formattedWorkQueue.test.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.test.js
@@ -44,7 +44,6 @@ describe('formatted work queue computed', () => {
   const FORMATTED_WORK_ITEM = {
     assigneeId: 'abc',
     assigneeName: 'Unassigned',
-    caseId: 'e631d81f-a579-4de5-b8a8-b3f10ef619fd',
     caseStatus: STATUS_TYPES.generalDocket,
     createdAtFormatted: '12/27/18',
     currentMessage: {
@@ -120,7 +119,6 @@ describe('formatted work queue computed', () => {
   const workItem = {
     assigneeId: 'abc',
     assigneeName: null,
-    caseId: 'e631d81f-a579-4de5-b8a8-b3f10ef619fd',
     caseStatus: STATUS_TYPES.generalDocket,
     createdAt: '2018-12-27T18:05:54.166Z',
     docketNumber: '101-18',
@@ -745,7 +743,6 @@ describe('formatted work queue computed', () => {
       assigneeId: null,
       assigneeName: null,
       caseCaption: 'Ori Petersen',
-      caseId: 'fa73b4ed-4b3d-43b3-b704-8b2af5bdecc1',
       caseStatus: 'New',
       createdAt: '2019-12-16T16:48:02.889Z',
       docketNumber: '114-19',

--- a/web-client/src/presenter/computeds/updateCaseModalHelper.test.js
+++ b/web-client/src/presenter/computeds/updateCaseModalHelper.test.js
@@ -17,7 +17,7 @@ let mockCase;
 describe('updateCaseModalHelper', () => {
   beforeEach(() => {
     mockCase = {
-      caseId: '123',
+      docketNumber: '123-20',
       status: CASE_STATUS_TYPES.new,
     };
   });

--- a/web-client/src/presenter/sequences/gotoReviewSavedPetitionSequence.test.js
+++ b/web-client/src/presenter/sequences/gotoReviewSavedPetitionSequence.test.js
@@ -10,7 +10,6 @@ describe('gotoReviewSavedPetitionSequence', () => {
   ({ PARTY_TYPES } = applicationContext.getConstants());
 
   const MOCK_CASE = {
-    caseId: 'foo-bar-baz',
     docketNumber: '105-15',
     documents: [{ documentId: '123', documentType: 'Petition' }],
     partyType: PARTY_TYPES.petitioner,

--- a/web-client/src/views/CaseDetailEdit/ReviewSavedPetition.jsx
+++ b/web-client/src/views/CaseDetailEdit/ReviewSavedPetition.jsx
@@ -73,7 +73,7 @@ export const ReviewSavedPetition = connect(
                         link
                         aria-label="edit parties"
                         className="margin-right-0 margin-top-1 padding-0 float-right"
-                        href={`/case-detail/${form.caseId}/petition-qc?tab=partyInfo`}
+                        href={`/case-detail/${form.docketNumber}/petition-qc?tab=partyInfo`}
                         icon="edit"
                       >
                         Edit
@@ -128,7 +128,7 @@ export const ReviewSavedPetition = connect(
                         link
                         aria-label="edit case information"
                         className="margin-right-0 margin-top-1 padding-0 float-right"
-                        href={`/case-detail/${form.caseId}/petition-qc?tab=caseInfo`}
+                        href={`/case-detail/${form.docketNumber}/petition-qc?tab=caseInfo`}
                         icon="edit"
                       >
                         Edit
@@ -213,7 +213,7 @@ export const ReviewSavedPetition = connect(
                         link
                         aria-label="edit IRS notice information"
                         className="margin-right-0 margin-top-1 padding-0 float-right"
-                        href={`/case-detail/${form.caseId}/petition-qc?tab=irsNotice`}
+                        href={`/case-detail/${form.docketNumber}/petition-qc?tab=irsNotice`}
                         icon="edit"
                       >
                         Edit

--- a/web-client/src/views/CaseListPetitioner.jsx
+++ b/web-client/src/views/CaseListPetitioner.jsx
@@ -77,7 +77,7 @@ export const CaseListPetitioner = connect(
                     <CaseListRowExternal
                       onlyLinkIfRequestedUserAssociated
                       formattedCase={item}
-                      key={item.caseId}
+                      key={item.docketNumber}
                     />
                   ))}
                 </tbody>

--- a/web-client/src/views/CaseListPractitioner.jsx
+++ b/web-client/src/views/CaseListPractitioner.jsx
@@ -66,7 +66,7 @@ export const CaseListPractitioner = connect(
                 <CaseListRowExternal
                   onlyLinkIfRequestedUserAssociated
                   formattedCase={item}
-                  key={item.caseId}
+                  key={item.docketNumber}
                 />
               ))}
             </tbody>

--- a/web-client/src/views/CaseListRespondent.jsx
+++ b/web-client/src/views/CaseListRespondent.jsx
@@ -66,7 +66,7 @@ export const CaseListRespondent = connect(
                 <CaseListRowExternal
                   onlyLinkIfRequestedUserAssociated
                   formattedCase={item}
-                  key={item.caseId}
+                  key={item.docketNumber}
                 />
               ))}
             </tbody>

--- a/web-client/src/views/CaseListRowExternal.jsx
+++ b/web-client/src/views/CaseListRowExternal.jsx
@@ -9,7 +9,7 @@ const getCaseRow = ({
   onlyText,
 }) => {
   return (
-    <React.Fragment key={formattedCase.caseId}>
+    <React.Fragment key={formattedCase.docketNumber}>
       <tr>
         <td>
           {formattedCase.isLeadCase && (

--- a/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecordHeader.jsx
@@ -22,7 +22,7 @@ export const DocketRecordHeader = connect(
   }) {
     const openDocketRecordPrintPreview = (options = {}) => {
       updateSessionMetadataSequence({
-        key: `docketRecordSort.${formattedCaseDetail.caseId}`,
+        key: `docketRecordSort.${formattedCaseDetail.docketNumber}`,
         value: 'byDate',
       });
       printDocketRecordSequence(options);
@@ -35,7 +35,7 @@ export const DocketRecordHeader = connect(
               <select
                 aria-label="docket record"
                 className="usa-select margin-top-0 margin-bottom-2 sort"
-                name={`docketRecordSort.${formattedCaseDetail.caseId}`}
+                name={`docketRecordSort.${formattedCaseDetail.docketNumber}`}
                 value={formattedCaseDetail.docketRecordSort}
                 onChange={e => {
                   updateSessionMetadataSequence({

--- a/web-client/src/views/DocketRecord/DraftDocumentViewerDocument.jsx
+++ b/web-client/src/views/DocketRecord/DraftDocumentViewerDocument.jsx
@@ -89,7 +89,7 @@ export const DraftDocumentViewerDocument = connect(
                 icon="trash"
                 onClick={() =>
                   archiveDraftDocumentModalSequence({
-                    caseId: caseDetail.caseId,
+                    docketNumber: caseDetail.docketNumber,
                     documentId: viewerDraftDocumentToDisplay.documentId,
                     documentTitle: viewerDraftDocumentToDisplay.documentTitle,
                     redirectToCaseDetail: true,

--- a/web-client/src/views/DocumentDetail/DocumentDetailHeader.jsx
+++ b/web-client/src/views/DocumentDetail/DocumentDetailHeader.jsx
@@ -61,7 +61,6 @@ export const DocumentDetailHeader = connect(
                     icon="edit"
                     onClick={() => {
                       openConfirmEditModalSequence({
-                        caseId: formattedCaseDetail.caseId,
                         docketNumber: formattedCaseDetail.docketNumber,
                         documentIdToEdit:
                           documentDetailHelper.formattedDocument.documentId,
@@ -87,7 +86,7 @@ export const DocumentDetailHeader = connect(
                   icon="trash"
                   onClick={() => {
                     archiveDraftDocumentModalSequence({
-                      caseId: caseDetail.caseId,
+                      docketNumber: caseDetail.docketNumber,
                       documentId:
                         documentDetailHelper.formattedDocument.documentId,
                       documentTitle:

--- a/web-client/src/views/FileDocument/MultiDocumentPartiesFilingReview.jsx
+++ b/web-client/src/views/FileDocument/MultiDocumentPartiesFilingReview.jsx
@@ -11,7 +11,7 @@ export const MultiDocumentPartiesFilingReview = connect(
     return selectedCases.map(selectedCase => (
       <div
         className="tablet:grid-col-3 margin-bottom-5"
-        key={selectedCase.caseId}
+        key={selectedCase.docketNumber}
       >
         <label className="usa-label" htmlFor="filing-parties">
           {selectedCase.docketNumber} {selectedCase.caseTitle}

--- a/wikiwiki/Glossary.md
+++ b/wikiwiki/Glossary.md
@@ -37,8 +37,6 @@ Court's Glossary of USTC Terminology: https://www.ustaxcourt.gov/taxpayer_info_g
 
 * **Case Detail Page** - Central summary page for an individual case and all case activity.
 
-* **CaseID** - Unique case ID only used by the system.
-
 * **Case Information Tab** - One of the tab options on the Case Detail page, displaying petition details such as Petition Details, Trial Information, and all Party Information
 
 * **Case Inventory Report** - a list of all cases within the system, filterable by judge and with the ability to print


### PR DESCRIPTION
* Remove caseId from tests
* Remove caseId from views
* Use docketNumber for createCourtIssuedOrderPdfFromHtmlInteractor
* Use docketNumber for generatePrintableFilingReceiptInteractor