### PR TITLE
6600 - refactor trigger to only need subset of application context

### DIFF
--- a/web-api/terraform/template/lambdas/cognito-triggers.js
+++ b/web-api/terraform/template/lambdas/cognito-triggers.js
@@ -1,8 +1,33 @@
-const createApplicationContext = require('../../../src/applicationContext');
+const AWS = require('aws-sdk');
+const {
+  createPetitionerAccountInteractor,
+} = require('../../../../shared/src/business/useCases/users/createPetitionerAccountInteractor');
+const {
+  persistUser,
+} = require('../../../../shared/src/persistence/dynamo/users/persistUser');
+
+const { DynamoDB } = AWS;
+
+const applicationContext = {
+  getDocumentClient: () => {
+    return new DynamoDB.DocumentClient({
+      endpoint: process.env.DYNAMODB_ENDPOINT,
+      region: process.env.AWS_REGION,
+    });
+  },
+  getEnvironment: () => ({
+    dynamoDbTableName: process.env.DYNAMODB_TABLE_NAME,
+    stage: process.env.STAGE,
+  }),
+  getPersistenceGateway: () => ({
+    persistUser,
+  }),
+  getUseCases: () => ({
+    createPetitionerAccountInteractor,
+  }),
+};
 
 exports.handler = async event => {
-  const applicationContext = createApplicationContext();
-
   const { email, name, sub: userId } = event.request.userAttributes;
 
   await applicationContext.getUseCases().createPetitionerAccountInteractor({


### PR DESCRIPTION
Something is messing up this trigger when using the full application context and we can't figure out what.... we are using a subset application context to get this working.

<img width="1051" alt="Screen Shot 2020-10-03 at 1 27 00 AM" src="https://user-images.githubusercontent.com/1868782/94984203-8b09e400-0517-11eb-9bd2-6820860e5a7c.png">
