### PR TITLE
6618 trial session working copy link

### DIFF
--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -25,6 +25,7 @@ const getUserIsAssignedToSession = ({ currentUser, get, result }) => {
 
   const isJudgeUserAssigned = !!(session?.judge?.userId === currentUser.userId);
   const isChambersUserAssigned =
+    judge &&
     session?.judge?.userId === judge?.userId &&
     judge?.section === currentUser.section;
   const isTrialClerkUserAssigned =

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -14,12 +14,25 @@ export const formattedClosedCases = (get, applicationContext) => {
   return cases.map(myCase => formatCase(applicationContext, myCase));
 };
 
-const getUserIsAssignedToSession = ({ currentUserId, session }) => {
-  const isJudgeUserAssigned = !!(session?.judge?.userId === currentUserId);
-  const isTrialClerkUserAssigned =
-    session?.trialClerk?.userId === currentUserId;
+const getUserIsAssignedToSession = ({ currentUser, get, result }) => {
+  const sessions = get(state.trialSessions);
+  let session;
+  if (sessions) {
+    session = sessions.find(s => s.trialSessionId === result.trialSessionId);
+  }
 
-  return isJudgeUserAssigned || isTrialClerkUserAssigned;
+  const judge = get(state.judgeUser);
+
+  const isJudgeUserAssigned = !!(session?.judge?.userId === currentUser.userId);
+  const isChambersUserAssigned =
+    session?.judge?.userId === judge?.userId &&
+    judge?.section === currentUser.section;
+  const isTrialClerkUserAssigned =
+    session?.trialClerk?.userId === currentUser.userId;
+
+  return (
+    isJudgeUserAssigned || isTrialClerkUserAssigned || isChambersUserAssigned
+  );
 };
 
 export const getShowDocumentViewerLink = ({
@@ -252,15 +265,10 @@ export const formattedCaseDetail = (get, applicationContext) => {
 
   result.consolidatedCases = result.consolidatedCases || [];
 
-  const sessions = get(state.trialSessions);
-  let session;
-  if (sessions) {
-    session = sessions.find(s => s.trialSessionId === result.trialSessionId);
-  }
-
   result.userIsAssignedToSession = getUserIsAssignedToSession({
-    currentUserId: user.userId,
-    session,
+    currentUser: user,
+    get,
+    result,
   });
 
   result.showBlockedTag = caseDetail.blocked || caseDetail.automaticBlocked;

--- a/web-client/src/presenter/computeds/formattedCaseDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.test.js
@@ -2326,7 +2326,7 @@ describe('formattedCaseDetail', () => {
     });
   });
 
-  describe('trial session', () => {
+  describe('userIsAssignedToSession', () => {
     const caseDetail = {
       archivedCorrespondences: [],
       archivedDocketEntries: [],
@@ -2596,7 +2596,7 @@ describe('formattedCaseDetail', () => {
       userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
     };
 
-    it("should set userIsAssignedToSession to true when the case's trial session judge is the currently logged in user", () => {
+    it("should be true when the case's trial session judge is the currently logged in user", () => {
       const mockTrialSessionId = applicationContext.getUniqueId();
 
       const result = runCompute(formattedCaseDetail, {
@@ -2620,7 +2620,31 @@ describe('formattedCaseDetail', () => {
       expect(result.userIsAssignedToSession).toBeTruthy();
     });
 
-    it('should set userIsAssignedToSession to true when the current user is a chambers user for the judge assigned to the trial session the case is scheduled for', () => {
+    it("should be false when the case's trial session judge is not the currently logged in user", () => {
+      const mockTrialSessionId = applicationContext.getUniqueId();
+
+      const result = runCompute(formattedCaseDetail, {
+        state: {
+          caseDetail: {
+            ...caseDetail,
+            trialSessionId: mockTrialSessionId,
+          },
+          ...getBaseState(petitionsClerkUser),
+          trialSessions: [
+            {
+              judge: {
+                userId: judgeUser.userId,
+              },
+              trialSessionId: mockTrialSessionId,
+            },
+          ],
+        },
+      });
+
+      expect(result.userIsAssignedToSession).toBeFalsy();
+    });
+
+    it('should be true when the current user is a chambers user for the judge assigned to the trial session the case is scheduled for', () => {
       const mockTrialSessionId = applicationContext.getUniqueId();
 
       const result = runCompute(formattedCaseDetail, {
@@ -2648,53 +2672,7 @@ describe('formattedCaseDetail', () => {
       expect(result.userIsAssignedToSession).toBeTruthy();
     });
 
-    it('should set userIsAssignedToSession to true when the current user is the trial clerk assigned to the trial session the case is scheduled for', () => {
-      const mockTrialSessionId = applicationContext.getUniqueId();
-
-      const result = runCompute(formattedCaseDetail, {
-        state: {
-          caseDetail: {
-            ...caseDetail,
-            trialSessionId: mockTrialSessionId,
-          },
-          ...getBaseState(trialClerkUser),
-          trialSessions: [
-            {
-              trialClerk: {
-                userId: trialClerkUser.userId,
-              },
-              trialSessionId: mockTrialSessionId,
-            },
-          ],
-        },
-      });
-
-      expect(result.userIsAssignedToSession).toBeTruthy();
-    });
-
-    it('should set userIsAssignedToSession to false when the current user is a trial clerk and is not assigned to the trial session the case is scheduled for', () => {
-      const mockTrialSessionId = applicationContext.getUniqueId();
-
-      const result = runCompute(formattedCaseDetail, {
-        state: {
-          caseDetail: {
-            ...caseDetail,
-            trialSessionId: mockTrialSessionId,
-          },
-          ...getBaseState(trialClerkUser),
-          trialSessions: [
-            {
-              trialClerk: {},
-              trialSessionId: mockTrialSessionId,
-            },
-          ],
-        },
-      });
-
-      expect(result.userIsAssignedToSession).toBeFalsy();
-    });
-
-    it('should set userIsAssignedToSession to false when the current user is a chambers user for a different judge than the one assigned to the case', () => {
+    it('should be false when the current user is a chambers user for a different judge than the one assigned to the case', () => {
       const mockTrialSessionId = applicationContext.getUniqueId();
 
       const result = runCompute(formattedCaseDetail, {
@@ -2722,7 +2700,7 @@ describe('formattedCaseDetail', () => {
       expect(result.userIsAssignedToSession).toBeFalsy();
     });
 
-    it("should set userIsAssignedToSession to false when the case's trial session judge is not the currently logged in user", () => {
+    it('should be true when the current user is the trial clerk assigned to the trial session the case is scheduled for', () => {
       const mockTrialSessionId = applicationContext.getUniqueId();
 
       const result = runCompute(formattedCaseDetail, {
@@ -2731,12 +2709,34 @@ describe('formattedCaseDetail', () => {
             ...caseDetail,
             trialSessionId: mockTrialSessionId,
           },
-          ...getBaseState(petitionsClerkUser),
+          ...getBaseState(trialClerkUser),
           trialSessions: [
             {
-              judge: {
-                userId: judgeUser.userId,
+              trialClerk: {
+                userId: trialClerkUser.userId,
               },
+              trialSessionId: mockTrialSessionId,
+            },
+          ],
+        },
+      });
+
+      expect(result.userIsAssignedToSession).toBeTruthy();
+    });
+
+    it('should be false when the current user is a trial clerk and is not assigned to the trial session the case is scheduled for', () => {
+      const mockTrialSessionId = applicationContext.getUniqueId();
+
+      const result = runCompute(formattedCaseDetail, {
+        state: {
+          caseDetail: {
+            ...caseDetail,
+            trialSessionId: mockTrialSessionId,
+          },
+          ...getBaseState(trialClerkUser),
+          trialSessions: [
+            {
+              trialClerk: {},
               trialSessionId: mockTrialSessionId,
             },
           ],

--- a/web-client/src/presenter/computeds/formattedCaseDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.test.js
@@ -15,6 +15,7 @@ describe('formattedCaseDetail', () => {
   let globalUser;
   const {
     DOCUMENT_RELATIONSHIPS,
+    JUDGES_CHAMBERS,
     OBJECTIONS_OPTIONS_MAP,
     STATUS_TYPES,
     USER_ROLES,
@@ -59,19 +60,29 @@ describe('formattedCaseDetail', () => {
 
   const petitionsClerkUser = {
     role: USER_ROLES.petitionsClerk,
-    userId: '123',
+    userId: '111',
   };
   const docketClerkUser = {
     role: USER_ROLES.docketClerk,
-    userId: '234',
+    userId: '222',
   };
   const petitionerUser = {
     role: USER_ROLES.petitioner,
-    userId: '456',
+    userId: '333',
   };
   const judgeUser = {
     role: USER_ROLES.judge,
-    userId: '789',
+    userId: '444',
+  };
+  const chambersUser = {
+    role: USER_ROLES.chambers,
+    section: JUDGES_CHAMBERS.ARMENS_CHAMBERS_SECTION.section,
+    userId: '555',
+  };
+  const trialClerkUser = {
+    role: USER_ROLES.chambers,
+    section: JUDGES_CHAMBERS.ARMENS_CHAMBERS_SECTION.section,
+    userId: '777',
   };
 
   const simpleDocketEntries = [
@@ -2606,6 +2617,108 @@ describe('formattedCaseDetail', () => {
       });
 
       expect(result.userIsAssignedToSession).toBeTruthy();
+    });
+
+    it('should set userIsAssignedToSession to true when the current user is a chambers user for the judge assigned to the trial session the case is scheduled for', () => {
+      const mockTrialSessionId = applicationContext.getUniqueId();
+
+      const result = runCompute(formattedCaseDetail, {
+        state: {
+          caseDetail: {
+            ...caseDetail,
+            trialSessionId: mockTrialSessionId,
+          },
+          judgeUser: {
+            section: JUDGES_CHAMBERS.ARMENS_CHAMBERS_SECTION.section,
+            userId: judgeUser.userId,
+          },
+          ...getBaseState(chambersUser),
+          trialSessions: [
+            {
+              judge: {
+                userId: judgeUser.userId,
+              },
+              trialSessionId: mockTrialSessionId,
+            },
+          ],
+        },
+      });
+
+      expect(result.userIsAssignedToSession).toBeTruthy();
+    });
+
+    it('should set userIsAssignedToSession to true when the current user is the trial clerk assigned to the trial session the case is scheduled for', () => {
+      const mockTrialSessionId = applicationContext.getUniqueId();
+
+      const result = runCompute(formattedCaseDetail, {
+        state: {
+          caseDetail: {
+            ...caseDetail,
+            trialSessionId: mockTrialSessionId,
+          },
+          ...getBaseState(trialClerkUser),
+          trialSessions: [
+            {
+              trialClerk: {
+                userId: trialClerkUser.userId,
+              },
+              trialSessionId: mockTrialSessionId,
+            },
+          ],
+        },
+      });
+
+      expect(result.userIsAssignedToSession).toBeTruthy();
+    });
+
+    it('should set userIsAssignedToSession to false when the current user is a trial clerk and is not assigned to the trial session the case is scheduled for', () => {
+      const mockTrialSessionId = applicationContext.getUniqueId();
+
+      const result = runCompute(formattedCaseDetail, {
+        state: {
+          caseDetail: {
+            ...caseDetail,
+            trialSessionId: mockTrialSessionId,
+          },
+          ...getBaseState(trialClerkUser),
+          trialSessions: [
+            {
+              trialClerk: {},
+              trialSessionId: mockTrialSessionId,
+            },
+          ],
+        },
+      });
+
+      expect(result.userIsAssignedToSession).toBeFalsy();
+    });
+
+    it('should set userIsAssignedToSession to false when the current user is a chambers user for a different judge than the one assigned to the case', () => {
+      const mockTrialSessionId = applicationContext.getUniqueId();
+
+      const result = runCompute(formattedCaseDetail, {
+        state: {
+          caseDetail: {
+            ...caseDetail,
+            trialSessionId: mockTrialSessionId,
+          },
+          judgeUser: {
+            section: JUDGES_CHAMBERS.BUCHS_CHAMBERS_SECTION.section,
+            userId: judgeUser.userId,
+          },
+          ...getBaseState(chambersUser),
+          trialSessions: [
+            {
+              judge: {
+                userId: judgeUser.userId,
+              },
+              trialSessionId: mockTrialSessionId,
+            },
+          ],
+        },
+      });
+
+      expect(result.userIsAssignedToSession).toBeFalsy();
     });
 
     it("should set userIsAssignedToSession to false when the case's trial session judge is not the currently logged in user", () => {

--- a/web-client/src/presenter/computeds/formattedCaseDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.test.js
@@ -18,6 +18,7 @@ describe('formattedCaseDetail', () => {
     JUDGES_CHAMBERS,
     OBJECTIONS_OPTIONS_MAP,
     STATUS_TYPES,
+    TRIAL_CLERKS_SECTION,
     USER_ROLES,
   } = applicationContext.getConstants();
 
@@ -80,8 +81,8 @@ describe('formattedCaseDetail', () => {
     userId: '555',
   };
   const trialClerkUser = {
-    role: USER_ROLES.chambers,
-    section: JUDGES_CHAMBERS.ARMENS_CHAMBERS_SECTION.section,
+    role: USER_ROLES.trialClerk,
+    section: TRIAL_CLERKS_SECTION,
     userId: '777',
   };
 

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -7,6 +7,7 @@ import { getCaseAssociationAction } from '../actions/getCaseAssociationAction';
 import { getCaseDeadlinesForCaseAction } from '../actions/CaseDeadline/getCaseDeadlinesForCaseAction';
 import { getConsolidatedCasesByCaseAction } from '../actions/caseConsolidation/getConsolidatedCasesByCaseAction';
 import { getConstants } from '../../getConstants';
+import { getJudgeForCurrentUserAction } from '../actions/getJudgeForCurrentUserAction';
 import { getJudgesCaseNoteForCaseAction } from '../actions/TrialSession/getJudgesCaseNoteForCaseAction';
 import { getMessagesForCaseAction } from '../actions/CaseDetail/getMessagesForCaseAction';
 import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
@@ -22,6 +23,7 @@ import { setDefaultCorrespondenceDocumentIdAction } from '../actions/setDefaultC
 import { setDefaultDocketRecordSortAction } from '../actions/DocketRecord/setDefaultDocketRecordSortAction';
 import { setDocketEntryIdAction } from '../actions/setDocketEntryIdAction';
 import { setIsPrimaryTabAction } from '../actions/setIsPrimaryTabAction';
+import { setJudgeUserAction } from '../actions/setJudgeUserAction';
 import { setJudgesCaseNoteOnCaseDetailAction } from '../actions/TrialSession/setJudgesCaseNoteOnCaseDetailAction';
 import { setTrialSessionJudgeAction } from '../actions/setTrialSessionJudgeAction';
 import { setTrialSessionsAction } from '../actions/TrialSession/setTrialSessionsAction';
@@ -35,6 +37,8 @@ const gotoCaseDetailInternal = [
   getTrialSessionsAction,
   setTrialSessionsAction,
   setTrialSessionJudgeAction,
+  getJudgeForCurrentUserAction,
+  setJudgeUserAction,
   setDefaultCorrespondenceDocumentIdAction,
   setDocketEntryIdAction,
   showModalFromQueryAction,
@@ -79,6 +83,7 @@ export const gotoCaseDetailSequence = [
         USER_ROLES.docketClerk,
         USER_ROLES.petitionsClerk,
         USER_ROLES.trialClerk,
+        USER_ROLES.chambers,
       ],
       [parallel([gotoCaseDetailInternal, fetchUserNotificationsSequence])],
     ),

--- a/web-client/src/views/CaseDetail/CaseInformationInternal.jsx
+++ b/web-client/src/views/CaseDetail/CaseInformationInternal.jsx
@@ -307,7 +307,13 @@ const TrialInformation = ({
           <div className="grid-col-4">
             <p className="label">Place of trial</p>
             <p>
-              <a href={`/trial-session-detail/${caseDetail.trialSessionId}`}>
+              <a
+                href={
+                  caseDetail.userIsAssignedToSession
+                    ? `/trial-session-working-copy/${caseDetail.trialSessionId}`
+                    : `/trial-session-detail/${caseDetail.trialSessionId}`
+                }
+              >
                 {caseDetail.formattedTrialCity}
               </a>
             </p>


### PR DESCRIPTION
Associated trial clerks and chambers users are now routed to trial session working copy instead of trial session detail when they click on the `Place of trial` link from Case Detail > Case Information tab.