### PR TITLE
5841 sign Proposed Stipulated Decision from document view

### DIFF
--- a/shared/src/business/useCases/saveSignedDocumentInteractor.js
+++ b/shared/src/business/useCases/saveSignedDocumentInteractor.js
@@ -79,17 +79,6 @@ exports.saveSignedDocumentInteractor = async ({
     document => document.documentId === originalDocumentId,
   );
 
-  const documentIdBeforeSignature = await saveOriginalDocumentWithNewId({
-    applicationContext,
-    originalDocumentId,
-  });
-
-  await replaceOriginalWithSignedDocument({
-    applicationContext,
-    originalDocumentId,
-    signedDocumentId,
-  });
-
   let signedDocumentEntity;
   if (originalDocumentEntity.documentType === 'Proposed Stipulated Decision') {
     signedDocumentEntity = new Document(
@@ -102,6 +91,7 @@ exports.saveSignedDocumentInteractor = async ({
           SIGNED_DOCUMENT_TYPES.signedStipulatedDecision.documentType,
         eventCode: SIGNED_DOCUMENT_TYPES.signedStipulatedDecision.eventCode,
         filedBy: originalDocumentEntity.filedBy,
+        isDraft: true,
         isPaper: false,
         processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
         userId: user.userId,
@@ -113,6 +103,17 @@ exports.saveSignedDocumentInteractor = async ({
 
     caseEntity.addDocumentWithoutDocketRecord(signedDocumentEntity);
   } else {
+    const documentIdBeforeSignature = await saveOriginalDocumentWithNewId({
+      applicationContext,
+      originalDocumentId,
+    });
+
+    await replaceOriginalWithSignedDocument({
+      applicationContext,
+      originalDocumentId,
+      signedDocumentId,
+    });
+
     signedDocumentEntity = new Document(
       {
         ...originalDocumentEntity,

--- a/shared/src/business/useCases/saveSignedDocumentInteractor.test.js
+++ b/shared/src/business/useCases/saveSignedDocumentInteractor.test.js
@@ -84,6 +84,8 @@ describe('saveSignedDocumentInteractor', () => {
     );
 
     expect(signedDocumentEntity.isPaper).toEqual(false);
+    expect(signedDocumentEntity.documentId).toEqual(mockSignedDocumentId);
+    expect(signedDocumentEntity.isDraft).toEqual(true);
     expect(signedDocumentEntity.signedJudgeName).toEqual('Guy Fieri');
     expect(signedDocumentEntity.documentType).toEqual('Stipulated Decision');
   });

--- a/web-client/src/presenter/actions/setSuccessFromDocumentTitleAction.js
+++ b/web-client/src/presenter/actions/setSuccessFromDocumentTitleAction.js
@@ -8,7 +8,11 @@ import { state } from 'cerebral';
  * @param {object} params.store the cerebral store
  * @returns {object} the props with the message
  */
-export const setSuccessFromDocumentTitleAction = ({ get, store }) => {
+export const setSuccessFromDocumentTitleAction = ({
+  applicationContext,
+  get,
+  store,
+}) => {
   const isCreatingOrder = get(state.isCreatingOrder);
   if (isCreatingOrder) {
     store.unset(state.isCreatingOrder);
@@ -20,12 +24,22 @@ export const setSuccessFromDocumentTitleAction = ({ get, store }) => {
     };
   }
 
+  const {
+    PROPOSED_STIPULATED_DECISION_EVENT_CODE,
+  } = applicationContext.getConstants();
   const { documents } = get(state.caseDetail);
   const documentId = get(state.documentId);
   const order = documents.find(d => d.documentId === documentId);
+
+  let successMessage = `${order.documentTitle || order.documentType} updated.`;
+
+  if (order.eventCode === PROPOSED_STIPULATED_DECISION_EVENT_CODE) {
+    successMessage = 'Stipulated Decision signed and saved.';
+  }
+
   return {
     alertSuccess: {
-      message: `${order.documentTitle || order.documentType} updated.`,
+      message: successMessage,
     },
   };
 };

--- a/web-client/src/presenter/actions/setSuccessFromDocumentTitleAction.test.js
+++ b/web-client/src/presenter/actions/setSuccessFromDocumentTitleAction.test.js
@@ -1,15 +1,23 @@
+import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
+import { presenter } from '../presenter-mock';
 import { runAction } from 'cerebral/test';
 import { setSuccessFromDocumentTitleAction } from './setSuccessFromDocumentTitleAction';
 
 describe('setSuccessFromDocumentTitleAction,', () => {
-  it('sets the success message from the documentTitle', async () => {
+  presenter.providers.applicationContext = applicationContext;
+
+  it('sets the success message from the documentTitle when the document eventCode is not PSDE', async () => {
     const result = await runAction(setSuccessFromDocumentTitleAction, {
+      modules: {
+        presenter,
+      },
       state: {
         caseDetail: {
           documents: [
             {
               documentId: 'abc',
               documentTitle: 'Order',
+              eventCode: 'O',
             },
           ],
         },
@@ -20,14 +28,18 @@ describe('setSuccessFromDocumentTitleAction,', () => {
     expect(result.output.alertSuccess.message).toEqual('Order updated.');
   });
 
-  it('sets the success message from the documentType if documentTitle is not present', async () => {
+  it('sets the success message from the documentType if documentTitle is not present and the eventCode is not PSDE', async () => {
     const result = await runAction(setSuccessFromDocumentTitleAction, {
+      modules: {
+        presenter,
+      },
       state: {
         caseDetail: {
           documents: [
             {
               documentId: 'abc',
               documentType: 'Order',
+              eventCode: 'O',
             },
           ],
         },
@@ -40,6 +52,9 @@ describe('setSuccessFromDocumentTitleAction,', () => {
 
   it('sets the created document success message if state.isCreatingOrder is true', async () => {
     const result = await runAction(setSuccessFromDocumentTitleAction, {
+      modules: {
+        presenter,
+      },
       state: {
         caseDetail: {
           documents: [
@@ -56,6 +71,30 @@ describe('setSuccessFromDocumentTitleAction,', () => {
 
     expect(result.output.alertSuccess.message).toEqual(
       'Your document has been successfully created and attached to this message',
+    );
+  });
+
+  it('should set the success message when the signed document eventCode is PSDE', async () => {
+    const result = await runAction(setSuccessFromDocumentTitleAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        caseDetail: {
+          documents: [
+            {
+              documentId: 'abc',
+              documentType: 'Proposed Stipulated Decision',
+              eventCode: 'PSDE',
+            },
+          ],
+        },
+        documentId: 'abc',
+      },
+    });
+
+    expect(result.output.alertSuccess.message).toEqual(
+      'Stipulated Decision signed and saved.',
     );
   });
 });

--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.js
@@ -4,6 +4,7 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
   const {
     EVENT_CODES_REQUIRING_SIGNATURE,
     NOTICE_EVENT_CODES,
+    STIPULATED_DECISION_EVENT_CODE,
   } = applicationContext.getConstants();
   const user = applicationContext.getCurrentUser();
   const permissions = get(state.permissions);
@@ -27,6 +28,10 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
   const isNotice =
     viewerDraftDocumentToDisplay &&
     NOTICE_EVENT_CODES.includes(viewerDraftDocumentToDisplay.eventCode);
+
+  const isStipulatedDecision =
+    viewerDraftDocumentToDisplay &&
+    viewerDraftDocumentToDisplay.eventCode === STIPULATED_DECISION_EVENT_CODE;
 
   const formattedDocumentToDisplay =
     viewerDraftDocumentToDisplay &&
@@ -58,6 +63,12 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
   const showEditButtonForRole = isInternalUser;
   const showApplyRemoveSignatureButtonForRole = isInternalUser;
 
+  const showEditButtonSigned =
+    showEditButtonForRole &&
+    documentIsSigned &&
+    !isNotice &&
+    !isStipulatedDecision;
+
   const showAddDocketEntryButtonForDocument =
     documentIsSigned ||
     !EVENT_CODES_REQUIRING_SIGNATURE.includes(
@@ -65,7 +76,8 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
     );
 
   const showApplySignatureButtonForDocument = !documentIsSigned;
-  const showRemoveSignatureButtonForDocument = documentIsSigned && !isNotice;
+  const showRemoveSignatureButtonForDocument =
+    documentIsSigned && !isNotice && !isStipulatedDecision;
 
   const showDocumentNotSignedAlert =
     documentRequiresSignature && !documentIsSigned;
@@ -81,8 +93,7 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
     showDocumentNotSignedAlert,
     showEditButtonNotSigned:
       showEditButtonForRole && (!documentIsSigned || isNotice),
-    showEditButtonSigned:
-      showEditButtonForRole && documentIsSigned && !isNotice,
+    showEditButtonSigned,
     showRemoveSignatureButton:
       showApplyRemoveSignatureButtonForRole &&
       showRemoveSignatureButtonForDocument,

--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
@@ -593,7 +593,7 @@ describe('draftDocumentViewerHelper', () => {
     expect(result.showEditButtonSigned).toEqual(false);
   });
 
-  it('return showEditButtonNotSigned true and showEditButtonSigned false for a Stipulated Decision document', () => {
+  it('return showEditButtonNotSigned false and showEditButtonSigned false for a Stipulated Decision document', () => {
     applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
 
     const result = runCompute(draftDocumentViewerHelper, {
@@ -619,6 +619,7 @@ describe('draftDocumentViewerHelper', () => {
       },
     });
 
+    expect(result.showEditButtonNotSigned).toEqual(false);
     expect(result.showEditButtonSigned).toEqual(false);
   });
 

--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
@@ -456,6 +456,35 @@ describe('draftDocumentViewerHelper', () => {
     expect(result.showRemoveSignatureButton).toEqual(false);
   });
 
+  it('returns showRemoveSignatureButton false for SDEC document type and internal users', () => {
+    applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
+
+    const result = runCompute(draftDocumentViewerHelper, {
+      state: {
+        ...getBaseState(docketClerkUser),
+        caseDetail: {
+          docketRecord: [],
+          documents: [
+            {
+              documentId: 'abc',
+              documentTitle: 'Stipulated Decision',
+              documentType: 'Stipulated Decision',
+              eventCode: 'SDEC',
+              isDraft: true,
+              signedAt: '2020-06-25T20:49:28.192Z',
+            },
+          ],
+        },
+        viewerDraftDocumentToDisplay: {
+          documentId: 'abc',
+          eventCode: 'SDEC',
+        },
+      },
+    });
+
+    expect(result.showRemoveSignatureButton).toEqual(false);
+  });
+
   it('return showEditButtonSigned true for an internal user and a document that is signed', () => {
     applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
 
@@ -561,6 +590,35 @@ describe('draftDocumentViewerHelper', () => {
     });
 
     expect(result.showEditButtonNotSigned).toEqual(true);
+    expect(result.showEditButtonSigned).toEqual(false);
+  });
+
+  it('return showEditButtonNotSigned true and showEditButtonSigned false for a Stipulated Decision document', () => {
+    applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
+
+    const result = runCompute(draftDocumentViewerHelper, {
+      state: {
+        ...getBaseState(docketClerkUser),
+        caseDetail: {
+          docketRecord: [],
+          documents: [
+            {
+              documentId: 'abc',
+              documentTitle: 'Stipulated Decision',
+              documentType: 'Stipulated Decision',
+              eventCode: 'SDEC',
+              isDraft: true,
+              signedAt: '2020-06-25T20:49:28.192Z',
+            },
+          ],
+        },
+        viewerDraftDocumentToDisplay: {
+          documentId: 'abc',
+          eventCode: 'SDEC',
+        },
+      },
+    });
+
     expect(result.showEditButtonSigned).toEqual(false);
   });
 


### PR DESCRIPTION
Items added in this PR:
- On Save, create draft with event code SDEC
- Navigate to Drafts with success message displayed “Stipulated Decision signed and saved.”
-  Stipulated Decision PDF is created with signature applied
- Stipulated Decision is displayed in Drafts list
- 'Remove Signature' option is hidden in toolbar
-  'Edit' option is hidden in toolbar