### PR TITLE
6070: ensure sealed addresses not returned

### DIFF
--- a/shared/src/business/useCases/getCaseInteractor.js
+++ b/shared/src/business/useCases/getCaseInteractor.js
@@ -123,46 +123,10 @@ exports.getCaseInteractor = async ({ applicationContext, docketNumber }) => {
     });
   }
 
-  if (
-    !isAuthorized(
-      applicationContext.getCurrentUser(),
-      ROLE_PERMISSIONS.VIEW_SEALED_ADDRESS,
-    )
-  ) {
-    if (
-      caseDetailRaw.contactPrimary &&
-      caseDetailRaw.contactPrimary.isAddressSealed
-    ) {
-      caseDetailRaw.contactPrimary = caseContactAddressSealedFormatter(
-        caseDetailRaw.contactPrimary,
-      );
-    }
-    if (
-      caseDetailRaw.contactSecondary &&
-      caseDetailRaw.contactSecondary.isAddressSealed
-    ) {
-      caseDetailRaw.contactSecondary = caseContactAddressSealedFormatter(
-        caseDetailRaw.contactSecondary,
-      );
-    }
-
-    if (Array.isArray(caseDetailRaw.otherFilers)) {
-      caseDetailRaw.otherFilers = caseDetailRaw.otherFilers.map(contact =>
-        contact.isAddressSealed
-          ? caseContactAddressSealedFormatter(contact)
-          : contact,
-      );
-    }
-
-    if (Array.isArray(caseDetailRaw.otherPetitioners)) {
-      caseDetailRaw.otherPetitioners = caseDetailRaw.otherPetitioners.map(
-        petitioner =>
-          petitioner.isAddressSealed
-            ? caseContactAddressSealedFormatter(petitioner)
-            : petitioner,
-      );
-    }
-  }
+  caseDetailRaw = caseContactAddressSealedFormatter(
+    caseDetailRaw,
+    applicationContext.getCurrentUser(),
+  );
 
   return caseDetailRaw;
 };

--- a/shared/src/business/useCases/public/getPublicCaseInteractor.js
+++ b/shared/src/business/useCases/public/getPublicCaseInteractor.js
@@ -1,5 +1,8 @@
+const {
+  caseContactAddressSealedFormatter,
+  caseSealedFormatter,
+} = require('../../utilities/caseFilter');
 const { Case } = require('../../entities/cases/Case');
-const { caseSealedFormatter } = require('../../utilities/caseFilter');
 const { NotFoundError } = require('../../../errors/errors');
 const { PublicCase } = require('../../entities/cases/PublicCase');
 
@@ -31,6 +34,10 @@ exports.getPublicCaseInteractor = async ({
   if (caseRecord.sealedDate) {
     caseRecord = caseSealedFormatter(caseRecord);
   }
+  caseRecord = caseContactAddressSealedFormatter(
+    caseRecord,
+    applicationContext.getCurrentUser(),
+  );
 
   const publicCaseDetail = new PublicCase(caseRecord, {
     applicationContext,

--- a/shared/src/business/useCases/public/getPublicCaseInteractor.js
+++ b/shared/src/business/useCases/public/getPublicCaseInteractor.js
@@ -34,10 +34,7 @@ exports.getPublicCaseInteractor = async ({
   if (caseRecord.sealedDate) {
     caseRecord = caseSealedFormatter(caseRecord);
   }
-  caseRecord = caseContactAddressSealedFormatter(
-    caseRecord,
-    applicationContext.getCurrentUser(),
-  );
+  caseRecord = caseContactAddressSealedFormatter(caseRecord, {});
 
   const publicCaseDetail = new PublicCase(caseRecord, {
     applicationContext,

--- a/shared/src/business/useCases/public/getPublicCaseInteractor.test.js
+++ b/shared/src/business/useCases/public/getPublicCaseInteractor.test.js
@@ -57,6 +57,18 @@ describe('getPublicCaseInteractor', () => {
     });
   });
 
+  it('should return minimal information when the requested case has been sealed', async () => {
+    const docketNumber = '102-20';
+    const result = await getPublicCaseInteractor({
+      applicationContext,
+      docketNumber,
+    });
+
+    expect(result).toMatchObject({
+      docketNumber: '102-20',
+    });
+  });
+
   it('should return minimal information when the requested case contact address has been sealed', async () => {
     const docketNumber = '102-20';
     mockCases[docketNumber] = cloneDeep({

--- a/shared/src/business/useCases/public/getPublicCaseInteractor.test.js
+++ b/shared/src/business/useCases/public/getPublicCaseInteractor.test.js
@@ -1,6 +1,7 @@
 const {
   applicationContext,
 } = require('../../test/createTestApplicationContext');
+const { cloneDeep } = require('lodash');
 const { getPublicCaseInteractor } = require('./getPublicCaseInteractor');
 const { MOCK_CASE } = require('../../../test/mockCase');
 
@@ -56,8 +57,13 @@ describe('getPublicCaseInteractor', () => {
     });
   });
 
-  it('should return minimal information when the requested case has been sealed', async () => {
+  it('should return minimal information when the requested case contact address has been sealed', async () => {
     const docketNumber = '102-20';
+    mockCases[docketNumber] = cloneDeep({
+      ...mockCases['102-20'],
+      sealedDate: undefined,
+    });
+    mockCases[docketNumber].contactPrimary.isAddressSealed = true;
 
     const result = await getPublicCaseInteractor({
       applicationContext,
@@ -65,7 +71,9 @@ describe('getPublicCaseInteractor', () => {
     });
 
     expect(result).toMatchObject({
-      docketNumber: '102-20',
+      docketNumber,
     });
+
+    expect(result.contactPrimary.address1).toBeUndefined();
   });
 });

--- a/shared/src/business/utilities/caseFilter.js
+++ b/shared/src/business/utilities/caseFilter.js
@@ -2,8 +2,8 @@ const {
   isAuthorized,
   ROLE_PERMISSIONS,
 } = require('../../authorization/authorizationClientService');
+const { cloneDeep, pick } = require('lodash');
 const { isAssociatedUser } = require('../entities/cases/Case');
-const { pick } = require('lodash');
 const CASE_ATTRIBUTE_WHITELIST = [
   'docketNumber',
   'docketNumberSuffix',
@@ -25,10 +25,43 @@ const caseSealedFormatter = caseRaw => {
   return pick(caseRaw, CASE_ATTRIBUTE_WHITELIST);
 };
 
-const caseContactAddressSealedFormatter = contactRaw => {
-  const result = pick(contactRaw, CASE_CONTACT_ATTRIBUTE_WHITELIST);
-  result.sealedAndUnavailable = true;
-  return result;
+/**
+ * caseContactAddressSealedFormatter
+ * Modifies raw case data if a contact address is sealed
+ * and user does not have permission to view sealed addresses.
+ * When sealed addresses are being formatted, the contact objects are
+ * emptied of all entries, then assigned key/value pairs from a whitelist.
+ *
+ * @param {object} caseRaw the raw case detail
+ * @param {object} currentUser the current
+ * @returns {object} reference to modified raw case detail
+ */
+const caseContactAddressSealedFormatter = (caseRaw, currentUser) => {
+  const userCanViewSealedAddresses = isAuthorized(
+    currentUser,
+    ROLE_PERMISSIONS.VIEW_SEALED_ADDRESS,
+  );
+  if (userCanViewSealedAddresses) {
+    return caseRaw;
+  }
+  const formattedCase = cloneDeep(caseRaw);
+  const formatSealedAddress = contactRaw => {
+    const result = pick(contactRaw, CASE_CONTACT_ATTRIBUTE_WHITELIST);
+    result.sealedAndUnavailable = true;
+    return result;
+  };
+  const caseContactsToBeSealed = [
+    formattedCase.contactPrimary,
+    formattedCase.contactSecondary,
+    ...(formattedCase.otherFilers || []),
+    ...(formattedCase.otherPetitioners || []),
+  ].filter(caseContact => caseContact && caseContact.isAddressSealed);
+  caseContactsToBeSealed.forEach(caseContact => {
+    const sealedContactAddress = formatSealedAddress(caseContact);
+    Object.keys(caseContact).map(key => delete caseContact[key]);
+    Object.assign(caseContact, sealedContactAddress);
+  });
+  return formattedCase;
 };
 
 const caseSearchFilter = (cases, currentUser) => {

--- a/shared/src/business/utilities/caseFilter.js
+++ b/shared/src/business/utilities/caseFilter.js
@@ -73,7 +73,11 @@ const caseSearchFilter = (cases, currentUser) => {
       ROLE_PERMISSIONS.VIEW_SEALED_CASE,
       caseRaw.userId,
     );
-  return cases.filter(caseSearchFilterConditionals);
+  return cases
+    .filter(caseSearchFilterConditionals)
+    .map(filteredCase =>
+      caseContactAddressSealedFormatter(filteredCase, currentUser),
+    );
 };
 
 module.exports = {

--- a/shared/src/business/utilities/caseFilter.test.js
+++ b/shared/src/business/utilities/caseFilter.test.js
@@ -90,6 +90,13 @@ describe('caseFilter', () => {
       },
       {
         baz: 'quux',
+        contactPrimary: {
+          address1: '1 Eagle Way',
+          city: 'Hotel California',
+          isAddressSealed: true,
+          name: 'Joe Walsh',
+          state: 'CA',
+        },
         docketNumber: '102-20',
         documents: [
           { documentType: 'Petition', servedAt: '2019-03-01T21:40:46.415Z' },
@@ -111,6 +118,20 @@ describe('caseFilter', () => {
       expect(result[0]).toMatchObject({
         docketNumber: '101-20',
         sealedDate: undefined,
+      });
+    });
+
+    it('should format sealed addresses in search results if user does not have permission to see sealed contact addresses', () => {
+      let result = caseSearchFilter(caseSearchResults, {
+        role: ROLES.petitionsClerk,
+        userId: 'petitionsClerk',
+      });
+
+      expect(result.length).toEqual(3);
+      expect(result[2].contactPrimary).toMatchObject({
+        isAddressSealed: true,
+        name: 'Joe Walsh',
+        sealedAndUnavailable: true,
       });
     });
 

--- a/shared/src/business/utilities/caseFilter.test.js
+++ b/shared/src/business/utilities/caseFilter.test.js
@@ -25,31 +25,49 @@ describe('caseFilter', () => {
     });
   });
 
-  it('caseContactAddressSealedFormatter', () => {
-    const result = caseContactAddressSealedFormatter({
-      additionalName: 'Bob',
-      bananas: '8-foot bunch',
-      city: 'Los Angeles',
-      contactId: '42-universe-everything',
-      inCareOf: 'Friendship is Magic',
-      isAddressSealed: 'maybe',
-      name: 'Joe Dirt',
-      otherFilerType: 'Nail File',
-      secondaryName: 'Cheeseburgers',
-      title: 'Emperor',
-      transmission: 'manual',
+  describe('caseContactAddressSealedFormatter', () => {
+    it('returns contact info with ONLY the whitelisted attributes present', () => {
+      const createContactInfo = () => ({
+        additionalName: 'Bob',
+        bananas: '8-foot bunch',
+        city: 'Los Angeles',
+        contactId: '42-universe-everything',
+        inCareOf: 'Friendship is Magic',
+        isAddressSealed: true,
+        name: 'Joe Dirt',
+        otherFilerType: 'Nail File',
+        secondaryName: 'Cheeseburgers',
+        title: 'Emperor',
+        transmission: 'manual',
+      });
+      const caseDetail = {};
+      caseDetail.contactPrimary = createContactInfo();
+      caseDetail.contactSecondary = createContactInfo();
+      caseDetail.otherFilers = [createContactInfo(), createContactInfo()];
+      caseDetail.otherPetitioners = [createContactInfo(), createContactInfo()];
+
+      const result = caseContactAddressSealedFormatter(caseDetail, {
+        role: ROLES.petitioner,
+      });
+      [
+        result.contactPrimary,
+        result.contactSecondary,
+        ...result.otherFilers,
+        ...result.otherPetitioners,
+      ].forEach(party => {
+        expect(Object.keys(party).sort()).toMatchObject([
+          'additionalName',
+          'contactId',
+          'inCareOf',
+          'isAddressSealed',
+          'name',
+          'otherFilerType',
+          'sealedAndUnavailable',
+          'secondaryName',
+          'title',
+        ]);
+      });
     });
-    expect(Object.keys(result).sort()).toMatchObject([
-      'additionalName',
-      'contactId',
-      'inCareOf',
-      'isAddressSealed',
-      'name',
-      'otherFilerType',
-      'sealedAndUnavailable',
-      'secondaryName',
-      'title',
-    ]);
   });
 
   describe('caseSearchFilter', () => {


### PR DESCRIPTION
for both 'get' and 'search' endpoints, ensure that cases with contact information are properly sealed if the user does not have permission to view sealed contact address information.