### PR TITLE
Bug: Sorting on Messages > Sent box should be Newest to Oldest

### DIFF
--- a/web-client/src/presenter/computeds/formattedMessages.js
+++ b/web-client/src/presenter/computeds/formattedMessages.js
@@ -40,6 +40,12 @@ export const formattedMessages = (get, applicationContext) => {
     messages: get(state.messages) || [],
   });
 
+  const currentMessageBox = get(state.messageBoxToDisplay.box);
+
+  if (currentMessageBox === 'outbox') {
+    messages.reverse();
+  }
+
   return {
     completedMessages,
     messages,

--- a/web-client/src/presenter/computeds/formattedMessages.test.js
+++ b/web-client/src/presenter/computeds/formattedMessages.test.js
@@ -211,9 +211,12 @@ describe('formattedMessages', () => {
     });
   });
 
-  it('returns filtered and sorted messages and completedMessages from state.messages', () => {
+  it('returns filtered messages sorted oldest to newest and completedMessages from state.messages when messageBoxToDisplay.box is inbox', () => {
     const result = runCompute(formattedMessages, {
       state: {
+        messageBoxToDisplay: {
+          box: 'inbox',
+        },
         messages: [
           {
             completedAt: '2019-01-02T16:29:13.122Z',
@@ -267,6 +270,70 @@ describe('formattedMessages', () => {
           message: 'This is a test message',
         },
       ],
+    });
+  });
+
+  it('returns filtered messages sorted newest to oldest when messageBoxToDisplay.box is outbox', () => {
+    const result = runCompute(formattedMessages, {
+      state: {
+        messageBoxToDisplay: {
+          box: 'outbox',
+        },
+        messages: [
+          {
+            completedAt: '2019-01-02T16:29:13.122Z',
+            createdAt: '2019-01-01T16:29:13.122Z',
+            docketNumber: '101-20',
+            message: 'This is a test message',
+          },
+          {
+            completedAt: '2019-01-01T16:29:13.122Z',
+            createdAt: '2019-01-02T17:29:13.122Z',
+            docketNumber: '103-20',
+            isCompleted: true,
+            message: 'This is a test message',
+          },
+          {
+            completedAt: '2019-01-03T16:29:13.122Z',
+            createdAt: '2019-01-01T17:29:13.122Z',
+            docketNumber: '102-20',
+            message: 'This is a test message',
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      messages: [
+        {
+          completedAt: '2019-01-01T16:29:13.122Z',
+          createdAt: '2019-01-02T17:29:13.122Z',
+          docketNumber: '103-20',
+          isCompleted: true,
+          message: 'This is a test message',
+        },
+        {
+          createdAt: '2019-01-01T17:29:13.122Z',
+          docketNumber: '102-20',
+          message: 'This is a test message',
+        },
+        {
+          createdAt: '2019-01-01T16:29:13.122Z',
+          docketNumber: '101-20',
+          message: 'This is a test message',
+        },
+      ],
+    });
+  });
+
+  it('returns empty arrays for completedMessages and messages if state.messages is not set', () => {
+    const result = runCompute(formattedMessages, {
+      state: {},
+    });
+
+    expect(result).toMatchObject({
+      completedMessages: [],
+      messages: [],
     });
   });
 });


### PR DESCRIPTION
https://trello.com/c/Q8SsxSee/729-sorting-on-messages-sent-box-should-be-newest-to-oldest

<img width="1425" alt="Screen Shot 2020-08-10 at 9 33 39 AM" src="https://user-images.githubusercontent.com/43251054/89810070-5407eb00-daf1-11ea-8b03-df22f4fbca61.png">
