### PR TITLE
Update served / processed QC views

### DIFF
--- a/web-client/src/presenter/computeds/formattedWorkQueue.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.js
@@ -65,9 +65,10 @@ export const formatWorkItem = ({
 
   result.highPriority = !!result.highPriority;
   result.sentBySection = capitalize(result.sentBySection);
-  result.completedAtFormatted = applicationContext
-    .getUtilities()
-    .formatDateString(result.completedAt, 'DATE_TIME');
+  result.completedAtFormatted = formatDateIfToday(
+    result.completedAt,
+    applicationContext,
+  );
   result.completedAtFormattedTZ = applicationContext
     .getUtilities()
     .formatDateString(result.completedAt, 'DATE_TIME_TZ');
@@ -304,7 +305,6 @@ export const formattedWorkQueue = (get, applicationContext) => {
   const workQueueToDisplay = get(state.workQueueToDisplay);
   const permissions = get(state.permissions);
   const selectedWorkItems = get(state.selectedWorkItems);
-  const { USER_ROLES } = applicationContext.getConstants();
 
   const judgeUser = get(state.judgeUser);
 
@@ -336,14 +336,12 @@ export const formattedWorkQueue = (get, applicationContext) => {
     my: {
       inProgress: 'receivedAt',
       inbox: 'receivedAt',
-      outbox:
-        user.role === USER_ROLES.petitionsClerk ? 'completedAt' : 'receivedAt',
+      outbox: 'completedAt',
     },
     section: {
       inProgress: 'receivedAt',
       inbox: 'receivedAt',
-      outbox:
-        user.role === USER_ROLES.petitionsClerk ? 'completedAt' : 'receivedAt',
+      outbox: 'completedAt',
     },
   };
 

--- a/web-client/src/presenter/computeds/formattedWorkQueue.test.js
+++ b/web-client/src/presenter/computeds/formattedWorkQueue.test.js
@@ -912,7 +912,7 @@ describe('formatted work queue computed', () => {
       expect(result.sentBySection).toEqual('Section');
     });
 
-    it('should return completedAtFormatted as DATE_TIME format', () => {
+    it('should return completedAtFormatted as MM/DD/YY format for items older than the prior day', () => {
       const workItem = {
         ...FORMATTED_WORK_ITEM,
         completedAt: '2019-02-28T21:14:39.488Z',
@@ -920,7 +920,42 @@ describe('formatted work queue computed', () => {
       };
 
       const result = formatWorkItem({ applicationContext, workItem });
-      expect(result.completedAtFormatted).toEqual('02/28/19 04:14 pm');
+      expect(result.completedAtFormatted).toEqual('02/28/19');
+    });
+
+    it('should return completedAtFormatted as Yesterday for items from the prior day', () => {
+      const currentTime = applicationContext
+        .getUtilities()
+        .createISODateString();
+      const yesterday = applicationContext
+        .getUtilities()
+        .calculateISODate({ dateString: currentTime, howMuch: -1 });
+
+      const workItem = {
+        ...FORMATTED_WORK_ITEM,
+        completedAt: yesterday,
+        completedAtFormatted: undefined,
+      };
+
+      const result = formatWorkItem({ applicationContext, workItem });
+      expect(result.completedAtFormatted).toEqual('Yesterday');
+    });
+
+    it('should return the current time for items completed today', () => {
+      const currentTime = applicationContext
+        .getUtilities()
+        .createISODateString();
+
+      const workItem = {
+        ...FORMATTED_WORK_ITEM,
+        completedAt: currentTime,
+        completedAtFormatted: undefined,
+      };
+
+      const result = formatWorkItem({ applicationContext, workItem });
+      expect(result.completedAtFormatted).toContain(':');
+      expect(result.completedAtFormatted).toContain('ET');
+      expect(result.completedAtFormatted).not.toContain('/');
     });
 
     it('should return completedAtFormattedTZ as DATE_TIME_TZ format', () => {

--- a/web-client/src/presenter/computeds/workQueueHelper.js
+++ b/web-client/src/presenter/computeds/workQueueHelper.js
@@ -57,7 +57,6 @@ export const workQueueHelper = (get, applicationContext) => {
     showSectionWorkQueue: workQueueToDisplay.queue === 'section',
     showSelectColumn: permissions.ASSIGN_WORK_ITEM,
     showSendToBar: selectedWorkItems.length > 0,
-    showServedColumn: userIsPetitionsClerk,
     showStartPetitionButton,
     workQueueTitle,
   };

--- a/web-client/src/views/WorkQueue/IndividualWorkQueueOutbox.jsx
+++ b/web-client/src/views/WorkQueue/IndividualWorkQueueOutbox.jsx
@@ -30,8 +30,7 @@ export const IndividualWorkQueueOutbox = connect(
               {workQueueHelper.showAssignedToColumn && (
                 <th className="max-width-7">Assigned To</th>
               )}
-              <th>Processed By</th>
-              {workQueueHelper.showServedColumn && <th>Served</th>}
+              <th>{workQueueHelper.sentTitle} Date</th>
             </tr>
           </thead>
           {formattedWorkQueue.map((item, idx) => (
@@ -69,12 +68,9 @@ export const IndividualWorkQueueOutbox = connect(
                     {item.currentMessage.to}
                   </td>
                 )}
-                <td className="message-queue-row">{item.completedBy}</td>
-                {workQueueHelper.showServedColumn && (
-                  <td className="message-queue-row">
-                    {item.completedAtFormatted}
-                  </td>
-                )}
+                <td className="message-queue-row">
+                  {item.completedAtFormatted}
+                </td>
               </tr>
             </tbody>
           ))}

--- a/web-client/src/views/WorkQueue/SectionWorkQueueOutbox.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueOutbox.jsx
@@ -23,12 +23,11 @@ export const SectionWorkQueueOutbox = connect(
               </th>
               <th>Case title</th>
               <th>Document</th>
-              <th>Processed By</th>
               {!workQueueHelper.hideFiledByColumn && <th>Filed By</th>}
               {!workQueueHelper.hideCaseStatusColumn && <th>Case Status</th>}
               {workQueueHelper.showAssignedToColumn && <th>Assigned To</th>}
-              {workQueueHelper.showProcessedByColumn && <th>QC’d By</th>}
-              {workQueueHelper.showServedColumn && <th>Served</th>}
+              <th>{workQueueHelper.sentTitle} By</th>
+              <th>{workQueueHelper.sentTitle} Date</th>
             </tr>
           </thead>
           {formattedWorkQueue.map((item, idx) => (
@@ -55,7 +54,6 @@ export const SectionWorkQueueOutbox = connect(
                     </a>
                   </div>
                 </td>
-                <td className="message-queue-row">{item.completedBy}</td>
                 {!workQueueHelper.hideFiledByColumn && (
                   <td className="message-queue-row">{item.document.filedBy}</td>
                 )}
@@ -67,14 +65,10 @@ export const SectionWorkQueueOutbox = connect(
                     {item.currentMessage.to}
                   </td>
                 )}
-                {workQueueHelper.showProcessedByColumn && (
-                  <td className="message-queue-row">{item.completedBy}</td>
-                )}
-                {workQueueHelper.showServedColumn && (
-                  <td className="message-queue-row">
-                    {item.completedAtFormatted}
-                  </td>
-                )}
+                <td className="message-queue-row">{item.completedBy}</td>
+                <td className="message-queue-row">
+                  {item.completedAtFormatted}
+                </td>
               </tr>
             </tbody>
           ))}


### PR DESCRIPTION
This is just the UI stuff from a previously closed PR.
https://github.com/flexion/ef-cms/pull/6031

Rachael made a really good point that we should address the 7 day fall-off period for outbox items. I ran into some odd situations when I started down this path, and then much of that work was going to be touched in a refactor, so I held off.

I'd like to get the UI changes in and then come back and address the persistence concerns after.