### PR TITLE
6069 checking for user token before displaying header to avoid race condition

### DIFF
--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -163,12 +163,14 @@ export const AppComponent = connect(
   {
     currentPage: state.currentPage,
     showModal: state.modal.showModal,
+    token: state.token,
     userContactEditInProgress: state.userContactEditProgress.inProgress,
     zipInProgress: state.batchDownloads.zipInProgress,
   },
   function AppComponent({
     currentPage,
     showModal,
+    token,
     userContactEditInProgress,
     zipInProgress,
   }) {
@@ -195,7 +197,7 @@ export const AppComponent = connect(
           Skip to main content
         </a>
         <UsaBanner />
-        <Header />
+        {token && <Header />}
         <main id="main-content" role="main">
           <CurrentPage />
           {zipInProgress && <BatchDownloadProgress />}


### PR DESCRIPTION
- Login on dev was flaky due to a race condition where notifications were being fetched for the global header before the user was successfully logged in. Only displaying header after there is a token present in state