### PR TITLE
5676: ux bug with text wrapping and stricken info

### DIFF
--- a/web-client/src/views/DocketRecord/DocumentViewer.jsx
+++ b/web-client/src/views/DocketRecord/DocumentViewer.jsx
@@ -65,7 +65,7 @@ export const DocumentViewer = connect(
                         >
                           {entry.createdAtFormatted}
                         </div>
-                        <div>
+                        <div className="grid-col-5">
                           <span
                             className={classNames(
                               entry.isStricken && 'stricken-docket-record',


### PR DESCRIPTION
<img width="817" alt="image" src="https://user-images.githubusercontent.com/1116426/90544206-6d8de000-e14c-11ea-91cb-f7e7194d757b.png">

...and by "bug" i mean something i removed that wasn't caught until after extensive UX testing