### PR TITLE
[bug] 6442: Duplicate language for Notice of Docket Change

### DIFF
--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
@@ -10,6 +10,10 @@ const {
   NOTICE_OF_DOCKET_CHANGE,
 } = require('../../entities/EntityConstants');
 const {
+  DOCKET_SECTION,
+  DOCUMENT_PROCESSING_STATUS_OPTIONS,
+} = require('../../entities/EntityConstants');
+const {
   formatDocketEntry,
   getFilingsAndProceedings,
 } = require('../../utilities/getFormattedCaseDetail');
@@ -22,7 +26,6 @@ const {
 } = require('../../../authorization/authorizationClientService');
 const { Case } = require('../../entities/cases/Case');
 const { CASE_CAPTION_POSTFIX } = require('../../entities/EntityConstants');
-const { DOCKET_SECTION } = require('../../entities/EntityConstants');
 const { DocketEntry } = require('../../entities/DocketEntry');
 const { formatDateString } = require('../../utilities/DateHandler');
 const { getCaseCaptionMeta } = require('../../utilities/getCaseCaptionMeta');
@@ -294,6 +297,7 @@ exports.completeDocketEntryQCInteractor = async ({
         ),
         isFileAttached: true,
         isOnDocketRecord: true,
+        processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
         userId: user.userId,
       },
       { applicationContext },

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
@@ -6,6 +6,7 @@ const {
   CASE_TYPES_MAP,
   COUNTRY_TYPES,
   DOCKET_SECTION,
+  DOCUMENT_PROCESSING_STATUS_OPTIONS,
   PARTY_TYPES,
   ROLES,
 } = require('../../entities/EntityConstants');
@@ -322,6 +323,7 @@ describe('completeDocketEntryQCInteractor', () => {
     expect(noticeOfDocketChange).toMatchObject({
       isFileAttached: true,
       numberOfPages: 999,
+      processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
     });
 
     expect(

--- a/web-client/integration-tests/docketClerkExternalDocumentQCWorkflow.test.js
+++ b/web-client/integration-tests/docketClerkExternalDocumentQCWorkflow.test.js
@@ -1,3 +1,4 @@
+import { DOCUMENT_PROCESSING_STATUS_OPTIONS } from '../../shared/src/business/entities/EntityConstants';
 import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import {
   assignWorkItems,
@@ -135,12 +136,15 @@ describe('Create a work item', () => {
 
     await test.runSequence('completeDocketEntryQCSequence');
 
-    const noticeDocument = test
+    const noticeDocketEntry = test
       .getState('caseDetail.docketEntries')
       .find(doc => doc.documentType === 'Notice of Docket Change');
 
-    expect(noticeDocument).toBeTruthy();
-    expect(noticeDocument.servedAt).toBeDefined();
+    expect(noticeDocketEntry).toBeTruthy();
+    expect(noticeDocketEntry.servedAt).toBeDefined();
+    expect(noticeDocketEntry.processingStatus).toEqual(
+      DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
+    );
     expect(test.getState('modal.showModal')).toEqual(
       'PaperServiceConfirmModal',
     );


### PR DESCRIPTION
Formatted `displayDescription` property was showing twice because this system-generated docket entry's `processingStatus` was defaulted to `processing`, and not explicitly set (unlike other system-generated document types). 

- Set this notice's `DocketEntry.processingStatus` to `complete` on initialization (see interactor)
- Added unit test and integration test check