### PR TITLE
Valid raw persistence

### DIFF
--- a/shared/src/errors/errors.js
+++ b/shared/src/errors/errors.js
@@ -89,6 +89,24 @@ module.exports.UnsanitizedEntityError = class UnsanitizedEntityError extends Err
 };
 
 /**
+ * UnblessedPersistenceError error
+ *
+ * @type {module.UnblessedPersistenceError}
+ */
+module.exports.UnblessedPersistenceError = class UnblessedPersistenceError extends Error {
+  /**
+   * constructor
+   *
+   * @param {string} message the error message
+   */
+  constructor(message = 'Unblessed entity') {
+    super(message);
+
+    this.statusCode = 500;
+  }
+};
+
+/**
  * InvalidEntityError error
  *
  * @type {module.InvalidEntityError}

--- a/shared/src/errors/errors.test.js
+++ b/shared/src/errors/errors.test.js
@@ -2,6 +2,7 @@ const {
   InvalidEntityError,
   NotFoundError,
   UnauthorizedError,
+  UnblessedPersistenceError,
   UnknownUserError,
   UnprocessableEntityError,
   UnsanitizedEntityError,
@@ -68,6 +69,22 @@ describe('UnprocessableEntityError', () => {
 
   it('should set the message', () => {
     expect(error.message).toEqual('cannot process');
+  });
+});
+
+describe('UnblessedPersistenceError', () => {
+  let error;
+
+  beforeEach(() => {
+    error = new UnblessedPersistenceError();
+  });
+
+  it('should set a status code of 500', () => {
+    expect(error.statusCode).toEqual(500);
+  });
+
+  it('should set the message', () => {
+    expect(error.message).toEqual('Unblessed entity');
   });
 });
 

--- a/shared/src/persistence/dynamo/cases/updateCase.js
+++ b/shared/src/persistence/dynamo/cases/updateCase.js
@@ -33,6 +33,10 @@ const { UnblessedPersistenceError } = require('../../../errors/errors');
  * @returns {Promise} the promise of the persistence calls
  */
 exports.updateCase = async ({ applicationContext, caseToUpdate }) => {
+  if (!caseToUpdate.blessed) {
+    throw new UnblessedPersistenceError();
+  }
+
   const oldCase = await getCaseByDocketNumber({
     applicationContext,
     docketNumber: caseToUpdate.docketNumber,
@@ -47,7 +51,9 @@ exports.updateCase = async ({ applicationContext, caseToUpdate }) => {
   );
 
   updatedDocketRecord.forEach(docketEntry => {
-    docketEntry.blessed || throw new UnblessedPersistenceError();
+    if (!docketEntry.blessed) {
+      throw new UnblessedPersistenceError();
+    }
     requests.push(
       client.put({
         Item: {
@@ -67,6 +73,9 @@ exports.updateCase = async ({ applicationContext, caseToUpdate }) => {
   );
 
   updatedDocuments.forEach(document => {
+    if (!document.blessed) {
+      throw new UnblessedPersistenceError();
+    }
     requests.push(
       client.put({
         Item: {

--- a/shared/src/persistence/dynamo/cases/updateCase.js
+++ b/shared/src/persistence/dynamo/cases/updateCase.js
@@ -22,6 +22,7 @@ const { Case } = require('../../../business/entities/cases/Case');
 const { differenceWith, isEqual } = require('lodash');
 const { getCaseByDocketNumber } = require('../cases/getCaseByDocketNumber');
 const { omit } = require('lodash');
+const { UnblessedPersistenceError } = require('../../../errors/errors');
 
 /**
  * updateCase
@@ -46,6 +47,7 @@ exports.updateCase = async ({ applicationContext, caseToUpdate }) => {
   );
 
   updatedDocketRecord.forEach(docketEntry => {
+    docketEntry.blessed || throw new UnblessedPersistenceError();
     requests.push(
       client.put({
         Item: {

--- a/shared/src/persistence/dynamo/cases/updateCase.test.js
+++ b/shared/src/persistence/dynamo/cases/updateCase.test.js
@@ -8,6 +8,8 @@ const {
 } = require('../../../business/entities/EntityConstants');
 const { updateCase } = require('./updateCase');
 
+const blessed = true;
+
 describe('updateCase', () => {
   let firstQueryStub;
   let secondQueryStub;
@@ -76,6 +78,7 @@ describe('updateCase', () => {
     await updateCase({
       applicationContext,
       caseToUpdate: {
+        blessed,
         docketNumber: '101-18',
         docketNumberSuffix: null,
         status: CASE_STATUS_TYPES.generalDocket,
@@ -91,11 +94,26 @@ describe('updateCase', () => {
     });
   });
 
+  it('throws exception for an unblessed case entity', async () => {
+    await expect(
+      updateCase({
+        applicationContext,
+        caseToUpdate: {
+          docketNumber: '101-18',
+          docketNumberSuffix: null,
+          status: CASE_STATUS_TYPES.generalDocket,
+          userId: 'petitioner',
+        },
+      }),
+    ).rejects.toThrow('Unblessed entity');
+  });
+
   it('updates fields on work items', async () => {
     await updateCase({
       applicationContext,
       caseToUpdate: {
         associatedJudge: 'Judge Buch',
+        blessed,
         caseCaption: 'Johnny Joe Jacobson, Petitioner',
         docketNumber: '101-18',
         docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
@@ -161,6 +179,7 @@ describe('updateCase', () => {
       applicationContext,
       caseToUpdate: {
         associatedJudge: 'Judge Buch',
+        blessed,
         docketNumberSuffix: null,
         status: CASE_STATUS_TYPES.generalDocket,
       },
@@ -179,6 +198,7 @@ describe('updateCase', () => {
     await updateCase({
       applicationContext,
       caseToUpdate: {
+        blessed,
         docketNumber: '101-18',
         docketNumberSuffix: null,
         status: CASE_STATUS_TYPES.generalDocket,
@@ -199,6 +219,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           irsPractitioners: [
@@ -225,6 +246,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           irsPractitioners: [
@@ -269,6 +291,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           irsPractitioners: [
@@ -313,6 +336,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           irsPractitioners: [
@@ -343,6 +367,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           privatePractitioners: [
@@ -371,6 +396,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           privatePractitioners: [
@@ -404,6 +430,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           privatePractitioners: [
@@ -438,6 +465,7 @@ describe('updateCase', () => {
       await updateCase({
         applicationContext,
         caseToUpdate: {
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           privatePractitioners: [
@@ -476,6 +504,7 @@ describe('updateCase', () => {
         applicationContext,
         caseToUpdate: {
           associatedJudge: 'Judge Buch',
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           inProgress: true,
@@ -500,6 +529,7 @@ describe('updateCase', () => {
         applicationContext,
         caseToUpdate: {
           associatedJudge: 'Judge Buch',
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
           inProgress: true,
@@ -524,6 +554,7 @@ describe('updateCase', () => {
         applicationContext,
         caseToUpdate: {
           associatedJudge: 'Judge Buch',
+          blessed,
           caseCaption: 'Guy Fieri, Petitioner',
           docketNumber: '101-18',
           docketNumberSuffix: null,
@@ -549,6 +580,7 @@ describe('updateCase', () => {
         applicationContext,
         caseToUpdate: {
           associatedJudge: 'Judge Buch',
+          blessed,
           docketNumber: '101-18',
           docketNumberSuffix: null,
           inProgress: true,

--- a/shared/src/persistence/dynamo/documents/updateDocument.js
+++ b/shared/src/persistence/dynamo/documents/updateDocument.js
@@ -1,4 +1,5 @@
 const client = require('../../dynamodbClientService');
+const { UnblessedPersistenceError } = require('../../../errors/errors');
 
 exports.updateDocument = async ({
   applicationContext,
@@ -6,6 +7,7 @@ exports.updateDocument = async ({
   document,
   documentId,
 }) => {
+  document.blessed || throw new UnblessedPersistenceError();
   await client.put({
     Item: {
       pk: `case|${docketNumber}`,

--- a/shared/src/persistence/dynamo/documents/updateDocument.js
+++ b/shared/src/persistence/dynamo/documents/updateDocument.js
@@ -7,7 +7,9 @@ exports.updateDocument = async ({
   document,
   documentId,
 }) => {
-  document.blessed || throw new UnblessedPersistenceError();
+  if (!document.blessed) {
+    throw new UnblessedPersistenceError();
+  }
   await client.put({
     Item: {
       pk: `case|${docketNumber}`,

--- a/shared/src/persistence/dynamo/documents/updateDocument.test.js
+++ b/shared/src/persistence/dynamo/documents/updateDocument.test.js
@@ -7,6 +7,7 @@ const mockDocumentId = '9b52c605-edba-41d7-b045-d5f992a499d3';
 const mockDocketNumber = '101-20';
 
 const mockDocument = {
+  blessed: true,
   documentId: mockDocumentId,
   documentTitle: 'Title of le Document',
   filedBy: 'The one and only, Guy Fieri',

--- a/shared/src/utilities/JoiValidationDecorator.js
+++ b/shared/src/utilities/JoiValidationDecorator.js
@@ -26,7 +26,23 @@ function toRawObject(entity) {
       obj[key] = value;
     }
   }
+  if (entity.blessed) {
+    bless(obj);
+  }
   return obj;
+}
+
+/**
+ * adds non-enumerable property 'blessed' to entity instances, objects, anything
+ *
+ * @param {object} the entity or object to be blessed
+ */
+function bless(obj) {
+  Object.defineProperty(obj, 'blessed', {
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
 }
 
 /**
@@ -174,6 +190,7 @@ exports.joiValidationDecorator = function (
         JSON.stringify(stringifyTransform(this.getValidationErrors())),
       );
     }
+    bless(this);
     return this;
   };
 
@@ -201,9 +218,7 @@ exports.joiValidationDecorator = function (
   const toRawObjectPrototype = function () {
     return toRawObject(this);
   };
-
   entityConstructor.prototype.toRawObject = toRawObjectPrototype;
-
   entityConstructor.prototype.toRawObjectFromJoi = toRawObjectPrototype;
 
   entityConstructor.validateRawCollection = function (

--- a/shared/src/utilities/JoiValidationDecorator.test.js
+++ b/shared/src/utilities/JoiValidationDecorator.test.js
@@ -90,6 +90,7 @@ describe('Joi Validation Decorator', () => {
         optionalThing: validNested,
       });
       expect(obj.isValid()).toBe(false);
+      expect(Object.hasOwnProperty(obj, 'blessed')).toBeFalsy();
       const errors = obj.getFormattedValidationErrors();
       expect(Object.keys(errors).length).not.toBe(0);
       const rawEntity = validNested.toRawObject();
@@ -161,6 +162,22 @@ describe('Joi Validation Decorator', () => {
     expect(error.message).toContain("'somethingId' is required");
     expect(error.message).toContain('"somethingId":"<undefined>"');
     expect(error.message).toContain('"docketNumber":"123-20"');
+  });
+
+  it('should add non-enumerable property "blessed" when `validate` succeeds, and persists through call to `toRawObject`', () => {
+    const obj1 = new MockCase({
+      docketNumber: '123-20',
+      somethingId: '23-skidoo',
+      title: 'some title',
+    });
+
+    obj1.validate();
+    expect(obj1.blessed).toBe(true);
+    expect(Object.keys(obj1)).not.toContain('blessed'); // not enumerable
+
+    const rawObj = obj1.toRawObject();
+    expect(rawObj.blessed).toBe(true);
+    expect(Object.keys(rawObj)).not.toContain('blessed'); // not enumerable
   });
 
   it('should have access to the schema without instantiating the entity', () => {


### PR DESCRIPTION
_*Edit for TL;DR*: we are at risk of "invalid" data making its way into persistence if hitchhiking on an entity that hasn't been validated. This is a proposed solution._

Updated `JoiValidationDecorator` so that when an entity calls `.validate()`, it will attach a non-enumerable property named 'blessed'.  If then `.toRawObject()` is called, the non-enumerable property `blessed` is added to the object being returned.

When I say 'non-enumerable', it means that although you may be able to `assert(entity.blessed)`, this property will not be produced by `Object.keys(entity)`, nor by `{...entity}`, meaning that it will not be sent to persistence.

Persistence methods (dynamo) can then check for this property and elect to throw an exception if it is not `true`.  This can be another way we prevent invalid data from making its way into persistence.  Discuss.

One thing I'm thinking of already is that this mechanism could be easily circumvented by calling `.validate()`, changing something else on the entity that causes it to fail validation, but still send to persistence with the flag which remains.