### PR TITLE
6464: show not signed alert after removing signature from document

### DIFF
--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
@@ -46,6 +46,8 @@ exports.getDownloadPolicyUrlInteractor = async ({
 
   const caseEntity = new Case(caseData, { applicationContext });
 
+  const petitionDocketEntry = caseEntity.getPetitionDocketEntry();
+
   if (!isInternalUser && !isIrsSuperuser) {
     if (key.includes('.pdf')) {
       if (caseEntity.getCaseConfirmationGeneratedPdfFileName() !== key) {
@@ -99,11 +101,7 @@ exports.getDownloadPolicyUrlInteractor = async ({
       }
     }
   } else if (isIrsSuperuser) {
-    const isPetitionServed = caseEntity.docketEntries.find(
-      doc => doc.documentType === 'Petition',
-    ).servedAt;
-
-    if (!isPetitionServed) {
+    if (petitionDocketEntry && !petitionDocketEntry.servedAt) {
       throw new UnauthorizedError(
         'Unauthorized to view case documents at this time',
       );
@@ -119,11 +117,11 @@ exports.getDownloadPolicyUrlInteractor = async ({
         INITIAL_DOCUMENT_TYPES.stin.documentType;
 
     if (isPetitionsClerk) {
-      const isPetitionServed = caseEntity.docketEntries.find(
-        doc => doc.documentType === 'Petition',
-      ).servedAt;
-
-      if (selectedIsStin && isPetitionServed) {
+      if (
+        selectedIsStin &&
+        petitionDocketEntry &&
+        petitionDocketEntry.servedAt
+      ) {
         throw new UnauthorizedError(
           'Unauthorized to view case documents at this time',
         );

--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.js
@@ -19,20 +19,6 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
 
   const viewerDraftDocumentToDisplay = get(state.viewerDraftDocumentToDisplay);
 
-  const documentRequiresSignature =
-    viewerDraftDocumentToDisplay &&
-    EVENT_CODES_REQUIRING_SIGNATURE.includes(
-      viewerDraftDocumentToDisplay.eventCode,
-    );
-
-  const isNotice =
-    viewerDraftDocumentToDisplay &&
-    NOTICE_EVENT_CODES.includes(viewerDraftDocumentToDisplay.eventCode);
-
-  const isStipulatedDecision =
-    viewerDraftDocumentToDisplay &&
-    viewerDraftDocumentToDisplay.eventCode === STIPULATED_DECISION_EVENT_CODE;
-
   const formattedDocumentToDisplay =
     viewerDraftDocumentToDisplay &&
     formattedCaseDetail.draftDocuments &&
@@ -41,18 +27,30 @@ export const draftDocumentViewerHelper = (get, applicationContext) => {
         draftDocument.docketEntryId ===
         viewerDraftDocumentToDisplay.docketEntryId,
     );
+
   if (!formattedDocumentToDisplay) {
     return {
       createdByLabel: '',
       documentTitle: '',
     };
   }
+
+  const documentRequiresSignature = EVENT_CODES_REQUIRING_SIGNATURE.includes(
+    formattedDocumentToDisplay.eventCode,
+  );
+
+  const isNotice = NOTICE_EVENT_CODES.includes(
+    formattedDocumentToDisplay.eventCode,
+  );
+
+  const isStipulatedDecision =
+    formattedDocumentToDisplay.eventCode === STIPULATED_DECISION_EVENT_CODE;
+
+  const documentIsSigned = !!formattedDocumentToDisplay.signedAt;
+
   const createdByLabel = formattedDocumentToDisplay.filedBy
     ? `Created by ${formattedDocumentToDisplay.filedBy}`
     : '';
-
-  const documentIsSigned =
-    viewerDraftDocumentToDisplay && !!formattedDocumentToDisplay.signedAt;
 
   const isInternalUser = applicationContext
     .getUtilities()

--- a/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/draftDocumentViewerHelper.test.js
@@ -556,6 +556,7 @@ describe('draftDocumentViewerHelper', () => {
               docketEntryId: 'abc',
               documentTitle: 'Notice',
               documentType: 'NOT',
+              eventCode: 'NOT',
               isDraft: true,
               signedAt: '2020-06-25T20:49:28.192Z',
             },
@@ -563,7 +564,6 @@ describe('draftDocumentViewerHelper', () => {
         },
         viewerDraftDocumentToDisplay: {
           docketEntryId: 'abc',
-          eventCode: 'NOT',
         },
       },
     });
@@ -635,13 +635,38 @@ describe('draftDocumentViewerHelper', () => {
               docketEntryId: 'abc',
               documentTitle: 'Order to do something',
               documentType: 'Order',
+              eventCode: 'O', // Requires a signature
               isDraft: true,
             },
           ],
         },
         viewerDraftDocumentToDisplay: {
           docketEntryId: 'abc',
-          eventCode: 'O', // Requires a signature
+          eventCode: 'O',
+        },
+      },
+    });
+
+    expect(result.showDocumentNotSignedAlert).toEqual(true);
+  });
+
+  it('should return showDocumentNotSignedAlert true if document is not signed but the event code requires a signature and viewerDraftDocumentToDisplay only contains a docketEntryId', () => {
+    const result = runCompute(draftDocumentViewerHelper, {
+      state: {
+        ...getBaseState(petitionerUser),
+        caseDetail: {
+          docketEntries: [
+            {
+              docketEntryId: 'abc',
+              documentTitle: 'Order to do something',
+              documentType: 'Order',
+              eventCode: 'O', // Requires a signature
+              isDraft: true,
+            },
+          ],
+        },
+        viewerDraftDocumentToDisplay: {
+          docketEntryId: 'abc',
         },
       },
     });


### PR DESCRIPTION
This bug was happening because `removeSignatureAction` was returning `viewerDraftDocumentToDisplay` with only the `docketEntryId` instead of the full object. Updated the `draftDocumentViewerHelper` to use the full object from the case instead of relying on the data in `viewerDraftDocumentToDisplay`.