### PR TITLE
Trello 734: aggregate statistics errors

### DIFF
--- a/web-client/src/presenter/actions/validatePetitionFromPaperAction.js
+++ b/web-client/src/presenter/actions/validatePetitionFromPaperAction.js
@@ -3,6 +3,11 @@ import { state } from 'cerebral';
 export const aggregateStatisticsErrors = ({ errors, get }) => {
   let newErrorStatistics;
 
+  Object.keys(errors).forEach(key => {
+    if (/statistics\[\d+\]/.test(errors[key])) {
+      delete errors[key];
+    }
+  });
   if (errors.statistics) {
     newErrorStatistics = [];
     const formStatistics = get(state.form.statistics);

--- a/web-client/src/presenter/actions/validatePetitionFromPaperAction.test.js
+++ b/web-client/src/presenter/actions/validatePetitionFromPaperAction.test.js
@@ -53,14 +53,19 @@ describe('validatePetitionFromPaperAction', () => {
   });
 
   it('aggregates statistics errors', async () => {
+    const mockError = {
+      caseCaption: 'Enter a case caption',
+      irsDeficiencyAmount: '"statistics[0].irsDeficiencyAmount" is required',
+      statistics: [
+        { deficiency: 'enter deficiency amount', index: 1 },
+        { index: 2, irsTotalPenalties: 'enter total penalties' },
+      ],
+      year: '"statistics[0].year" is required',
+    };
+
     applicationContext
       .getUseCases()
-      .validatePetitionFromPaperInteractor.mockReturnValue({
-        statistics: [
-          { deficiency: 'enter deficiency amount', index: 1 },
-          { index: 2, irsTotalPenalties: 'enter total penalties' },
-        ],
-      });
+      .validatePetitionFromPaperInteractor.mockReturnValue(mockError);
 
     await runAction(validatePetitionFromPaperAction, {
       modules: {
@@ -77,16 +82,20 @@ describe('validatePetitionFromPaperAction', () => {
       },
     });
 
-    expect(errorStub.mock.calls[0][0].errors.statistics).toEqual([
-      {},
-      {
-        enterAllValues: 'Enter period, deficiency amount, and total penalties',
-        index: 1,
-      },
-      {
-        enterAllValues: 'Enter year, deficiency amount, and total penalties',
-        index: 2,
-      },
-    ]);
+    expect(errorStub.mock.calls[0][0].errors).toEqual({
+      caseCaption: expect.anything(),
+      statistics: [
+        {},
+        {
+          enterAllValues:
+            'Enter period, deficiency amount, and total penalties',
+          index: 1,
+        },
+        {
+          enterAllValues: 'Enter year, deficiency amount, and total penalties',
+          index: 2,
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
hide "nested" error messages
![Screen Shot 2020-08-12 at 1 23 52 PM](https://user-images.githubusercontent.com/2445917/90052836-53ad5280-dc9f-11ea-9af4-e6057016dba1.png)

https://trello.com/c/Fg27eOTi/734-deficiency-stat-error-messages-showing-incorrectly-on-create-case
