### PR TITLE
#6694 bugfix display additionalInfo without hyperlink on docket record when not added to coversheet

### DIFF
--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -167,7 +167,11 @@ const formatDocketEntry = (applicationContext, docketEntry) => {
   }
 
   if (formattedEntry.additionalInfo) {
-    formattedEntry.descriptionDisplay += ` ${formattedEntry.additionalInfo}`;
+    if (formattedEntry.addToCoversheet) {
+      formattedEntry.descriptionDisplay += ` ${formattedEntry.additionalInfo}`;
+    } else {
+      formattedEntry.additionalInfoDisplay = `${formattedEntry.additionalInfo}`;
+    }
   }
 
   if (formattedEntry.lodged) {

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.js
@@ -321,7 +321,33 @@ describe('formatCase', () => {
     expect(result.formattedPreferredTrialCity).toEqual('No location selected');
   });
 
-  it('should apply additional information', () => {
+  it('should append additional information to the hyperlinked descriptionDisplay when addToCoversheet is true', () => {
+    const result = formatCase(applicationContext, {
+      ...mockCaseDetail,
+      docketEntries: [
+        {
+          addToCoversheet: true,
+          additionalInfo: 'additional information',
+          createdAt: getDateISO(),
+          docketEntryId: 'd-1-2-3',
+          documentTitle: 'desc',
+          documentType: 'Petition',
+          index: '1',
+          isOnDocketRecord: true,
+          servedAt: getDateISO(),
+        },
+      ],
+    });
+
+    expect(result.formattedDocketEntries[0].descriptionDisplay).toEqual(
+      'desc additional information',
+    );
+    expect(
+      result.formattedDocketEntries[0].additionalInfoDisplay,
+    ).toBeUndefined();
+  });
+
+  it('should not append additional information to the hyperlinked descriptionDisplay when addToCoversheet is undefined', () => {
     const result = formatCase(applicationContext, {
       ...mockCaseDetail,
       docketEntries: [
@@ -338,8 +364,9 @@ describe('formatCase', () => {
       ],
     });
 
-    expect(result.formattedDocketEntries[0].descriptionDisplay).toEqual(
-      'desc additional information',
+    expect(result.formattedDocketEntries[0].descriptionDisplay).toEqual('desc');
+    expect(result.formattedDocketEntries[0].additionalInfoDisplay).toEqual(
+      'additional information',
     );
   });
 

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -194,7 +194,7 @@ export const formattedCaseDetail = (get, applicationContext) => {
 
     if (entry.documentTitle) {
       formattedResult.descriptionDisplay = entry.documentTitle;
-      if (entry.additionalInfo) {
+      if (entry.additionalInfo && entry.addToCoversheet) {
         formattedResult.descriptionDisplay += ` ${entry.additionalInfo}`;
       }
     }

--- a/web-client/src/presenter/computeds/formattedCaseDetail.test.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.test.js
@@ -176,6 +176,7 @@ describe('formattedCaseDetail', () => {
       supportingDocumentFreeText: 'Rachael',
     },
     {
+      addToCoversheet: true,
       additionalInfo: 'Additional Info',
       additionalInfo2: 'Additional Info2',
       category: 'Supporting Document',

--- a/web-client/src/views/DocketRecord/FilingsAndProceedings.jsx
+++ b/web-client/src/views/DocketRecord/FilingsAndProceedings.jsx
@@ -53,6 +53,7 @@ export const FilingsAndProceedings = connect(
               )}
               {entry.descriptionDisplay}
             </Button>
+            {!entry.addToCoversheet && entry.additionalInfoDisplay}
           </NonMobile>
           <Mobile>
             <Button
@@ -68,6 +69,7 @@ export const FilingsAndProceedings = connect(
             >
               {entry.descriptionDisplay}
             </Button>
+            {!entry.addToCoversheet && entry.additionalInfoDisplay}
           </Mobile>
         </>
       );
@@ -84,39 +86,46 @@ export const FilingsAndProceedings = connect(
                 <span aria-hidden="true">Processing</span>
               </span>
             )}
-            {entry.descriptionDisplay}
+            {entry.descriptionDisplay}{' '}
+            {!entry.addToCoversheet && entry.additionalInfoDisplay}
           </>
         )}
 
         {entry.showDocumentViewerLink && (
-          <Button
-            link
-            aria-label="View PDF"
-            className={classNames(
-              'text-left',
-              entry.isStricken && 'stricken-docket-record',
-              'view-pdf-link',
-            )}
-            onClick={() =>
-              changeTabAndSetViewerDocumentToDisplaySequence({
-                docketRecordTab: 'documentView',
-                viewerDocumentToDisplay: entry,
-              })
-            }
-          >
-            {entry.isPaper && (
-              <span className="filing-type-icon-mobile">
-                <FontAwesomeIcon icon={['fas', 'file-alt']} />
-              </span>
-            )}
-            {entry.descriptionDisplay}
-          </Button>
+          <>
+            <Button
+              link
+              aria-label="View PDF"
+              className={classNames(
+                'text-left',
+                entry.isStricken && 'stricken-docket-record',
+                'view-pdf-link',
+              )}
+              onClick={() =>
+                changeTabAndSetViewerDocumentToDisplaySequence({
+                  docketRecordTab: 'documentView',
+                  viewerDocumentToDisplay: entry,
+                })
+              }
+            >
+              {entry.isPaper && (
+                <span className="filing-type-icon-mobile">
+                  <FontAwesomeIcon icon={['fas', 'file-alt']} />
+                </span>
+              )}
+              {entry.descriptionDisplay}
+            </Button>
+            {!entry.addToCoversheet && entry.additionalInfoDisplay}
+          </>
         )}
 
         <span
           className={classNames(entry.isStricken && 'stricken-docket-record')}
         >
           {entry.showDocumentDescriptionWithoutLink && entry.descriptionDisplay}
+          {entry.showDocumentDescriptionWithoutLink &&
+            !entry.addToCoversheet &&
+            entry.additionalInfoDisplay}
         </span>
 
         <span> {entry.signatory}</span>


### PR DESCRIPTION
- Additional info for paper filings when added to coversheet are hyperlinked, not hyperlinked when not added to coversheet

![image](https://user-images.githubusercontent.com/20514925/95901411-24bb6780-0d48-11eb-9bdb-b33995b39348.png)
