### PR TITLE
6507 edit docket entry coversheet bug

### DIFF
--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
@@ -100,11 +100,19 @@ exports.updateDocketEntryMetaInteractor = async ({
     caseEntity.updateDocketEntry(docketEntryEntity);
 
     if (shouldGenerateCoversheet) {
+      await applicationContext.getPersistenceGateway().updateDocketEntry({
+        applicationContext,
+        docketEntryId: docketEntryEntity.docketEntryId,
+        docketNumber,
+        document: docketEntryEntity.validate(),
+      });
+
       // servedAt or filingDate has changed, generate a new coversheet
       await applicationContext.getUseCases().addCoversheetInteractor({
         applicationContext,
         docketEntryId: originalDocketEntry.docketEntryId,
         docketNumber: caseEntity.docketNumber,
+        replaceCoversheet: true,
       });
     }
   }

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
@@ -241,7 +241,29 @@ describe('updateDocketEntryMetaInteractor', () => {
     ).toHaveBeenCalled();
   });
 
-  it('should generate a new coversheet for the document if the filingDate field is changed', async () => {
+  it('should make a call to update the docketEntryEntity before adding a coversheet when the filingDate field is changed', async () => {
+    await updateDocketEntryMetaInteractor({
+      applicationContext,
+      docketEntryMeta: {
+        ...docketEntries[0],
+        filingDate: '2020-08-01T00:01:00.000Z',
+      },
+      docketNumber: '101-20',
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateDocketEntry,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().updateDocketEntry.mock
+        .calls[0][0],
+    ).toMatchObject({
+      docketNumber: '101-20',
+      document: { filingDate: '2020-08-01T00:01:00.000Z' },
+    });
+  });
+
+  it("should replace the document's coversheet with a new one when the filingDate field is changed", async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
       docketEntryMeta: {
@@ -254,6 +276,12 @@ describe('updateDocketEntryMetaInteractor', () => {
     expect(
       applicationContext.getUseCases().addCoversheetInteractor,
     ).toHaveBeenCalled();
+    expect(
+      applicationContext.getUseCases().addCoversheetInteractor.mock.calls[0][0],
+    ).toMatchObject({
+      docketNumber: '101-20',
+      replaceCoversheet: true,
+    });
   });
 
   it('should NOT generate a new coversheet for the document if the servedAt and filingDate fields are NOT changed', async () => {


### PR DESCRIPTION
- Editing docket entry would generate multiple coversheets, now only generating one coversheet each time and replacing the old one.
- New coversheet ONLY generated when filedBy or servedAt is updated for docket entry. No new coversheet when other meta fields updates