### PR TITLE
BUG #6745: Recent Messages (Judge's Dashboard) - docket number and received columns are swapped

### DIFF
--- a/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
+++ b/web-client/src/views/WorkQueue/RecentMessagesInbox.jsx
@@ -37,10 +37,10 @@ export const RecentMessagesInbox = connect(
             return (
               <tbody key={idx}>
                 <tr>
-                  <td>{item.createdAtFormatted}</td>
                   <td className="message-queue-row small">
                     {item.docketNumberWithSuffix}
                   </td>
+                  <td>{item.createdAtFormatted}</td>
                   <td className="message-unread-column">
                     {!item.isRead && (
                       <Icon


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20249233/96631192-dddeec00-12ca-11eb-8b67-54eacd2535bb.png)

After:
![image](https://user-images.githubusercontent.com/20249233/96631125-c43da480-12ca-11eb-836f-356cadd5f059.png)
