### PR TITLE
BUG - 6656 - Case Entity: Ensure petition paid and waived dates are validated

### DIFF
--- a/docs/entities/Case.md
+++ b/docs/entities/Case.md
@@ -70728,9 +70728,17 @@
                 override: true
               - "Paid"
           then: 
-            type: "any"
+            type: "date"
             flags: 
+              format: 
+                - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+                - "YYYY-MM-DD"
               presence: "required"
+            rules: 
+              - 
+                name: "max"
+                args: 
+                  date: "now"
           otherwise: 
             type: "any"
             flags: 
@@ -70796,9 +70804,17 @@
                 override: true
               - "Waived"
           then: 
-            type: "any"
+            type: "date"
             flags: 
+              format: 
+                - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+                - "YYYY-MM-DD"
               presence: "required"
+            rules: 
+              - 
+                name: "max"
+                args: 
+                  date: "now"
           otherwise: 
             type: "any"
             flags: 

--- a/docs/entities/CaseInternal.md
+++ b/docs/entities/CaseInternal.md
@@ -3963,9 +3963,17 @@
                 override: true
               - "Waived"
           then: 
-            type: "any"
+            type: "date"
             flags: 
+              format: 
+                - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+                - "YYYY-MM-DD"
               presence: "required"
+            rules: 
+              - 
+                name: "max"
+                args: 
+                  date: "now"
           otherwise: 
             type: "any"
             flags: 

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -561,7 +561,7 @@ Case.VALIDATION_RULES = {
     {
       is: PAYMENT_STATUS.PAID,
       otherwise: joi.optional().allow(null),
-      then: joi.required(),
+      then: JoiValidationConstants.ISO_DATE.max('now').required(),
     },
   ).description('When the petitioner paid the case fee.'),
   petitionPaymentMethod: JoiValidationConstants.STRING.max(50)
@@ -581,7 +581,7 @@ Case.VALIDATION_RULES = {
     {
       is: PAYMENT_STATUS.WAIVED,
       otherwise: joi.allow(null).optional(),
-      then: joi.required(),
+      then: JoiValidationConstants.ISO_DATE.max('now').required(),
     },
   ).description('When the case fee was waived.'),
   preferredTrialCity: joi

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -1005,6 +1005,41 @@ describe('Case entity', () => {
         });
       });
     });
+
+    it('fails validation if a petition fee payment date is in the future', () => {
+      const myCase = new Case(
+        {
+          ...MOCK_CASE,
+          petitionPaymentDate: '2050-10-01T21:40:46.415Z',
+          petitionPaymentMethod: 'Magic Beans',
+          petitionPaymentStatus: PAYMENT_STATUS.PAID,
+        },
+        {
+          applicationContext,
+        },
+      );
+
+      expect(myCase.getFormattedValidationErrors()).toMatchObject({
+        petitionPaymentDate: expect.anything(),
+      });
+    });
+
+    it('fails validation if a petition fee waived date is in the future', () => {
+      const myCase = new Case(
+        {
+          ...MOCK_CASE,
+          petitionPaymentStatus: PAYMENT_STATUS.WAIVED,
+          petitionPaymentWaivedDate: '2050-10-01T21:40:46.415Z',
+        },
+        {
+          applicationContext,
+        },
+      );
+
+      expect(myCase.getFormattedValidationErrors()).toMatchObject({
+        petitionPaymentWaivedDate: expect.anything(),
+      });
+    });
   });
 
   describe('validate', () => {


### PR DESCRIPTION
Fixes a bug where the dates we not validated before submitting update to petition details.