### PR TITLE
Smoke test fix - setup blocks to allow proper retries

### DIFF
--- a/cypress-smoketests/integration/case-creation.spec.js
+++ b/cypress-smoketests/integration/case-creation.spec.js
@@ -42,19 +42,28 @@ describe('Petitioner', () => {
     login(token);
   });
 
-  it('should be able to create a case', () => {
-    goToStartCreatePetition();
-    goToWizardStep1();
-    completeWizardStep1();
-    goToWizardStep2();
-    completeWizardStep2(hasIrsNotice.NO, 'Innocent Spouse');
-    goToWizardStep3();
-    completeWizardStep3(filingTypes.INDIVIDUAL, 'Petitioner');
-    goToWizardStep4();
-    completeWizardStep4();
-    goToWizardStep5();
-    submitPetition();
-    goToDashboard();
+  describe('should be able to create a case', () => {
+    it('should complete wizard step 1', () => {
+      goToStartCreatePetition();
+      goToWizardStep1();
+      completeWizardStep1();
+    });
+
+    // this is in its own step because sometimes the click fails, and if it's in its own step it will retry properly
+    it('should go to wizard step 2', () => {
+      goToWizardStep2();
+    });
+
+    it('should complete the form and submit the petition', () => {
+      completeWizardStep2(hasIrsNotice.NO, 'Innocent Spouse');
+      goToWizardStep3();
+      completeWizardStep3(filingTypes.INDIVIDUAL, 'Petitioner');
+      goToWizardStep4();
+      completeWizardStep4();
+      goToWizardStep5();
+      submitPetition();
+      goToDashboard();
+    });
   });
 });
 
@@ -71,21 +80,30 @@ describe('Private practitioner', () => {
     login(token);
   });
 
-  it('should be able to create a case', () => {
-    goToStartCreatePetition();
-    completeWizardStep1();
-    goToWizardStep2();
-    completeWizardStep2(hasIrsNotice.YES, 'Notice of Deficiency');
-    goToWizardStep3();
-    completeWizardStep3(
-      filingTypes.PETITIONER_AND_SPOUSE,
-      'Private practitioner',
-    );
-    goToWizardStep4();
-    completeWizardStep4();
-    goToWizardStep5();
-    submitPetition();
-    goToDashboard();
+  describe('should be able to create a case', () => {
+    it('should complete wizard step 1', () => {
+      goToStartCreatePetition();
+      completeWizardStep1();
+    });
+
+    // this is in its own step because sometimes the click fails, and if it's in its own step it will retry properly
+    it('should go to wizard step 2', () => {
+      goToWizardStep2();
+    });
+
+    it('should complete the form and submit the petition', () => {
+      completeWizardStep2(hasIrsNotice.YES, 'Notice of Deficiency');
+      goToWizardStep3();
+      completeWizardStep3(
+        filingTypes.PETITIONER_AND_SPOUSE,
+        'Private practitioner',
+      );
+      goToWizardStep4();
+      completeWizardStep4();
+      goToWizardStep5();
+      submitPetition();
+      goToDashboard();
+    });
   });
 });
 


### PR DESCRIPTION
Our Cypress config is set up to auto-retry now, but it retries the entire block. Sometimes the click on step 2 of creating a petition fails, but the retry doesn't work properly because it goes back to the beginning of the block and doesn't find the right elements. This setup allows that step to retry by itself.