### PR TITLE
6702 bug fix - no error when consolidating 2 cases with different preferred trial cities.

### DIFF
--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -1563,7 +1563,7 @@ Case.prototype.getConsolidationStatus = function ({ caseEntity }) {
     reason.push('Case procedure is not the same');
   }
 
-  if (this.trialLocation !== caseEntity.trialLocation) {
+  if (this.preferredTrialCity !== caseEntity.preferredTrialCity) {
     canConsolidate = false;
     reason.push('Place of trial is not the same');
   }

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -3172,8 +3172,8 @@ describe('Case entity', () => {
         expect(result.reason).toEqual(['Case procedure is not the same']);
       });
 
-      it('should fail when case trial locations are not the same', () => {
-        pendingCaseEntity.trialLocation = 'Flavortown, AR';
+      it('should fail when case requested place of trials are not the same', () => {
+        pendingCaseEntity.preferredTrialCity = 'Flavortown, AR';
 
         const result = leadCaseEntity.getConsolidationStatus({
           caseEntity: pendingCaseEntity,
@@ -3227,7 +3227,7 @@ describe('Case entity', () => {
 
       it('should return all reasons for the failure if the case status is eligible', () => {
         pendingCaseEntity.procedureType = 'small';
-        pendingCaseEntity.trialLocation = 'Flavortown, AR';
+        pendingCaseEntity.preferredTrialCity = 'Flavortown, AR';
         pendingCaseEntity.associatedJudge = 'Some judge';
 
         const result = leadCaseEntity.getConsolidationStatus({

--- a/web-client/integration-tests/docketClerkConsolidatesCases.test.js
+++ b/web-client/integration-tests/docketClerkConsolidatesCases.test.js
@@ -1,5 +1,6 @@
 import { loginAs, setupTest, uploadPetition } from './helpers';
 // docketclerk
+import { docketClerkConsolidatesCaseThatCannotBeConsolidated } from './journey/docketClerkConsolidatesCaseThatCannotBeConsolidated';
 import { docketClerkConsolidatesCases } from './journey/docketClerkConsolidatesCases';
 import { docketClerkOpensCaseConsolidateModal } from './journey/docketClerkOpensCaseConsolidateModal';
 import { docketClerkSearchesForCaseToConsolidateWith } from './journey/docketClerkSearchesForCaseToConsolidateWith';
@@ -36,7 +37,21 @@ describe('Case Consolidation Journey', () => {
 
   loginAs(test, 'petitioner@example.com');
 
+  it('login as a petitioner and create a case that cannot be consolidated with the lead case', async () => {
+    //not passing in overrides to preferredTrialCity to ensure case cannot be consolidated
+    const caseDetail = await uploadPetition(test);
+    expect(caseDetail.docketNumber).toBeDefined();
+    test.docketNumberDifferentPlaceOfTrial = caseDetail.docketNumber;
+  });
+
+  loginAs(test, 'docketclerk@example.com');
+  docketClerkUpdatesCaseStatusToReadyForTrial(test);
+  docketClerkOpensCaseConsolidateModal(test);
+  docketClerkSearchesForCaseToConsolidateWith(test);
+  docketClerkConsolidatesCaseThatCannotBeConsolidated(test);
+
   it('login as a petitioner and create the case to consolidate with', async () => {
+    test.docketNumberDifferentPlaceOfTrial = null;
     const caseDetail = await uploadPetition(test, overrides);
     expect(caseDetail.docketNumber).toBeDefined();
     test.docketNumber = caseDetail.docketNumber;

--- a/web-client/integration-tests/journey/docketClerkConsolidatesCaseThatCannotBeConsolidated.js
+++ b/web-client/integration-tests/journey/docketClerkConsolidatesCaseThatCannotBeConsolidated.js
@@ -1,0 +1,12 @@
+export const docketClerkConsolidatesCaseThatCannotBeConsolidated = test => {
+  return it('Docket clerk consolidates case that cannot be consolidated', async () => {
+    test.setState('modal.confirmSelection', true);
+    await test.runSequence('submitAddConsolidatedCaseSequence');
+
+    expect(test.getState('modal.showModal')).toBe('AddConsolidatedCaseModal');
+    expect(test.getState('modal.error')).toEqual([
+      'Place of trial is not the same',
+    ]);
+    expect(test.getState('caseDetail.consolidatedCases')).toBeUndefined();
+  });
+};

--- a/web-client/integration-tests/journey/docketClerkConsolidatesCases.js
+++ b/web-client/integration-tests/journey/docketClerkConsolidatesCases.js
@@ -5,5 +5,6 @@ export const docketClerkConsolidatesCases = test => {
 
     expect(test.getState('caseDetail')).toHaveProperty('consolidatedCases');
     expect(test.getState('caseDetail.consolidatedCases').length).toEqual(2);
+    expect(test.getState('modal.showModal')).toBeUndefined();
   });
 };

--- a/web-client/integration-tests/journey/docketClerkUpdatesCaseStatusToReadyForTrial.js
+++ b/web-client/integration-tests/journey/docketClerkUpdatesCaseStatusToReadyForTrial.js
@@ -8,7 +8,7 @@ export const docketClerkUpdatesCaseStatusToReadyForTrial = test => {
     test.setState('caseDetail', {});
 
     await test.runSequence('gotoCaseDetailSequence', {
-      docketNumber: test.docketNumber,
+      docketNumber: test.docketNumberDifferentPlaceOfTrial || test.docketNumber,
     });
 
     const currentStatus = test.getState('caseDetail.status');


### PR DESCRIPTION
- Modal now correctly displays error when trying to consolidate 2 different cases with the same trial city. After discussing with Kristen, it was found that we were incorrectly checking for the 2 cases' `trialLocation` to be the same when it should actually be checking for the same `preferredTrialCity` for consolidation

![image](https://user-images.githubusercontent.com/20514925/95772968-71cd0a00-0c72-11eb-8dd5-72d07ae5d919.png)

![image](https://user-images.githubusercontent.com/20514925/95772993-7ee9f900-0c72-11eb-8a3e-73132d9284c4.png)
