### PR TITLE
6675 tab displaying wrong doc

### DIFF
--- a/web-client/src/presenter/actions/clearViewerDocumentToDisplayAction.js
+++ b/web-client/src/presenter/actions/clearViewerDocumentToDisplayAction.js
@@ -1,0 +1,15 @@
+import { state } from 'cerebral';
+
+/**
+ * clears the viewerDocumentToDisplay from state
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.props the cerebral props object
+ * @param {object} providers.store the cerebral store object
+ */
+export const clearViewerDocumentToDisplayAction = async ({ props, store }) => {
+  if (props.tabName === 'documentView') {
+    store.unset(state.viewerDocumentToDisplay);
+    store.unset(state.iframeSrc);
+  }
+};

--- a/web-client/src/presenter/actions/clearViewerDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/clearViewerDocumentToDisplayAction.test.js
@@ -1,0 +1,36 @@
+import { clearViewerDocumentToDisplayAction } from './clearViewerDocumentToDisplayAction';
+import { presenter } from '../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('clearViewerDocumentToDisplayAction', () => {
+  it('should clear the viewerDocumentToDisplay when props.tabName is documentViewer', async () => {
+    const result = await runAction(clearViewerDocumentToDisplayAction, {
+      props: {
+        tabName: 'documentView',
+      },
+      state: {
+        iframeSrc: 'http://example.com',
+        viewerDocumentToDisplay: 'something',
+      },
+    });
+    expect(result.state.iframeSrc).toBeUndefined();
+    expect(result.state.viewerDocumentToDisplay).toBeUndefined();
+  });
+
+  it('should NOT clear the viewerDocumentToDisplay when props.tabName is NOT documentViewer', async () => {
+    const result = await runAction(clearViewerDocumentToDisplayAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        tabName: 'docketRecord',
+      },
+      state: {
+        iframeSrc: 'http://example.com',
+        viewerDocumentToDisplay: 'something',
+      },
+    });
+    expect(result.state.iframeSrc).toEqual('http://example.com');
+    expect(result.state.viewerDocumentToDisplay).toEqual('something');
+  });
+});

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -42,6 +42,7 @@ import { clearModalSequence } from './sequences/clearModalSequence';
 import { clearOpenClosedCasesCurrentPageSequence } from './sequences/clearOpenClosedCasesCurrentPageSequence';
 import { clearPdfPreviewUrlSequence } from './sequences/clearPdfPreviewUrlSequence';
 import { clearPreferredTrialCitySequence } from './sequences/clearPreferredTrialCitySequence';
+import { clearViewerDocumentToDisplaySequence } from './sequences/clearViewerDocumentToDisplaySequence';
 import { closeModalAndNavigateBackSequence } from './sequences/closeModalAndNavigateBackSequence';
 import { closeModalAndNavigateSequence } from './sequences/closeModalAndNavigateSequence';
 import { closeModalAndReturnToCaseDetailDraftDocumentsSequence } from './sequences/closeModalAndReturnToCaseDetailDraftDocumentsSequence';
@@ -481,6 +482,7 @@ export const presenter = {
     clearOpenClosedCasesCurrentPageSequence,
     clearPdfPreviewUrlSequence,
     clearPreferredTrialCitySequence,
+    clearViewerDocumentToDisplaySequence,
     closeModalAndNavigateBackSequence,
     closeModalAndNavigateSequence,
     closeModalAndReturnToCaseDetailDraftDocumentsSequence,

--- a/web-client/src/presenter/sequences/clearViewerDocumentToDisplaySequence.js
+++ b/web-client/src/presenter/sequences/clearViewerDocumentToDisplaySequence.js
@@ -1,0 +1,5 @@
+import { clearViewerDocumentToDisplayAction } from '../actions/clearViewerDocumentToDisplayAction';
+
+export const clearViewerDocumentToDisplaySequence = [
+  clearViewerDocumentToDisplayAction,
+];

--- a/web-client/src/views/CaseDetail/CaseDetailInternal.jsx
+++ b/web-client/src/views/CaseDetail/CaseDetailInternal.jsx
@@ -22,18 +22,21 @@ import { Statistics } from './Statistics';
 import { SuccessNotification } from '../SuccessNotification';
 import { Tab, Tabs } from '../../ustc-ui/Tabs/Tabs';
 import { connect } from '@cerebral/react';
-import { state } from 'cerebral';
+import { sequences, state } from 'cerebral';
 import React from 'react';
 
 export const CaseDetailInternal = connect(
   {
     caseDetailInternalTabs:
       state.currentViewMetadata.caseDetail.caseDetailInternalTabs,
+    clearViewerDocumentToDisplaySequence:
+      sequences.clearViewerDocumentToDisplaySequence,
     showEditPetition: state.currentViewMetadata.caseDetail.showEditPetition,
     showModal: state.modal.showModal,
   },
   function CaseDetailInternal({
     caseDetailInternalTabs,
+    clearViewerDocumentToDisplaySequence,
     showEditPetition,
     showModal,
   }) {
@@ -53,6 +56,9 @@ export const CaseDetailInternal = connect(
             <Tabs
               bind="currentViewMetadata.caseDetail.docketRecordTab"
               className="classic-horizontal-header3 tab-border"
+              onSelect={tabName =>
+                clearViewerDocumentToDisplaySequence({ tabName })
+              }
             >
               <Tab
                 id="tab-docket-sub-record"


### PR DESCRIPTION
Fixing a bug where viewing a document in the viewer causes the ID to persist when clicking document view on another case.