### PR TITLE
set validation flag on entitites being processed via streams

### DIFF
--- a/shared/src/business/useCases/processStreamRecordsInteractor.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.js
@@ -5,15 +5,6 @@ const getRemoveRecords = ({ records }) => {
   return records.filter(record => record.eventName === 'REMOVE');
 };
 
-const setIsValidated = obj => {
-  Object.defineProperty(obj, 'isValidated', {
-    enumerable: false,
-    value: true,
-    writable: false,
-  });
-  return obj;
-};
-
 /**
  * filters out records we do not want to index with elasticsearch
  *
@@ -168,7 +159,7 @@ exports.processStreamRecordsInteractor = async ({
           try {
             await applicationContext.getPersistenceGateway().indexRecord({
               applicationContext,
-              fullRecord: setIsValidated({ ...failedRecord }),
+              fullRecord: { ...failedRecord },
               isAlreadyMarshalled: true,
               record: {
                 recordPk: failedRecord.pk.S,
@@ -203,7 +194,7 @@ exports.processStreamRecordsInteractor = async ({
 
           await applicationContext.getPersistenceGateway().indexRecord({
             applicationContext,
-            fullRecord: setIsValidated(newImage),
+            fullRecord: newImage,
             isAlreadyMarshalled: true,
             record: {
               recordPk: record.dynamodb.Keys.pk.S,

--- a/shared/src/business/useCases/processStreamRecordsInteractor.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.js
@@ -5,6 +5,15 @@ const getRemoveRecords = ({ records }) => {
   return records.filter(record => record.eventName === 'REMOVE');
 };
 
+const setIsValidated = obj => {
+  Object.defineProperty(obj, 'isValidated', {
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
+  return obj;
+};
+
 /**
  * filters out records we do not want to index with elasticsearch
  *
@@ -159,7 +168,7 @@ exports.processStreamRecordsInteractor = async ({
           try {
             await applicationContext.getPersistenceGateway().indexRecord({
               applicationContext,
-              fullRecord: { ...failedRecord },
+              fullRecord: setIsValidated({ ...failedRecord }),
               isAlreadyMarshalled: true,
               record: {
                 recordPk: failedRecord.pk.S,
@@ -190,11 +199,11 @@ exports.processStreamRecordsInteractor = async ({
 
       for (const record of recordsToReprocess) {
         try {
-          let newImage = record.dynamodb.NewImage;
+          const newImage = record.dynamodb.NewImage;
 
           await applicationContext.getPersistenceGateway().indexRecord({
             applicationContext,
-            fullRecord: newImage,
+            fullRecord: setIsValidated(newImage),
             isAlreadyMarshalled: true,
             record: {
               recordPk: record.dynamodb.Keys.pk.S,

--- a/shared/src/business/useCases/reprocessFailedRecordsInteractor.js
+++ b/shared/src/business/useCases/reprocessFailedRecordsInteractor.js
@@ -12,14 +12,6 @@ exports.reprocessFailedRecordsInteractor = async ({ applicationContext }) => {
     .getPersistenceGateway()
     .getElasticsearchReindexRecords({ applicationContext });
 
-  const setIsValidated = obj => {
-    Object.defineProperty(obj, 'isValidated', {
-      enumerable: false,
-      value: true,
-      writable: false,
-    });
-  };
-
   if (recordsToProcess.length) {
     for (const record of recordsToProcess) {
       try {
@@ -54,9 +46,6 @@ exports.reprocessFailedRecordsInteractor = async ({ applicationContext }) => {
               recordSk: record.recordSk,
             });
         }
-
-        setIsValidated(fullRecord);
-        setIsValidated(record);
 
         await applicationContext.getPersistenceGateway().indexRecord({
           applicationContext,

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1034,9 +1034,11 @@ const entitiesByName = {
 
 const isValidatedDecorator = persistenceGatewayMethods => {
   /**
-   * decorates the function to verify any entities passed have the isValid flag
+   * Decorates the function to verify any entities passed have the isValid flag.
+   * Should be used whenever a persistence method might be called by an interactor via lambda
+   * when an entity's complete record is being created or updated.
    *
-   * @returns the original methods decorated
+   * @returns {Function} the original methods decorated
    */
   function decorate(method) {
     return function () {
@@ -1065,27 +1067,61 @@ const isValidatedDecorator = persistenceGatewayMethods => {
   return persistenceGatewayMethods;
 };
 
-const gatewayMethods = isValidatedDecorator({
-  addWorkItemToSectionInbox,
+const gatewayMethods = {
+  ...isValidatedDecorator({
+    addWorkItemToSectionInbox,
+    associateUserWithCase,
+    associateUserWithCasePending,
+    bulkDeleteRecords,
+    bulkIndexRecords,
+    createCase,
+    createCaseCatalogRecord,
+    createCaseDeadline,
+    createCaseTrialSortMappingRecords,
+    createElasticsearchReindexRecord,
+    createMessage,
+    createPractitionerUser,
+    createSectionInboxRecord,
+    createTrialSession,
+    createTrialSessionWorkingCopy,
+    createUser,
+    createUserInboxRecord,
+    fetchPendingItems: fetchPendingItemsPersistence,
+    fileCaseCorrespondence,
+    incrementCounter,
+    indexRecord,
+    markMessageThreadRepliedTo,
+    persistUser,
+    putWorkItemInOutbox,
+    putWorkItemInUsersOutbox,
+    saveDocumentFromLambda,
+    saveUserConnection,
+    saveWorkItemForDocketClerkFilingExternalDocument,
+    saveWorkItemForDocketEntryInProgress,
+    saveWorkItemForNonPaper,
+    saveWorkItemForPaper,
+    setPriorityOnAllWorkItems,
+    setWorkItemAsRead,
+    updateCase,
+    updateCaseDeadline,
+    updateCaseTrialSortMappingRecords,
+    updateDocketRecord,
+    updateDocument,
+    updateDocumentProcessingStatus,
+    updateHighPriorityCaseTrialSortMappingRecords,
+    updateMessage,
+    updatePractitionerUser,
+    updateTrialSession,
+    updateTrialSessionWorkingCopy,
+    updateUser,
+    updateUserCaseNote,
+    updateWorkItem,
+    updateWorkItemInCase,
+  }),
+  // methods below are not known to create "entity" records
   advancedDocumentSearch,
-  associateUserWithCase,
-  associateUserWithCasePending,
-  bulkDeleteRecords,
-  bulkIndexRecords,
   caseAdvancedSearch,
   casePublicSearch: casePublicSearchPersistence,
-  createCase,
-  createCaseCatalogRecord,
-  createCaseDeadline,
-  createCaseTrialSortMappingRecords,
-  createElasticsearchReindexRecord,
-  createMessage,
-  createPractitionerUser,
-  createSectionInboxRecord,
-  createTrialSession,
-  createTrialSessionWorkingCopy,
-  createUser,
-  createUserInboxRecord,
   deleteCaseByDocketNumber,
   deleteCaseCorrespondence,
   deleteCaseDeadline,
@@ -1103,8 +1139,6 @@ const gatewayMethods = isValidatedDecorator({
   deleteUserOutboxRecord,
   deleteWorkItemFromInbox,
   deleteWorkItemFromSection,
-  fetchPendingItems: fetchPendingItemsPersistence,
-  fileCaseCorrespondence,
   getAllCaseDeadlines,
   getAllCatalogCases,
   getBlockedCases,
@@ -1153,40 +1187,11 @@ const gatewayMethods = isValidatedDecorator({
   getWebSocketConnectionByConnectionId,
   getWebSocketConnectionsByUserId,
   getWorkItemById,
-  incrementCounter,
-  indexRecord,
   isFileExists,
-  markMessageThreadRepliedTo,
-  persistUser,
-  putWorkItemInOutbox,
-  putWorkItemInUsersOutbox,
-  saveDocumentFromLambda,
-  saveUserConnection,
-  saveWorkItemForDocketClerkFilingExternalDocument,
-  saveWorkItemForDocketEntryInProgress,
-  saveWorkItemForNonPaper,
-  saveWorkItemForPaper,
-  setPriorityOnAllWorkItems,
-  setWorkItemAsRead,
-  updateCase,
-  updateCaseDeadline,
-  updateCaseTrialSortMappingRecords,
-  updateDocketRecord,
-  updateDocument,
-  updateDocumentProcessingStatus,
-  updateHighPriorityCaseTrialSortMappingRecords,
-  updateMessage,
-  updatePractitionerUser,
-  updateTrialSession,
-  updateTrialSessionWorkingCopy,
-  updateUser,
-  updateUserCaseNote,
-  updateWorkItem,
-  updateWorkItemInCase,
   verifyCaseForUser,
   verifyPendingCaseForUser,
   zipDocuments,
-});
+};
 
 module.exports = appContextUser => {
   if (appContextUser) setCurrentUser(appContextUser);


### PR DESCRIPTION
To address exceptions from persistence methods without "isValidated" flags on entities.

These happen to be records that are headed to ES via streams, which should have already gone through validation via interactors in the API.