### PR TITLE
Trial session smoke tests - add retries

### DIFF
--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -12,5 +12,6 @@
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000,
   "viewportWidth": 1200,
-  "viewportHeight": 900
+  "viewportHeight": 900,
+  "retries": 3
 }

--- a/cypress-smoketests/integration/trial-sessions/create-trial-session.spec.js
+++ b/cypress-smoketests/integration/trial-sessions/create-trial-session.spec.js
@@ -1,26 +1,36 @@
 const faker = require('faker');
 const uuid = require('uuid');
 const {
+  blockCaseFromTrial,
+  goToCaseOverview,
+  manuallyAddCaseToCalendaredTrialSession,
+  manuallyAddCaseToNewTrialSession,
+  removeCaseFromTrialSession,
+  setCaseAsHighPriority,
+  unblockCaseFromTrial,
+} = require('../../support/pages/case-detail');
+const {
   COUNTRY_TYPES,
 } = require('../../../shared/src/business/entities/EntityConstants');
+const {
+  createTrialSession,
+  goToTrialSession,
+  markCaseAsQcCompleteForTrial,
+  setTrialSessionAsCalendared,
+  verifyOpenCaseOnTrialSession,
+} = require('../../support/pages/trial-sessions');
 const {
   getRestApi,
   getUserToken,
   login,
 } = require('../../support/pages/login');
+const {
+  runTrialSessionPlanningReport,
+  viewBlockedCaseOnBlockedReport,
+} = require('../../support/pages/reports');
 const { BASE_CASE } = require('../../fixtures/caseMigrations');
 
 faker.seed(faker.random.number());
-
-const createFutureDate = () => {
-  const month = faker.random.number({ max: 12, min: 1 });
-  const day = faker.random.number({ max: 28, min: 1 });
-  const year =
-    new Date().getUTCFullYear() + faker.random.number({ max: 5, min: 1 });
-  return `${month}/${day}/${year}`;
-};
-
-const preferredTrialCity = 'Cheyenne, Wyoming';
 
 const createDocketNumber = () => {
   const docketNumberYear = faker.random.number({ max: 99, min: 80 });
@@ -44,22 +54,11 @@ const createRandomContact = () => ({
   state: faker.address.stateAbbr(),
 });
 
-const gotoCaseOverview = docketNumber => {
-  cy.goToRoute(`/case-detail/${docketNumber}`);
-  cy.get('#tab-case-information').click();
-  cy.get('#tab-overview').click();
-};
-
-const removeFromTrialSession = () => {
-  cy.get('#remove-from-trial-session-btn').should('exist').click();
-  cy.get('#disposition').type(faker.company.catchPhrase());
-  cy.get('#modal-root .modal-button-confirm').click();
-  cy.get('#add-to-trial-session-btn').should('not.exist');
-};
-
 let token = null;
-let trialSessionId;
-let trialSessionIds = [];
+const testData = {
+  preferredTrialCity: 'Cheyenne, Wyoming',
+  trialSessionIds: [],
+};
 const firstDocketNumber = createDocketNumber();
 const secondDocketNumber = createDocketNumber();
 
@@ -97,7 +96,7 @@ describe('Petitions Clerk', () => {
           },
           docketNumber,
           docketNumberWithSuffix: docketNumber,
-          preferredTrialCity,
+          preferredTrialCity: testData.preferredTrialCity,
         };
         cy.request({
           body: migrateCase,
@@ -120,168 +119,71 @@ describe('Petitions Clerk', () => {
       );
     });
 
-    const createTrialSession = () => {
-      it('creates a trial session', () => {
-        cy.get('a[href="/trial-sessions"]').click();
-        cy.get('a[href="/add-a-trial-session"]').click();
-
-        // session information
-        cy.get('#start-date-date').type(createFutureDate());
-        cy.get('#start-time-hours')
-          .clear()
-          .type(faker.random.number({ max: 11, min: 6 }));
-        cy.get('#start-time-minutes')
-          .clear()
-          .type(faker.random.arrayElement(['00', '15', '30', '45']));
-        cy.get('label[for="startTimeExtension-pm"]').click();
-        cy.get('label[for="session-type-Hybrid"]').click();
-        cy.get('#max-cases').type(faker.random.number({ max: 100, min: 10 }));
-
-        // location information
-        cy.get('#trial-location').select(preferredTrialCity);
-        cy.get('#courthouse-name').type(faker.commerce.productName());
-        cy.get('#address1').type(faker.address.streetAddress());
-        cy.get('#city').type(faker.address.city());
-        cy.get('#state').select(faker.address.stateAbbr());
-        cy.get('#postal-code').type(faker.address.zipCode());
-
-        // session assignments
-        cy.get('#judgeId').select('Chief Judge Foley');
-        cy.get('#trial-clerk').select('Test trialclerk1');
-        cy.get('#court-reporter').type(faker.name.findName());
-        cy.get('#irs-calendar-administrator').type(faker.name.findName());
-        cy.get('#notes').type(faker.company.catchPhrase());
-
-        cy.get('#submit-trial-session').click();
-
-        // set up listener for POST call, get trialSessionId
-        cy.wait('@postTrialSession').then(xhr => {
-          ({ trialSessionId } = xhr.response.body);
-          trialSessionIds.push(trialSessionId);
-          cy.get('#new-trial-sessions-tab').click();
-          cy.get(`a[href="/trial-session-detail/${trialSessionId}"]`).should(
-            'exist',
-          );
-        });
-      });
-    };
-    createTrialSession();
-    createTrialSession();
+    it('creates two trial sessions', () => {
+      createTrialSession(testData);
+      createTrialSession(testData);
+    });
 
     it('navigates to the first newly-created trial session', () => {
-      trialSessionId = trialSessionIds[0];
-      cy.get(`a[href="/trial-session-detail/${trialSessionId}"]`).click();
+      goToTrialSession(testData.trialSessionIds[0]);
     });
   });
 
-  // skipping for now until these are more stable
-  describe.skip('after a new trial session is created', () => {
+  describe('after a new trial session is created', () => {
     it('it is possible to manually add, view, and remove first case from an UNSET trial session', () => {
-      gotoCaseOverview(firstDocketNumber);
-      trialSessionId = trialSessionIds[0]; // the first trial session
-      cy.get('#add-to-trial-session-btn').should('exist').click();
-      cy.get('label[for="show-all-locations-true"]').click();
-      cy.get('select#trial-session')
-        .select(trialSessionId)
-        .should('have.value', trialSessionId);
-      cy.get('#modal-root .modal-button-confirm').click();
-      cy.get('.usa-alert--success').should(
-        'contain',
-        'Case scheduled for trial.',
-      );
-
-      removeFromTrialSession();
+      goToCaseOverview(firstDocketNumber);
+      manuallyAddCaseToNewTrialSession(testData.trialSessionIds[0]);
+      removeCaseFromTrialSession();
     });
 
     it('manually block second case', () => {
       // block it
-      gotoCaseOverview(secondDocketNumber);
-      cy.get('#tabContent-overview .block-from-trial-btn').click();
-      cy.get('.modal-dialog #reason').type(faker.company.catchPhrase());
-      cy.get('.modal-dialog .modal-button-confirm').click();
-      cy.contains('Blocked From Trial');
-
+      goToCaseOverview(secondDocketNumber);
+      blockCaseFromTrial();
       // do this well before we look for it on blocked cases report...
     });
 
     it('sets the first trial session as calendared', () => {
-      trialSessionId = trialSessionIds[0]; // the first trial session
-      cy.goToRoute(`/trial-session-detail/${trialSessionId}`);
-      cy.get('#set-calendar-button').should('exist').click();
-      cy.get('#modal-root .modal-button-confirm').click();
-      cy.get('#set-calendar-button').should('not.exist');
+      setTrialSessionAsCalendared(testData.trialSessionIds[0]);
     });
 
     it('manually add, view, and remove first case case from the SET trial session', () => {
-      gotoCaseOverview(firstDocketNumber);
-
-      trialSessionId = trialSessionIds[0]; // the first trial session
-      cy.get('#add-to-trial-session-btn').should('exist').click();
-      cy.get('label[for="show-all-locations-true"]').click();
-      cy.get('select#trial-session')
-        .select(trialSessionId)
-        .should('have.value', trialSessionId);
-      cy.get('#modal-root .modal-button-confirm').click();
-      cy.get('.usa-alert--success').should('contain', 'Case set for trial.');
-
-      removeFromTrialSession();
+      goToCaseOverview(firstDocketNumber);
+      manuallyAddCaseToCalendaredTrialSession(testData.trialSessionIds[0]);
+      removeCaseFromTrialSession();
     });
 
     it('view Blocked report containing second case, and unblock second case', () => {
       // enough time has elapsed since we blocked second case. look for it on blocked cases report
       // warning: if there are elasticsearch delays, this test might be brittle...
       // view blocked report
-      cy.get('#reports-btn').click();
-      cy.get('#all-blocked-cases').click();
-      cy.get('#trial-location').select(preferredTrialCity);
-      cy.get(`a[href="/case-detail/${secondDocketNumber}"]`).should('exist');
+      viewBlockedCaseOnBlockedReport({
+        ...testData,
+        docketNumber: secondDocketNumber,
+      });
+    });
 
-      // unblock it
-      gotoCaseOverview(secondDocketNumber);
-      cy.get('button.red-warning').click(); // TODO: #remove-block
-      cy.get('.modal-button-confirm').click();
-      cy.contains('Block removed.');
+    it('unblock second case', () => {
+      goToCaseOverview(secondDocketNumber);
+      unblockCaseFromTrial();
     });
 
     it('set second case as High Priority for a trial session', () => {
-      gotoCaseOverview(secondDocketNumber);
-
-      cy.get('.high-priority-btn').click();
-      cy.get('#reason').type(faker.company.catchPhrase());
-      cy.get('.modal-button-confirm').click();
-      cy.get('.modal-dialog').should('not.exist');
-      cy.contains('High Priority').should('exist');
+      goToCaseOverview(secondDocketNumber);
+      setCaseAsHighPriority();
     });
 
     it('complete QC of eligible (second) case and set calendar for second trial session', () => {
-      trialSessionId = trialSessionIds[1];
-      cy.goToRoute(`/trial-session-detail/${trialSessionId}`);
-      cy.get(
-        `#upcoming-sessions label[for="${secondDocketNumber}-complete"]`,
-      ).click();
+      goToTrialSession(testData.trialSessionIds[1]);
+      markCaseAsQcCompleteForTrial(secondDocketNumber);
 
       // set as calendared
-      cy.get('#set-calendar-button').should('exist').click();
-      cy.get('.modal-dialog .modal-button-confirm').click();
-      cy.get('#set-calendar-button').should('not.exist');
-      cy.get(
-        `#open-cases-tab-content a[href="/case-detail/${secondDocketNumber}"]`,
-      ).should('exist');
+      setTrialSessionAsCalendared(testData.trialSessionIds[1]);
+      verifyOpenCaseOnTrialSession(secondDocketNumber);
     });
 
     it('run Trial Session Planning Report', () => {
-      const nextYear = new Date().getUTCFullYear() + 1;
-      cy.get('#reports-btn').click();
-      cy.get('#trial-session-planning-btn').click();
-      cy.get('#modal-root select[name="term"]')
-        .select('Winter')
-        .should('have.value', 'winter');
-      cy.get('#modal-root select[name="year"]')
-        .select(`${nextYear}`)
-        .should('have.value', `${nextYear}`);
-      cy.get('.modal-button-confirm').click();
-      cy.url().should('contain', '/trial-session-planning-report');
-      cy.contains('Trial Session Planning Report');
+      runTrialSessionPlanningReport();
     });
   });
 });

--- a/cypress-smoketests/support/pages/case-detail.js
+++ b/cypress-smoketests/support/pages/case-detail.js
@@ -1,7 +1,17 @@
+const faker = require('faker');
+
+faker.seed(faker.random.number());
+
 exports.goToCaseDetail = docketNumber => {
   cy.get('#search-field').type(docketNumber);
   cy.get('.ustc-search-button').click();
   cy.get(`.big-blue-header h1 a:contains("${docketNumber}")`).should('exist');
+};
+
+exports.goToCaseOverview = docketNumber => {
+  cy.goToRoute(`/case-detail/${docketNumber}`);
+  cy.get('#tab-case-information').click();
+  cy.get('#tab-overview').click();
 };
 
 exports.createOrder = ({ docketNumber, token }) => {
@@ -52,4 +62,52 @@ exports.addDocketEntryForOrderAndServePaper = () => {
   cy.get('button:contains("Order to Show Cause")').click();
   cy.get('h3:contains("Order to Show Cause")').should('exist');
   cy.get('div:contains("Served")').should('exist');
+};
+
+exports.manuallyAddCaseToNewTrialSession = trialSessionId => {
+  cy.get('#add-to-trial-session-btn').should('exist').click();
+  cy.get('label[for="show-all-locations-true"]').click();
+  cy.get('select#trial-session')
+    .select(trialSessionId)
+    .should('have.value', trialSessionId);
+  cy.get('#modal-root .modal-button-confirm').click();
+  cy.get('.usa-alert--success').should('contain', 'Case scheduled for trial.');
+};
+
+exports.manuallyAddCaseToCalendaredTrialSession = trialSessionId => {
+  cy.get('#add-to-trial-session-btn').should('exist').click();
+  cy.get('label[for="show-all-locations-true"]').click();
+  cy.get('select#trial-session')
+    .select(trialSessionId)
+    .should('have.value', trialSessionId);
+  cy.get('#modal-root .modal-button-confirm').click();
+  cy.get('.usa-alert--success').should('contain', 'Case set for trial.');
+};
+
+exports.removeCaseFromTrialSession = () => {
+  cy.get('#remove-from-trial-session-btn').should('exist').click();
+  cy.get('#disposition').type(faker.company.catchPhrase());
+  cy.get('#modal-root .modal-button-confirm').click();
+  cy.get('#add-to-trial-session-btn').should('not.exist');
+};
+
+exports.blockCaseFromTrial = () => {
+  cy.get('#tabContent-overview .block-from-trial-btn').click();
+  cy.get('.modal-dialog #reason').type(faker.company.catchPhrase());
+  cy.get('.modal-dialog .modal-button-confirm').click();
+  cy.contains('Blocked From Trial');
+};
+
+exports.unblockCaseFromTrial = () => {
+  cy.get('button.red-warning').click(); // TODO: #remove-block
+  cy.get('.modal-button-confirm').click();
+  cy.contains('Block removed.');
+};
+
+exports.setCaseAsHighPriority = () => {
+  cy.get('.high-priority-btn').click();
+  cy.get('#reason').type(faker.company.catchPhrase());
+  cy.get('.modal-button-confirm').click();
+  cy.get('.modal-dialog').should('not.exist');
+  cy.contains('High Priority').should('exist');
 };

--- a/cypress-smoketests/support/pages/case-detail.js
+++ b/cypress-smoketests/support/pages/case-detail.js
@@ -136,7 +136,7 @@ exports.blockCaseFromTrial = () => {
 };
 
 exports.unblockCaseFromTrial = () => {
-  cy.get('button.red-warning').click(); // TODO: #remove-block
+  cy.get('#remove-block').click();
   cy.get('.modal-button-confirm').click();
   cy.contains('Block removed.');
 };

--- a/cypress-smoketests/support/pages/reports.js
+++ b/cypress-smoketests/support/pages/reports.js
@@ -1,0 +1,21 @@
+exports.viewBlockedCaseOnBlockedReport = testData => {
+  cy.get('#reports-btn').click();
+  cy.get('#all-blocked-cases').click();
+  cy.get('#trial-location').select(testData.preferredTrialCity);
+  cy.get(`a[href="/case-detail/${testData.docketNumber}"]`).should('exist');
+};
+
+exports.runTrialSessionPlanningReport = () => {
+  const nextYear = new Date().getUTCFullYear() + 1;
+  cy.get('#reports-btn').click();
+  cy.get('#trial-session-planning-btn').click();
+  cy.get('#modal-root select[name="term"]')
+    .select('Winter')
+    .should('have.value', 'winter');
+  cy.get('#modal-root select[name="year"]')
+    .select(`${nextYear}`)
+    .should('have.value', `${nextYear}`);
+  cy.get('.modal-button-confirm').click();
+  cy.url().should('contain', '/trial-session-planning-report');
+  cy.contains('Trial Session Planning Report');
+};

--- a/cypress-smoketests/support/pages/trial-sessions.js
+++ b/cypress-smoketests/support/pages/trial-sessions.js
@@ -1,0 +1,74 @@
+const faker = require('faker');
+
+faker.seed(faker.random.number());
+
+exports.createTrialSession = testData => {
+  const createFutureDate = () => {
+    const month = faker.random.number({ max: 12, min: 1 });
+    const day = faker.random.number({ max: 28, min: 1 });
+    const year =
+      new Date().getUTCFullYear() + faker.random.number({ max: 5, min: 1 });
+    return `${month}/${day}/${year}`;
+  };
+
+  cy.get('a[href="/trial-sessions"]').click();
+  cy.get('a[href="/add-a-trial-session"]').click();
+
+  // session information
+  cy.get('#start-date-date').type(createFutureDate());
+  cy.get('#start-time-hours')
+    .clear()
+    .type(faker.random.number({ max: 11, min: 6 }));
+  cy.get('#start-time-minutes')
+    .clear()
+    .type(faker.random.arrayElement(['00', '15', '30', '45']));
+  cy.get('label[for="startTimeExtension-pm"]').click();
+  cy.get('label[for="session-type-Hybrid"]').click();
+  cy.get('#max-cases').type(faker.random.number({ max: 100, min: 10 }));
+
+  // location information
+  cy.get('#trial-location').select(testData.preferredTrialCity);
+  cy.get('#courthouse-name').type(faker.commerce.productName());
+  cy.get('#address1').type(faker.address.streetAddress());
+  cy.get('#city').type(faker.address.city());
+  cy.get('#state').select(faker.address.stateAbbr());
+  cy.get('#postal-code').type(faker.address.zipCode());
+
+  // session assignments
+  cy.get('#judgeId').select('Chief Judge Foley');
+  cy.get('#trial-clerk').select('Test trialclerk1');
+  cy.get('#court-reporter').type(faker.name.findName());
+  cy.get('#irs-calendar-administrator').type(faker.name.findName());
+  cy.get('#notes').type(faker.company.catchPhrase());
+
+  cy.get('#submit-trial-session').click();
+
+  // set up listener for POST call, get trialSessionId
+  cy.wait('@postTrialSession').then(xhr => {
+    const { trialSessionId } = xhr.response.body;
+    testData.trialSessionIds.push(trialSessionId);
+    cy.get('#new-trial-sessions-tab').click();
+    cy.get(`a[href="/trial-session-detail/${trialSessionId}"]`).should('exist');
+  });
+};
+
+exports.goToTrialSession = trialSessionId => {
+  cy.goToRoute(`/trial-session-detail/${trialSessionId}`);
+};
+
+exports.setTrialSessionAsCalendared = trialSessionId => {
+  cy.goToRoute(`/trial-session-detail/${trialSessionId}`);
+  cy.get('#set-calendar-button').should('exist').click();
+  cy.get('#modal-root .modal-button-confirm').click();
+  cy.get('#set-calendar-button').should('not.exist');
+};
+
+exports.markCaseAsQcCompleteForTrial = docketNumber => {
+  cy.get(`#upcoming-sessions label[for="${docketNumber}-complete"]`).click();
+};
+
+exports.verifyOpenCaseOnTrialSession = docketNumber => {
+  cy.get(
+    `#open-cases-tab-content a[href="/case-detail/${docketNumber}"]`,
+  ).should('exist');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,7 @@
             "@babel/helper-split-export-declaration": "^7.11.0",
             "@babel/template": "^7.10.4",
             "@babel/types": "^7.11.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -174,7 +174,7 @@
             "@babel/types": "^7.11.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -192,7 +192,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {


### PR DESCRIPTION
* Pulled out functions into separate files to be consistent with the rest of the smoke test setup and for reusability
* Added global retries option to smoke test config and unskipped tests that have been causing problems to see if the retries will resolve them
