### PR TITLE
closing modal when setting trial session as calendared

### DIFF
--- a/web-client/src/presenter/sequences/setTrialSessionCalendarSequence.js
+++ b/web-client/src/presenter/sequences/setTrialSessionCalendarSequence.js
@@ -1,4 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
+import { clearModalAction } from '../actions/clearModalAction';
+import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { getCalendaredCasesForTrialSessionAction } from '../actions/TrialSession/getCalendaredCasesForTrialSessionAction';
 import { getTrialSessionDetailsAction } from '../actions/TrialSession/getTrialSessionDetailsAction';
@@ -11,6 +13,8 @@ import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAct
 import { startWebSocketConnectionAction } from '../actions/webSocketConnection/startWebSocketConnectionAction';
 
 export const setTrialSessionCalendarSequence = [
+  clearModalStateAction,
+  clearModalAction,
   setWaitingForResponseAction,
   clearAlertsAction,
   clearScreenMetadataAction,


### PR DESCRIPTION
- there was a bug where the set trial session as calendared modal would remain open after clicking the "yes, set calendared" button.