### PR TITLE
#6810: allow data: protocol for frame-src in CSP

### DIFF
--- a/web-client/terraform/common/cloudfront-edge/header-security-lambda.js
+++ b/web-client/terraform/common/cloudfront-edge/header-security-lambda.js
@@ -48,7 +48,7 @@ exports.handler = (event, context, callback) => {
     `style-src 'self' 'unsafe-inline' ${dynamsoftUrl}`,
     `img-src ${applicationUrl} ${subdomainsUrl} data:`,
     `font-src ${applicationUrl} ${subdomainsUrl}`,
-    `frame-src ${s3Url} ${subdomainsUrl} blob:`,
+    `frame-src ${s3Url} ${subdomainsUrl} blob: data:`,
     "frame-ancestors 'none'",
   ];
   headers['content-security-policy'] = [


### PR DESCRIPTION
ustaxcourt/ef-cms#7385 

(Tested with my Samsung Galaxy S9 in developer mode, connected with USB cable to my Macbook, using chrome remote devices debugging tools.)

To test and develop locally against the CSP and my chrome android instance, I created a tiny express app with a content-security policy.  First, a tiny page with a PDF in an iframe which seems like it SHOULD have loaded (according to security policy), but did not:
![Screen Shot 2020-10-20 at 12 13 02 PM](https://user-images.githubusercontent.com/2445917/96621469-4380a780-12ce-11eb-9bef-5c71cddb50c8.png)

Then, the exact same iframe but with a content-security policy which also included the `data:` protocol:
![Screen Shot 2020-10-20 at 12 16 50 PM](https://user-images.githubusercontent.com/2445917/96621478-467b9800-12ce-11eb-80da-cf1e3dde4656.png)


EDIT:
index.html:
```

<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <title>U.S. Tax Court Electronic Filing and Case Management System</title>
  </head>
  <body>
    <p>Welcome to my document.</p>
    <iframe src="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf" 
      style="height: 200px; width: 200px"></iframe>
  </body>
</html>
```

express app:
```
const express = require('express');
const app = express();

const sources = {
  'frame-src': ['https://www.w3.org/', 'data:', 'blob:'],
};

const CSP = Object.keys(sources)
  .map(key => `${key} ${sources[key].join(' ')};`)
  .join(' ');

app.use(function (req, res, next) {
  res.setHeader('Content-Security-Policy', CSP);
  return next();
});

app.use(express.static(__dirname + '/'));

app.listen(process.env.PORT || 7777);
console.log('OK, listening.');

```

And a ServerFault thread that lead me to this solution:
https://serverfault.com/questions/945834/refused-to-frame-because-it-violates-the-following-content-security-policy-di