### PR TITLE
5511: delete old case message records; fix judge's dashboard recent messages

### DIFF
--- a/web-api/migrations/00023-old-message-records.js
+++ b/web-api/migrations/00023-old-message-records.js
@@ -1,0 +1,22 @@
+const {
+  DOCKET_NUMBER_MATCHER,
+} = require('../../shared/src/business/entities/EntityConstants');
+const { isCaseMessageRecord, upGenerator } = require('./utilities');
+
+const mutateRecord = async (item, documentClient, tableName) => {
+  if (isCaseMessageRecord(item)) {
+    const caseIdentifier = item.pk.split('|')[1];
+
+    if (caseIdentifier && !caseIdentifier.match(DOCKET_NUMBER_MATCHER)) {
+      await documentClient.delete({
+        Key: {
+          pk: item.pk,
+          sk: item.sk,
+        },
+        TableName: tableName,
+      });
+    }
+  }
+};
+
+module.exports = { mutateRecord, up: upGenerator(mutateRecord) };

--- a/web-api/migrations/00023-old-message-records.test.js
+++ b/web-api/migrations/00023-old-message-records.test.js
@@ -1,0 +1,70 @@
+const { forAllRecords } = require('./utilities');
+const { up } = require('./00023-old-message-records');
+
+describe('delete old case message records', () => {
+  let documentClient;
+  let scanStub;
+  let putStub;
+  let deleteStub;
+  let mockItems = [];
+
+  const DOCKET_NUMBER = '101-20';
+  const CASE_ID = 'd4e78eb9-33cf-434b-a266-c2b51a909a6d';
+  const MESSAGE_ID = '4bf4a134-e2cd-4c78-b3e6-b2570e17129e';
+
+  const mockNewCaseMessageRecord = {
+    pk: `case|${DOCKET_NUMBER}`,
+    sk: `message|${MESSAGE_ID}`,
+  };
+  const mockOldCaseMessageRecord = {
+    pk: `case|${CASE_ID}`,
+    sk: `message|${MESSAGE_ID}`,
+  };
+
+  beforeEach(() => {
+    mockItems = [mockNewCaseMessageRecord, mockOldCaseMessageRecord];
+
+    scanStub = jest.fn().mockReturnValue({
+      promise: async () => ({
+        Items: mockItems,
+      }),
+    });
+
+    putStub = jest.fn().mockReturnValue({
+      promise: async () => ({}),
+    });
+
+    deleteStub = jest.fn().mockReturnValue({
+      promise: async () => ({}),
+    });
+
+    documentClient = {
+      delete: deleteStub,
+      put: putStub,
+      scan: scanStub,
+    };
+  });
+
+  it('should not modify records that are are NOT a case message', async () => {
+    mockItems = [
+      {
+        pk: 'case|101-20',
+        sk: 'case|101-20',
+      },
+    ];
+
+    await up(documentClient, '', forAllRecords);
+
+    expect(putStub).not.toBeCalled();
+  });
+
+  it('should call delete on case message records that do not use a docketNumber in the pk to reference the case', async () => {
+    await up(documentClient, '', forAllRecords);
+
+    expect(putStub).not.toBeCalled();
+    expect(deleteStub.mock.calls.length).toEqual(1);
+    expect(deleteStub.mock.calls[0][0].Key).toMatchObject(
+      mockOldCaseMessageRecord,
+    );
+  });
+});

--- a/web-client/src/presenter/computeds/formattedWorkQueue.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.js
@@ -226,78 +226,75 @@ export const filterWorkItems = ({
   });
 
   const filters = {
-    documentQc: {
-      my: {
-        inProgress: item => {
-          return (
-            // DocketClerks
-            (item.assigneeId === user.userId &&
-              user.role === USER_ROLES.docketClerk &&
-              !item.completedAt &&
-              item.section === user.section &&
-              (item.document.isFileAttached === false || item.inProgress)) ||
-            // PetitionsClerks
-            (item.assigneeId === user.userId &&
-              user.role === USER_ROLES.petitionsClerk &&
-              item.caseStatus === STATUS_TYPES.new &&
-              item.caseIsInProgress === true)
-          );
-        },
-        inbox: item => {
-          return (
-            item.assigneeId === user.userId &&
+    my: {
+      inProgress: item => {
+        return (
+          // DocketClerks
+          (item.assigneeId === user.userId &&
+            user.role === USER_ROLES.docketClerk &&
             !item.completedAt &&
             item.section === user.section &&
-            item.document.isFileAttached !== false &&
-            !item.inProgress &&
-            item.caseIsInProgress !== true
-          );
-        },
-        outbox: item => {
-          return (
-            (user.role === USER_ROLES.petitionsClerk ? !!item.section : true) &&
-            item.completedByUserId &&
-            item.completedByUserId === user.userId &&
-            !!item.completedAt
-          );
-        },
+            (item.document.isFileAttached === false || item.inProgress)) ||
+          // PetitionsClerks
+          (item.assigneeId === user.userId &&
+            user.role === USER_ROLES.petitionsClerk &&
+            item.caseStatus === STATUS_TYPES.new &&
+            item.caseIsInProgress === true)
+        );
       },
-      section: {
-        inProgress: item => {
-          return (
-            // DocketClerks
-            (!item.completedAt &&
-              user.role === USER_ROLES.docketClerk &&
-              item.section === user.section &&
-              (item.document.isFileAttached === false || item.inProgress)) ||
-            // PetitionsClerks
-            (user.role === USER_ROLES.petitionsClerk &&
-              item.caseStatus === STATUS_TYPES.new &&
-              item.caseIsInProgress === true)
-          );
-        },
-        inbox: item => {
-          return (
-            !item.completedAt &&
-            item.section === docQCUserSection &&
-            item.document.isFileAttached !== false &&
-            !item.inProgress &&
-            additionalFilters(item) &&
-            item.caseIsInProgress !== true
-          );
-        },
-        outbox: item => {
-          return (
-            !!item.completedAt &&
-            (user.role === USER_ROLES.petitionsClerk ? !!item.section : true)
-          );
-        },
+      inbox: item => {
+        return (
+          item.assigneeId === user.userId &&
+          !item.completedAt &&
+          item.section === user.section &&
+          item.document.isFileAttached !== false &&
+          !item.inProgress &&
+          item.caseIsInProgress !== true
+        );
+      },
+      outbox: item => {
+        return (
+          (user.role === USER_ROLES.petitionsClerk ? !!item.section : true) &&
+          item.completedByUserId &&
+          item.completedByUserId === user.userId &&
+          !!item.completedAt
+        );
+      },
+    },
+    section: {
+      inProgress: item => {
+        return (
+          // DocketClerks
+          (!item.completedAt &&
+            user.role === USER_ROLES.docketClerk &&
+            item.section === user.section &&
+            (item.document.isFileAttached === false || item.inProgress)) ||
+          // PetitionsClerks
+          (user.role === USER_ROLES.petitionsClerk &&
+            item.caseStatus === STATUS_TYPES.new &&
+            item.caseIsInProgress === true)
+        );
+      },
+      inbox: item => {
+        return (
+          !item.completedAt &&
+          item.section === docQCUserSection &&
+          item.document.isFileAttached !== false &&
+          !item.inProgress &&
+          additionalFilters(item) &&
+          item.caseIsInProgress !== true
+        );
+      },
+      outbox: item => {
+        return (
+          !!item.completedAt &&
+          (user.role === USER_ROLES.petitionsClerk ? !!item.section : true)
+        );
       },
     },
   };
 
-  const view = 'documentQc';
-  const composedFilter = filters[view][queue][box];
+  const composedFilter = filters[queue][box];
   return composedFilter;
 };
 
@@ -336,66 +333,38 @@ export const formattedWorkQueue = (get, applicationContext) => {
     });
 
   const sortFields = {
-    documentQc: {
-      my: {
-        inProgress: 'receivedAt',
-        inbox: 'receivedAt',
-        outbox:
-          user.role === USER_ROLES.petitionsClerk
-            ? 'completedAt'
-            : 'receivedAt',
-      },
-      section: {
-        inProgress: 'receivedAt',
-        inbox: 'receivedAt',
-        outbox:
-          user.role === USER_ROLES.petitionsClerk
-            ? 'completedAt'
-            : 'receivedAt',
-      },
+    my: {
+      inProgress: 'receivedAt',
+      inbox: 'receivedAt',
+      outbox:
+        user.role === USER_ROLES.petitionsClerk ? 'completedAt' : 'receivedAt',
     },
-    messages: {
-      my: {
-        inbox: 'receivedAt',
-        outbox: 'receivedAt',
-      },
-      section: {
-        inbox: 'receivedAt',
-        outbox: 'receivedAt',
-      },
+    section: {
+      inProgress: 'receivedAt',
+      inbox: 'receivedAt',
+      outbox:
+        user.role === USER_ROLES.petitionsClerk ? 'completedAt' : 'receivedAt',
     },
   };
 
   const sortDirections = {
-    documentQc: {
-      my: {
-        inProgress: 'asc',
-        inbox: 'asc',
-        outbox: 'desc',
-      },
-      section: {
-        inProgress: 'asc',
-        inbox: 'asc',
-        outbox: 'desc',
-      },
+    my: {
+      inProgress: 'asc',
+      inbox: 'asc',
+      outbox: 'desc',
     },
-    messages: {
-      my: {
-        inbox: 'asc',
-        outbox: 'desc',
-      },
-      section: {
-        inbox: 'asc',
-        outbox: 'desc',
-      },
+    section: {
+      inProgress: 'asc',
+      inbox: 'asc',
+      outbox: 'desc',
     },
   };
 
   const sortField =
-    sortFields.documentQc[workQueueToDisplay.queue][workQueueToDisplay.box];
+    sortFields[workQueueToDisplay.queue][workQueueToDisplay.box];
 
   const sortDirection =
-    sortDirections.documentQc[workQueueToDisplay.queue][workQueueToDisplay.box];
+    sortDirections[workQueueToDisplay.queue][workQueueToDisplay.box];
 
   let highPriorityField = [];
   let highPriorityDirection = [];

--- a/web-client/src/presenter/computeds/recentMessagesHelper.js
+++ b/web-client/src/presenter/computeds/recentMessagesHelper.js
@@ -1,0 +1,15 @@
+import { getFormattedMessages } from './formattedMessages';
+import { state } from 'cerebral';
+
+export const recentMessagesHelper = (get, applicationContext) => {
+  const { messages } = getFormattedMessages({
+    applicationContext,
+    messages: get(state.messages) || [],
+  });
+
+  const recentMessages = messages.reverse().splice(0, 5);
+
+  return {
+    recentMessages,
+  };
+};

--- a/web-client/src/presenter/computeds/recentMessagesHelper.test.js
+++ b/web-client/src/presenter/computeds/recentMessagesHelper.test.js
@@ -1,0 +1,91 @@
+import { recentMessagesHelper as recentMessagesHelperComputed } from './recentMessagesHelper';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../withAppContext';
+
+const recentMessagesHelper = withAppContextDecorator(
+  recentMessagesHelperComputed,
+);
+
+describe('recentMessagesHelper', () => {
+  it('returns 5 most recent messages', () => {
+    const result = runCompute(recentMessagesHelper, {
+      state: {
+        messages: [
+          {
+            createdAt: '2019-01-01T00:00:00.000Z',
+            docketNumber: '102-20',
+            message: 'This is a test message',
+          },
+          {
+            createdAt: '2019-01-02T00:00:00.000Z',
+            docketNumber: '102-20',
+            isCompleted: true,
+            message: 'This is a test message',
+          },
+          {
+            createdAt: '2019-01-03T00:00:00.000Z',
+            docketNumber: '102-20',
+            message: 'This is a test message',
+          },
+          {
+            createdAt: '2019-01-04T00:00:00.000Z',
+            docketNumber: '102-20',
+            message: 'This is a test message',
+          },
+          {
+            createdAt: '2019-01-05T00:00:00.000Z',
+            docketNumber: '102-20',
+            message: 'This is a test message',
+          },
+          {
+            createdAt: '2019-01-06T00:00:00.000Z',
+            docketNumber: '102-20',
+            message: 'This is a test message',
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      recentMessages: [
+        {
+          createdAt: '2019-01-06T00:00:00.000Z',
+          docketNumber: '102-20',
+          message: 'This is a test message',
+        },
+        {
+          createdAt: '2019-01-05T00:00:00.000Z',
+          docketNumber: '102-20',
+          message: 'This is a test message',
+        },
+        {
+          createdAt: '2019-01-04T00:00:00.000Z',
+          docketNumber: '102-20',
+          message: 'This is a test message',
+        },
+        {
+          createdAt: '2019-01-03T00:00:00.000Z',
+          docketNumber: '102-20',
+          message: 'This is a test message',
+        },
+        {
+          createdAt: '2019-01-02T00:00:00.000Z',
+          docketNumber: '102-20',
+          message: 'This is a test message',
+        },
+      ],
+    });
+  });
+
+  it('returns an empty array for recentMessages if state.messages is undefined', () => {
+    const result = runCompute(recentMessagesHelper, {
+      state: {
+        messages: undefined,
+      },
+    });
+
+    expect(result).toMatchObject({
+      recentMessages: [],
+    });
+  });
+});

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -67,6 +67,7 @@ import { pdfSignerHelper } from './computeds/pdfSignerHelper';
 import { practitionerDetailHelper } from './computeds/practitionerDetailHelper';
 import { practitionerSearchFormHelper } from './computeds/practitionerSearchFormHelper';
 import { printPaperServiceHelper } from './computeds/printPaperServiceHelper';
+import { recentMessagesHelper } from './computeds/recentMessagesHelper';
 import { requestAccessHelper } from './computeds/requestAccessHelper';
 import { reviewSavedPetitionHelper } from './computeds/reviewSavedPetitionHelper';
 import { scanBatchPreviewerHelper } from './computeds/scanBatchPreviewerHelper';
@@ -157,6 +158,7 @@ const helpers = {
   practitionerDetailHelper,
   practitionerSearchFormHelper,
   printPaperServiceHelper,
+  recentMessagesHelper,
   requestAccessHelper,
   reviewSavedPetitionHelper,
   scanBatchPreviewerHelper,

--- a/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
+++ b/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
@@ -5,9 +5,9 @@ import React from 'react';
 
 export const RecentMessagesInbox = connect(
   {
-    formattedMessages: state.formattedMessages,
+    recentMessagesHelper: state.recentMessagesHelper,
   },
-  function RecentMessagesInbox({ formattedMessages }) {
+  function RecentMessagesInbox({ recentMessagesHelper }) {
     return (
       <React.Fragment>
         <table
@@ -28,7 +28,7 @@ export const RecentMessagesInbox = connect(
               <th>Section</th>
             </tr>
           </thead>
-          {formattedMessages.messages.slice(0, 5).map((item, idx) => {
+          {recentMessagesHelper.recentMessages.map((item, idx) => {
             return (
               <tbody key={idx}>
                 <tr>
@@ -61,7 +61,7 @@ export const RecentMessagesInbox = connect(
             );
           })}
         </table>
-        {formattedMessages.messages.length === 0 && (
+        {recentMessagesHelper.recentMessages.length === 0 && (
           <p>There are no messages.</p>
         )}
       </React.Fragment>


### PR DESCRIPTION
When migrating all the case records, instead of deleting the old records, we `put` the new record with the updated pk. This leaves the old case records in place. Normally that is okay because we retrieve case data by `case|{docketNumber}`, so the old data is just not accessible - except on case messages, where we retrieve them without referencing the case. We now have duplicate case message records that need to be deleted.


---
Also includes fix for judge's dashboard recent messages:

<img width="1392" alt="Screen Shot 2020-08-04 at 9 58 14 AM" src="https://user-images.githubusercontent.com/43251054/89323134-24ad3600-d63a-11ea-9e4b-85ddfd37db65.png">
