### PR TITLE
Removing pa11y-folder-specific docker commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,6 @@ RUN npm set progress=false && \
 
 COPY . /home/app
 
-COPY web-client/pa11y/package.json /home/app/web-client/pa11y/package.json
-COPY web-client/pa11y/package-lock.json /home/app/web-client/pa11y/package-lock.json
-RUN npm set progress=false && npm ci --prefix=web-client/pa11y/
-COPY ./web-client/pa11y /home/app/web-client/pa11y
-
 RUN mkdir -p /home/app/web-client/cypress/screenshots && \
   mkdir -p /home/app/web-client/cypress/videos && \
   mkdir -p /home/app/web-client/cypress-smoketests/videos

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -50,11 +50,6 @@ RUN npm set progress=false && \
 
 COPY . /home/app
 
-COPY web-client/pa11y/package.json /home/app/web-client/pa11y/package.json
-COPY web-client/pa11y/package-lock.json /home/app/web-client/pa11y/package-lock.json
-RUN npm set progress=false && npm ci --prefix=web-client/pa11y/
-COPY ./web-client/pa11y /home/app/web-client/pa11y
-
 RUN mkdir -p /home/app/web-client/cypress/screenshots && \
   mkdir -p /home/app/web-client/cypress/videos && \
   mkdir -p /home/app/web-client/cypress-smoketests/videos


### PR DESCRIPTION
rendered obsolete now that pa11y package files are gone