### PR TITLE
6507 coversheet bug

### DIFF
--- a/shared/src/business/useCases/addCoversheetInteractor.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.js
@@ -18,6 +18,7 @@ exports.generateCoverSheetData = ({
   applicationContext,
   caseEntity,
   docketEntryEntity,
+  filingDateUpdated,
   useInitialData,
 }) => {
   const isLodged = docketEntryEntity.lodged;
@@ -40,11 +41,10 @@ exports.generateCoverSheetData = ({
           .formatDateString(docketEntryEntity.createdAt, 'MMDDYY')) ||
       '';
   } else {
-    dateReceivedFormatted =
-      (docketEntryEntity.createdAt &&
-        applicationContext
-          .getUtilities()
-          .formatDateString(docketEntryEntity.createdAt, 'MM/DD/YY hh:mm a')) ||
+    (docketEntryEntity.filingDate &&
+      applicationContext
+        .getUtilities()
+        .formatDateString(docketEntryEntity.filingDate, 'MMDDYY')) ||
       '';
   }
 
@@ -86,7 +86,9 @@ exports.generateCoverSheetData = ({
     certificateOfService,
     dateFiledLodged: dateFiledFormatted,
     dateFiledLodgedLabel: isLodged ? 'Lodged' : 'Filed',
-    dateReceived: dateReceivedFormatted,
+    dateReceived: filingDateUpdated
+      ? dateFiledFormatted
+      : dateReceivedFormatted,
     dateServed: dateServedFormatted,
     docketNumberWithSuffix,
     documentTitle,
@@ -122,6 +124,7 @@ exports.addCoverToPdf = async ({
   applicationContext,
   caseEntity,
   docketEntryEntity,
+  filingDateUpdated = false,
   pdfData,
   replaceCoversheet = false,
   useInitialData = false,
@@ -130,6 +133,7 @@ exports.addCoverToPdf = async ({
     applicationContext,
     caseEntity,
     docketEntryEntity,
+    filingDateUpdated,
     useInitialData,
   });
 

--- a/shared/src/business/useCases/addCoversheetInteractor.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.js
@@ -41,10 +41,11 @@ exports.generateCoverSheetData = ({
           .formatDateString(docketEntryEntity.createdAt, 'MMDDYY')) ||
       '';
   } else {
-    (docketEntryEntity.filingDate &&
-      applicationContext
-        .getUtilities()
-        .formatDateString(docketEntryEntity.filingDate, 'MMDDYY')) ||
+    dateReceivedFormatted =
+      (docketEntryEntity.createdAt &&
+        applicationContext
+          .getUtilities()
+          .formatDateString(docketEntryEntity.createdAt, 'MM/DD/YY hh:mm a')) ||
       '';
   }
 
@@ -185,6 +186,7 @@ exports.addCoversheetInteractor = async ({
   applicationContext,
   docketEntryId,
   docketNumber,
+  filingDateUpdated = false,
   replaceCoversheet = false,
   useInitialData = false,
 }) => {
@@ -220,6 +222,7 @@ exports.addCoversheetInteractor = async ({
     applicationContext,
     caseEntity,
     docketEntryEntity,
+    filingDateUpdated,
     pdfData,
     replaceCoversheet,
     useInitialData,

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -387,7 +387,7 @@ describe('addCoversheetInteractor', () => {
           documentType:
             'Motion for Entry of Order that Undenied Allegations be Deemed Admitted Pursuant to Rule 37(c)',
           eventCode: 'M008',
-          filingDate: '2019-04-19T14:45:15x.595Z',
+          filingDate: '2019-04-19T14:45:15.595Z',
           isPaper: false,
         },
         filingDateUpdated: false,

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -364,12 +364,13 @@ describe('addCoversheetInteractor', () => {
           filingDate: '2019-04-19T14:45:15.595Z',
           isPaper: false,
         },
+        filingDateUpdated: false,
       });
 
       expect(result.dateReceived).toEqual('04/19/19 10:45 am');
     });
 
-    it('shows does not show the received date if the document does not have a valid createdAt and is electronically filed', async () => {
+    it('does not show the received date if the document does not have a valid createdAt and is electronically filed', async () => {
       const result = generateCoverSheetData({
         applicationContext,
         caseEntity: {
@@ -386,9 +387,10 @@ describe('addCoversheetInteractor', () => {
           documentType:
             'Motion for Entry of Order that Undenied Allegations be Deemed Admitted Pursuant to Rule 37(c)',
           eventCode: 'M008',
-          filingDate: '2019-04-19T14:45:15.595Z',
+          filingDate: '2019-04-19T14:45:15x.595Z',
           isPaper: false,
         },
+        filingDateUpdated: false,
       });
 
       expect(result.dateReceived).toEqual('');
@@ -772,6 +774,58 @@ describe('addCoversheetInteractor', () => {
       expect(result.dateReceived).toBeUndefined();
       expect(result.electronicallyFiled).toBeUndefined();
       expect(result.dateServed).toBeUndefined();
+    });
+
+    it('sets the dateRecieved to dateFiledFormatted when the filingDate has been updated', () => {
+      const result = generateCoverSheetData({
+        applicationContext,
+        caseEntity: {
+          ...caseData,
+          caseCaption: 'Janie Petitioner, Petitioner',
+        },
+        docketEntryEntity: {
+          ...testingCaseData.docketEntries[0],
+          addToCoversheet: true,
+          additionalInfo: 'Additional Info Something',
+          certificateOfService: true,
+          createdAt: '2019-02-19T14:45:15.595Z',
+          docketEntryId: 'b6b81f4d-1e47-423a-8caf-6d2fdc3d3858',
+          documentType:
+            'Motion for Entry of Order that Undenied Allegations be Deemed Admitted Pursuant to Rule 37(c)',
+          eventCode: 'M008',
+          filingDate: '2019-05-19T14:45:15.595Z',
+          isPaper: false,
+        },
+        filingDateUpdated: true,
+      });
+
+      expect(result.dateReceived).toBe('05/19/19');
+    });
+
+    it('ets the dateRecieved to createdAt date when the filingDate has not been updated', () => {
+      const result = generateCoverSheetData({
+        applicationContext,
+        caseEntity: {
+          ...caseData,
+          caseCaption: 'Janie Petitioner, Petitioner',
+        },
+        docketEntryEntity: {
+          ...testingCaseData.docketEntries[0],
+          addToCoversheet: true,
+          additionalInfo: 'Additional Info Something',
+          certificateOfService: true,
+          createdAt: '2019-02-15T14:45:15.595Z',
+          docketEntryId: 'b6b81f4d-1e47-423a-8caf-6d2fdc3d3858',
+          documentType:
+            'Motion for Entry of Order that Undenied Allegations be Deemed Admitted Pursuant to Rule 37(c)',
+          eventCode: 'M008',
+          filingDate: '2019-05-19T14:45:15.595Z',
+          isPaper: true,
+        },
+        filingDateUpdated: false,
+      });
+
+      expect(result.dateReceived).toBe('02/15/19');
     });
   });
 });

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -802,7 +802,7 @@ describe('addCoversheetInteractor', () => {
       expect(result.dateReceived).toBe('05/19/19');
     });
 
-    it('ets the dateRecieved to createdAt date when the filingDate has not been updated', () => {
+    it('sets the dateRecieved to createdAt date when the filingDate has not been updated', () => {
       const result = generateCoverSheetData({
         applicationContext,
         caseEntity: {

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
@@ -112,7 +112,7 @@ exports.updateDocketEntryMetaInteractor = async ({
         applicationContext,
         docketEntryId: originalDocketEntry.docketEntryId,
         docketNumber: caseEntity.docketNumber,
-        replaceCoversheet: true,
+        filingDateUpdated,
       });
     }
   }

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
@@ -263,7 +263,7 @@ describe('updateDocketEntryMetaInteractor', () => {
     });
   });
 
-  it("should replace the document's coversheet with a new one when the filingDate field is changed", async () => {
+  it('should add a new coversheet when filingDate field is changed', async () => {
     await updateDocketEntryMetaInteractor({
       applicationContext,
       docketEntryMeta: {
@@ -280,7 +280,7 @@ describe('updateDocketEntryMetaInteractor', () => {
       applicationContext.getUseCases().addCoversheetInteractor.mock.calls[0][0],
     ).toMatchObject({
       docketNumber: '101-20',
-      replaceCoversheet: true,
+      filingDateUpdated: true,
     });
   });
 


### PR DESCRIPTION
both the filed date and the received date now update to the new filing date. A second cover sheet is generated to display the changed dates. The original cover sheet remains.