### PR TITLE
6683: fix migration deploy

### DIFF
--- a/web-api/migration-terraform/bin/deploy-app.sh
+++ b/web-api/migration-terraform/bin/deploy-app.sh
@@ -21,6 +21,8 @@ else
   echo "dynamodb lock table already exists"
 fi
 
+npm run build:assets
+
 pushd ../main/lambdas
 npx parcel build migration-segments.js migration.js --target node --bundle-node-modules --no-minify --no-cache --no-source-maps
 popd


### PR DESCRIPTION
I had to include `applicationContext` for migration 3, and it requires `index.pug_`, which is created during `build:assets`.