### PR TITLE
Bug 6715: don't show Sign Stip Decision button when PSDE is not served

### DIFF
--- a/web-client/src/presenter/computeds/documentViewerHelper.js
+++ b/web-client/src/presenter/computeds/documentViewerHelper.js
@@ -65,6 +65,7 @@ export const documentViewerHelper = (get, applicationContext) => {
   const showSignStipulatedDecisionButton =
     formattedDocumentToDisplay.eventCode ===
       PROPOSED_STIPULATED_DECISION_EVENT_CODE &&
+    formattedDocumentToDisplay.servedAt &&
     !formattedCaseDetail.docketEntries.find(
       d => d.eventCode === STIPULATED_DECISION_EVENT_CODE && !d.archived,
     );

--- a/web-client/src/presenter/computeds/documentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/documentViewerHelper.test.js
@@ -601,7 +601,33 @@ describe('documentViewerHelper', () => {
   });
 
   describe('showSignStipulatedDecisionButton', () => {
-    it('should be true if the eventCode is PSDE and the SDEC eventCode is not in the documents', () => {
+    it('should be true if the eventCode is PSDE, the PSDE is served, and the SDEC eventCode is not in the documents', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            correspondence: [],
+            docketEntries: [
+              {
+                docketEntryId: '123',
+                documentType: 'Proposed Stipulated Decision',
+                entityName: 'Document',
+                eventCode: 'PSDE',
+                isOnDocketRecord: true,
+                servedAt: '2019-08-25T05:00:00.000Z',
+              },
+            ],
+          },
+          permissions: {},
+          viewerDocumentToDisplay: {
+            docketEntryId: '123',
+          },
+        },
+      });
+
+      expect(result.showSignStipulatedDecisionButton).toEqual(true);
+    });
+
+    it('should be true if the eventCode is PSDE and the PSDE is not served', () => {
       const result = runCompute(documentViewerHelper, {
         state: {
           caseDetail: {
@@ -623,10 +649,10 @@ describe('documentViewerHelper', () => {
         },
       });
 
-      expect(result.showSignStipulatedDecisionButton).toEqual(true);
+      expect(result.showSignStipulatedDecisionButton).toBeUndefined();
     });
 
-    it('should be true if the document code is PSDE and an archived SDEC eventCode is in the documents', () => {
+    it('should be true if the document code is PSDE, the PSDE is served, and an archived SDEC eventCode is in the documents', () => {
       const result = runCompute(documentViewerHelper, {
         state: {
           caseDetail: {
@@ -638,6 +664,7 @@ describe('documentViewerHelper', () => {
                 entityName: 'Document',
                 eventCode: 'PSDE',
                 isOnDocketRecord: true,
+                servedAt: '2019-08-25T05:00:00.000Z',
               },
               {
                 archived: true,
@@ -658,7 +685,7 @@ describe('documentViewerHelper', () => {
       expect(result.showSignStipulatedDecisionButton).toEqual(true);
     });
 
-    it('should be false if the document code is PSDE and the SDEC eventCode is in the documents (and is not archived)', () => {
+    it('should be false if the document code is PSDE, the PSDE is served, and the SDEC eventCode is in the documents (and is not archived)', () => {
       const result = runCompute(documentViewerHelper, {
         state: {
           caseDetail: {
@@ -670,6 +697,7 @@ describe('documentViewerHelper', () => {
                 entityName: 'Document',
                 eventCode: 'PSDE',
                 isOnDocketRecord: true,
+                servedAt: '2019-08-25T05:00:00.000Z',
               },
               {
                 docketEntryId: '234',

--- a/web-client/src/presenter/computeds/documentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/documentViewerHelper.test.js
@@ -627,7 +627,7 @@ describe('documentViewerHelper', () => {
       expect(result.showSignStipulatedDecisionButton).toEqual(true);
     });
 
-    it('should be true if the eventCode is PSDE and the PSDE is not served', () => {
+    it('should be undefined if the eventCode is PSDE and the PSDE is not served', () => {
       const result = runCompute(documentViewerHelper, {
         state: {
           caseDetail: {

--- a/web-client/src/presenter/computeds/messageDocumentHelper.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.js
@@ -114,6 +114,7 @@ export const messageDocumentHelper = (get, applicationContext) => {
   const showSignStipulatedDecisionButton =
     isInternalUser &&
     caseDocument.eventCode === PROPOSED_STIPULATED_DECISION_EVENT_CODE &&
+    caseDocument.servedAt &&
     !docketEntries.find(
       d => d.eventCode === STIPULATED_DECISION_EVENT_CODE && !d.archived,
     );

--- a/web-client/src/presenter/computeds/messageDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.test.js
@@ -487,7 +487,7 @@ describe('messageDocumentHelper', () => {
             docketEntries: [
               {
                 ...baseDocketEntry,
-                signedAt: '123',
+                signedAt: '2020-06-25T20:49:28.192Z',
               },
             ],
           },
@@ -512,7 +512,7 @@ describe('messageDocumentHelper', () => {
               {
                 ...baseDocketEntry,
                 eventCode: 'SDEC',
-                signedAt: '123',
+                signedAt: '2020-06-25T20:49:28.192Z',
               },
             ],
           },
@@ -1010,7 +1010,31 @@ describe('messageDocumentHelper', () => {
   });
 
   describe('showSignStipulatedDecisionButton', () => {
-    it('should be true if the user is an internal user, the eventCode is PSDE, and the SDEC eventCode is not in the documents', () => {
+    it('should be true if the user is an internal user, the eventCode is PSDE, the PSDE is served, and the SDEC eventCode is not in the documents', () => {
+      const result = runCompute(messageDocumentHelper, {
+        state: {
+          ...getBaseState(petitionsClerkUser),
+          caseDetail: {
+            ...baseCaseDetail,
+            docketEntries: [
+              {
+                ...baseDocketEntry,
+                documentType: 'Proposed Stipulated Decision',
+                eventCode: 'PSDE',
+                servedAt: '2019-08-25T05:00:00.000Z',
+              },
+            ],
+          },
+          viewerDocumentToDisplay: {
+            documentId: '123',
+          },
+        },
+      });
+
+      expect(result.showSignStipulatedDecisionButton).toEqual(true);
+    });
+
+    it('should be false if the user is an internal user, the eventCode is PSDE, and the PSDE is not served', () => {
       const result = runCompute(messageDocumentHelper, {
         state: {
           ...getBaseState(petitionsClerkUser),
@@ -1030,10 +1054,10 @@ describe('messageDocumentHelper', () => {
         },
       });
 
-      expect(result.showSignStipulatedDecisionButton).toEqual(true);
+      expect(result.showSignStipulatedDecisionButton).toBeFalsy();
     });
 
-    it('should be true if the user is an internal user, the document code is PSDE, and an archived SDEC eventCode is in the documents', () => {
+    it('should be true if the user is an internal user, the document code is PSDE, the PSDE is served, and an archived SDEC eventCode is in the documents', () => {
       const result = runCompute(messageDocumentHelper, {
         state: {
           ...getBaseState(petitionsClerkUser),
@@ -1044,6 +1068,7 @@ describe('messageDocumentHelper', () => {
                 ...baseDocketEntry,
                 documentType: 'Proposed Stipulated Decision',
                 eventCode: 'PSDE',
+                servedAt: '2019-08-25T05:00:00.000Z',
               },
               {
                 ...baseDocketEntry,
@@ -1063,7 +1088,7 @@ describe('messageDocumentHelper', () => {
       expect(result.showSignStipulatedDecisionButton).toEqual(true);
     });
 
-    it('should be false if the user is an internal user, the document code is PSDE, and the SDEC eventCode is in the documents (and not archived)', () => {
+    it('should be false if the user is an internal user, the document code is PSDE, the PSDE is served, and the SDEC eventCode is in the documents (and not archived)', () => {
       const result = runCompute(messageDocumentHelper, {
         state: {
           ...getBaseState(petitionsClerkUser),
@@ -1074,6 +1099,7 @@ describe('messageDocumentHelper', () => {
                 ...baseDocketEntry,
                 documentType: 'Proposed Stipulated Decision',
                 eventCode: 'PSDE',
+                servedAt: '2019-08-25T05:00:00.000Z',
               },
               {
                 ...baseDocketEntry,
@@ -1092,7 +1118,7 @@ describe('messageDocumentHelper', () => {
       expect(result.showSignStipulatedDecisionButton).toEqual(false);
     });
 
-    it('should be false if the user is an external user, the eventCode is PSDE, and the SDEC event code is not in the documents', () => {
+    it('should be false if the user is an external user, the eventCode is PSDE, the PSDE is served, and the SDEC event code is not in the documents', () => {
       applicationContext.getCurrentUser.mockReturnValue(petitionerUser);
 
       const result = runCompute(messageDocumentHelper, {
@@ -1105,6 +1131,7 @@ describe('messageDocumentHelper', () => {
                 ...baseDocketEntry,
                 documentType: 'Proposed Stipulated Decision',
                 eventCode: 'PSDE',
+                servedAt: '2019-08-25T05:00:00.000Z',
               },
             ],
           },

--- a/web-client/src/views/Messages/MessageDocument.jsx
+++ b/web-client/src/views/Messages/MessageDocument.jsx
@@ -162,7 +162,7 @@ export const MessageDocument = connect(
                   iconColor="white"
                   onClick={() => {
                     openConfirmServePaperFiledDocumentSequence({
-                      documentId: viewerDocumentToDisplay.documentId,
+                      docketEntryId: viewerDocumentToDisplay.documentId,
                       redirectUrl: `/messages/${caseDetail.docketNumber}/message-detail/${parentMessageId}`,
                     });
                   }}


### PR DESCRIPTION
<img width="1424" alt="Screen Shot 2020-10-12 at 2 40 29 PM" src="https://user-images.githubusercontent.com/43251054/95793757-25e28b00-0c9b-11eb-8e6c-284a5df6c1de.png">
<img width="1412" alt="Screen Shot 2020-10-12 at 2 40 39 PM" src="https://user-images.githubusercontent.com/43251054/95793760-2713b800-0c9b-11eb-979e-b68329075e3d.png">
<img width="1413" alt="Screen Shot 2020-10-12 at 2 42 31 PM" src="https://user-images.githubusercontent.com/43251054/95793761-27ac4e80-0c9b-11eb-8ab0-b81c377d1a47.png">
<img width="1425" alt="Screen Shot 2020-10-12 at 2 45 34 PM" src="https://user-images.githubusercontent.com/43251054/95793764-28dd7b80-0c9b-11eb-87eb-102995c980c4.png">
