### PR TITLE
Do not show untouched icon if in progress on docket record

### DIFF
--- a/web-client/src/views/DocketRecord/DocketRecord.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecord.jsx
@@ -94,12 +94,13 @@ export const DocketRecord = connect(
                             />
                           )}
 
-                          {entry.qcWorkItemsUntouched && (
-                            <FontAwesomeIcon
-                              icon={['fa', 'star']}
-                              title="is untouched"
-                            />
-                          )}
+                          {entry.qcWorkItemsUntouched &&
+                            !entry.isInProgress && (
+                              <FontAwesomeIcon
+                                icon={['fa', 'star']}
+                                title="is untouched"
+                              />
+                            )}
 
                           {entry.showLoadingIcon && (
                             <FontAwesomeIcon


### PR DESCRIPTION
Per UX Pain Point - We should not show the "QC untouched" icon if the document is in progress.