### PR TITLE
Selected draft documents smoke tests fix

### DIFF
--- a/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.js
@@ -13,6 +13,7 @@ export const submitCourtIssuedOrderAction = async ({
   applicationContext,
   get,
   props,
+  store,
 }) => {
   let caseDetail;
   const { docketNumber } = get(state.caseDetail);
@@ -60,15 +61,12 @@ export const submitCourtIssuedOrderAction = async ({
       });
   }
 
-  const viewerDraftDocumentToDisplay = caseDetail.docketEntries.find(
-    entry => entry.docketEntryId === docketEntryId && entry.isDraft,
-  );
+  store.set(state.draftDocumentViewerDocketEntryId, docketEntryId);
 
   return {
     caseDetail,
     docketEntryId,
     docketNumber,
     eventCode: documentMetadata.eventCode,
-    viewerDraftDocumentToDisplay,
   };
 };

--- a/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.test.js
@@ -72,7 +72,7 @@ describe('submitCourtIssuedOrderAction', () => {
     });
   });
 
-  it('should return the newly submitted document as props.viewerDraftDocumentToDisplay', async () => {
+  it('should set state.draftDocumentViewerDocketEntryId to the docketEntryId from props', async () => {
     applicationContext
       .getUseCases()
       .fileCourtIssuedOrderInteractor.mockReturnValue({
@@ -87,7 +87,7 @@ describe('submitCourtIssuedOrderAction', () => {
         ],
       });
 
-    const { output } = await runAction(submitCourtIssuedOrderAction, {
+    const { state } = await runAction(submitCourtIssuedOrderAction, {
       modules: {
         presenter,
       },
@@ -104,9 +104,8 @@ describe('submitCourtIssuedOrderAction', () => {
       },
     });
 
-    expect(output.viewerDraftDocumentToDisplay).toMatchObject({
-      docketEntryId: '4234312d-7294-47ae-9f1d-182df17546a1',
-      documentType: 'Notice of Intervention',
-    });
+    expect(state.draftDocumentViewerDocketEntryId).toBe(
+      '4234312d-7294-47ae-9f1d-182df17546a1',
+    );
   });
 });

--- a/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.js
+++ b/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.js
@@ -15,11 +15,10 @@ export const getDefaultDraftViewerDocumentToDisplayAction = ({
   get,
   props,
 }) => {
-  const { docketEntryId } = props;
+  const docketEntryId =
+    get(state.draftDocumentViewerDocketEntryId) || props.docketEntryId;
 
-  let viewerDraftDocumentToDisplay =
-    get(state.viewerDraftDocumentToDisplay) || null;
-
+  let viewerDraftDocumentToDisplay = null;
   const caseDetail = get(state.caseDetail);
 
   const { draftDocuments } = applicationContext
@@ -30,7 +29,7 @@ export const getDefaultDraftViewerDocumentToDisplayAction = ({
     viewerDraftDocumentToDisplay = draftDocuments.find(
       d => d.docketEntryId === docketEntryId,
     );
-  } else if (!viewerDraftDocumentToDisplay) {
+  } else {
     viewerDraftDocumentToDisplay = draftDocuments[0];
   }
 

--- a/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.test.js
@@ -65,7 +65,41 @@ describe('getDefaultDraftViewerDocumentToDisplayAction', () => {
     });
   });
 
-  it('returns the correct document if props.docketEntryId is set', async () => {
+  it('returns the correct document when state.draftDocumentViewerDocketEntryId is set', async () => {
+    const result = await runAction(
+      getDefaultDraftViewerDocumentToDisplayAction,
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          caseDetail: {
+            draftDocuments: [
+              {
+                docketEntryId: '123',
+                documentType: 'Petition',
+              },
+              {
+                docketEntryId: '123456',
+                documentType: 'Order',
+              },
+              {
+                docketEntryId: '345',
+                documentType: 'Notice',
+                isDraft: true,
+              },
+            ],
+          },
+          draftDocumentViewerDocketEntryId: '123456',
+        },
+      },
+    );
+    expect(result.output).toMatchObject({
+      viewerDraftDocumentToDisplay: { docketEntryId: '123456' },
+    });
+  });
+
+  it('returns the correct document when state.draftDocumentViewerDocketEntryId is not set and props.docketEntryId is set', async () => {
     const result = await runAction(
       getDefaultDraftViewerDocumentToDisplayAction,
       {
@@ -96,44 +130,6 @@ describe('getDefaultDraftViewerDocumentToDisplayAction', () => {
     );
     expect(result.output).toMatchObject({
       viewerDraftDocumentToDisplay: { docketEntryId: '345' },
-    });
-  });
-
-  it('returns the correct document if props.docketEntryId is not set and state.viwerDraftDOcumentToDisplay is set', async () => {
-    const result = await runAction(
-      getDefaultDraftViewerDocumentToDisplayAction,
-      {
-        modules: {
-          presenter,
-        },
-        props: {},
-        state: {
-          caseDetail: {
-            docketEntries: [
-              {
-                docketEntryId: '123',
-                documentType: 'Petition',
-              },
-              {
-                docketEntryId: '234',
-                documentType: 'Order',
-              },
-              {
-                docketEntryId: '345',
-                documentType: 'Notice',
-                isDraft: true,
-              },
-            ],
-          },
-          viewerDraftDocumentToDisplay: {
-            docketEntryId: '234',
-            documentType: 'Order',
-          },
-        },
-      },
-    );
-    expect(result.output).toMatchObject({
-      viewerDraftDocumentToDisplay: { docketEntryId: '234' },
     });
   });
 });

--- a/web-client/src/presenter/sequences/uploadCourtIssuedDocumentSequence.js
+++ b/web-client/src/presenter/sequences/uploadCourtIssuedDocumentSequence.js
@@ -41,7 +41,7 @@ export const uploadCourtIssuedDocumentSequence = [
           setupUploadMetadataAction,
           submitCourtIssuedOrderAction,
           setCaseAction,
-          setViewerDraftDocumentToDisplayAction,
+          // setViewerDraftDocumentToDisplayAction,
           getUploadCourtIssuedDocumentAlertSuccessAction,
           setAlertSuccessAction,
           setSaveAlertsForNavigationAction,

--- a/web-client/src/presenter/sequences/uploadCourtIssuedDocumentSequence.js
+++ b/web-client/src/presenter/sequences/uploadCourtIssuedDocumentSequence.js
@@ -12,7 +12,6 @@ import { setIsPrimaryTabAction } from '../actions/setIsPrimaryTabAction';
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
-import { setViewerDraftDocumentToDisplayAction } from '../actions/setViewerDraftDocumentToDisplayAction';
 import { setupUploadMetadataAction } from '../actions/uploadCourtIssuedDocument/setupUploadMetadataAction';
 import { showProgressSequenceDecorator } from '../utilities/sequenceHelpers';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
@@ -41,7 +40,6 @@ export const uploadCourtIssuedDocumentSequence = [
           setupUploadMetadataAction,
           submitCourtIssuedOrderAction,
           setCaseAction,
-          // setViewerDraftDocumentToDisplayAction,
           getUploadCourtIssuedDocumentAlertSuccessAction,
           setAlertSuccessAction,
           setSaveAlertsForNavigationAction,

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -230,8 +230,8 @@ export const baseState = {
   },
   // needs its own object because it's present when other forms are on screen
   docketEntryId: null,
-
   docketRecordIndex: 0,
+  draftDocumentViewerDocketEntryId: null,
   fileUploadProgress: {
     // used for the progress bar shown in modal when uploading files
     isUploading: false,


### PR DESCRIPTION
Smoke tests were failing due to the bug fix implemented in #6431. Now setting draftDocumentViewerDocketEntryId after submitting a court issued document to correctly select the newest created draft document in the 'Drafts' view, fixes failing smoke test too