### PR TITLE
6281 - DOD, email service fix

### DIFF
--- a/shared/src/persistence/ses/getSesStatus.js
+++ b/shared/src/persistence/ses/getSesStatus.js
@@ -1,7 +1,7 @@
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 exports.getSesStatus = async () => {
-  const result = await execSync(
+  const result = await spawnSync(
     'ping email.us-east-1.amazonaws.com -c 1 -W 10',
   );
 

--- a/web-client/integration-tests-public/journey/unauthedUserViewsHealthCheck.js
+++ b/web-client/integration-tests-public/journey/unauthedUserViewsHealthCheck.js
@@ -1,0 +1,29 @@
+export const unauthedUserViewsHealthCheck = test => {
+  return it('should view health check', async () => {
+    await test.runSequence('gotoHealthCheckSequence', {});
+
+    expect(test.getState('health')).toEqual(
+      expect.objectContaining({
+        clamAV: expect.anything(),
+        cognito: expect.anything(),
+        dynamo: expect.objectContaining({
+          efcms: expect.anything(),
+          efcmsDeploy: expect.anything(),
+        }),
+        dynamsoft: expect.anything(),
+        elasticsearch: expect.anything(),
+        emailService: expect.anything(),
+        s3: expect.objectContaining({
+          app: expect.anything(),
+          appFailover: expect.anything(),
+          eastDocuments: expect.anything(),
+          eastTempDocuments: expect.anything(),
+          public: expect.anything(),
+          publicFailover: expect.anything(),
+          westDocuments: expect.anything(),
+          westTempDocuments: expect.anything(),
+        }),
+      }),
+    );
+  });
+};

--- a/web-client/integration-tests-public/unauthedUserViewsHealthCheck.test.js
+++ b/web-client/integration-tests-public/unauthedUserViewsHealthCheck.test.js
@@ -1,0 +1,12 @@
+import { setupTest } from './helpers';
+import { unauthedUserViewsHealthCheck } from './journey/unauthedUserViewsHealthCheck';
+
+const test = setupTest();
+
+describe('Unauthed user views health check', () => {
+  beforeAll(() => {
+    jest.setTimeout(30000);
+  });
+
+  unauthedUserViewsHealthCheck(test);
+});

--- a/web-client/pa11y/pa11y-public-user.js
+++ b/web-client/pa11y/pa11y-public-user.js
@@ -52,4 +52,5 @@ module.exports = [
     url: 'http://localhost:5678/',
   },
   'http://localhost:5678/todays-opinions',
+  'http://localhost:5678/health',
 ];


### PR DESCRIPTION
- Integration test
- Pa11y test
- Try using spawnSync instead of execSync so the lambda can ping the email service for a health check (https://stackoverflow.com/questions/58956951/curl-on-aws-lambda-gives-command-not-found-error/58961234#58961234)