### PR TITLE
6069 - Add unread indicator to inbox message rows

### DIFF
--- a/web-client/src/styles/tables.scss
+++ b/web-client/src/styles/tables.scss
@@ -287,6 +287,12 @@ table.work-queue {
     label {
       margin: 0;
     }
+
+    &.message-unread-column {
+      width: 20px;
+      padding: 15px 0;
+      text-align: right;
+    }
   }
 
   tr {

--- a/web-client/src/views/Messages/MessagesIndividualInbox.jsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.jsx
@@ -1,4 +1,5 @@
 import { Button } from '../../ustc-ui/Button/Button';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -15,6 +16,7 @@ export const MessagesIndividualInbox = connect(
                 Docket No.
               </th>
               <th className="small">Received</th>
+              <th className="message-unread-column"></th>
               <th>Message</th>
               <th>Case Title</th>
               <th>Case Status</th>
@@ -23,6 +25,9 @@ export const MessagesIndividualInbox = connect(
             </tr>
           </thead>
           {formattedMessages.map((message, idx) => {
+            const isUnread = !message.isRead;
+            const unreadClass = isUnread ? 'text-bold' : '';
+
             return (
               <tbody key={idx}>
                 <tr key={idx}>
@@ -35,11 +40,21 @@ export const MessagesIndividualInbox = connect(
                       {message.createdAtFormatted}
                     </span>
                   </td>
+                  <td className="message-unread-column">
+                    {isUnread && (
+                      <Icon
+                        aria-label="create message"
+                        className="fa-icon-blue"
+                        icon="envelope"
+                        size="1x"
+                      />
+                    )}
+                  </td>
                   <td className="message-queue-row message-queue-document message-subject">
                     <div className="message-document-title">
                       <Button
                         link
-                        className="padding-0"
+                        className={`padding-0 ${unreadClass}`}
                         href={`/messages/${message.docketNumber}/message-detail/${message.parentMessageId}`}
                       >
                         {message.subject}

--- a/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
+++ b/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
@@ -1,4 +1,5 @@
 import { Button } from '../../ustc-ui/Button/Button';
+import { Icon } from '../../ustc-ui/Icon/Icon';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
@@ -21,6 +22,7 @@ export const RecentMessagesInbox = connect(
                 <span className="padding-left-2px">Docket Number</span>
               </th>
               <th className="small">Received</th>
+              <th className="message-unread-column"></th>
               <th>Message</th>
               <th>Case Title</th>
               <th className="no-wrap">Case Status</th>
@@ -29,6 +31,9 @@ export const RecentMessagesInbox = connect(
             </tr>
           </thead>
           {recentMessagesHelper.recentMessages.map((item, idx) => {
+            const isUnread = !item.isRead;
+            const unreadClass = isUnread ? 'text-bold' : '';
+
             return (
               <tbody key={idx}>
                 <tr>
@@ -36,11 +41,21 @@ export const RecentMessagesInbox = connect(
                   <td className="message-queue-row small">
                     {item.docketNumberWithSuffix}
                   </td>
+                  <td className="message-unread-column">
+                    {isUnread && (
+                      <Icon
+                        aria-label="create message"
+                        className="fa-icon-blue"
+                        icon="envelope"
+                        size="1x"
+                      />
+                    )}
+                  </td>
                   <td>
                     <div className="message-document-title">
                       <Button
                         link
-                        className="padding-0"
+                        className={`padding-0 ${unreadClass}`}
                         href={`/messages/${item.docketNumber}/message-detail/${item.parentMessageId}`}
                       >
                         {item.subject}


### PR DESCRIPTION
<img width="917" alt="Screen Shot 2020-09-11 at 11 24 29 AM" src="https://user-images.githubusercontent.com/1891789/92954942-8fb01080-f421-11ea-8600-611252774f43.png">

This applies to both individual inbox and chambers dashboard