### PR TITLE
Ensure real user id gets returned from createUser

### DIFF
--- a/shared/src/business/useCases/users/createUserInteractor.js
+++ b/shared/src/business/useCases/users/createUserInteractor.js
@@ -47,12 +47,16 @@ exports.createUserInteractor = async ({ applicationContext, user }) => {
     );
   }
 
-  await applicationContext.getPersistenceGateway().createUser({
+  const {
+    userId,
+  } = await applicationContext.getPersistenceGateway().createUser({
     applicationContext,
     disableCognitoUser: user.role === ROLES.legacyJudge,
     password: user.password,
     user: userEntity.validate().toRawObject(),
   });
+
+  userEntity.userId = userId;
 
   return userEntity.validate().toRawObject();
 };

--- a/shared/src/business/useCases/users/createUserInteractor.test.js
+++ b/shared/src/business/useCases/users/createUserInteractor.test.js
@@ -12,12 +12,13 @@ describe('create user', () => {
     const mockUser = {
       name: 'Test PetitionsClerk',
       role: ROLES.petitionsClerk,
-      userId: 'petitionsclerk1@example.com',
+      userId: '615b7d39-8fae-4c2f-893c-3c829598bc71',
     };
+
     applicationContext.getCurrentUser.mockReturnValue({
       name: 'Admin',
       role: ROLES.admin,
-      userId: 'admin',
+      userId: 'ad3b7d39-8fae-4c2f-893c-3c829598bc71',
     });
     applicationContext
       .getPersistenceGateway()
@@ -27,7 +28,7 @@ describe('create user', () => {
       barNumber: '',
       name: 'Jesse Pinkman',
       role: ROLES.petitionsClerk,
-      userId: 'petitionsclerk1@example.com',
+      userId: '245b7d39-8fae-4c2f-893c-3c829598bc71',
     };
     const user = await createUserInteractor({
       applicationContext,
@@ -40,17 +41,17 @@ describe('create user', () => {
     const mockUser = {
       name: 'Test Petitioner',
       role: ROLES.petitioner,
-      userId: 'petitioner1@example.com',
+      userId: '245b7d39-8fae-4c2f-893c-3c829598bc71',
     };
     applicationContext.getCurrentUser.mockReturnValue({
       name: 'Admin',
       role: ROLES.petitioner,
-      userId: 'admin',
+      userId: 'ad2b7d39-8fae-4c2f-893c-3c829598bc71',
     });
     applicationContext
       .getPersistenceGateway()
       .createUser.mockReturnValue(mockUser);
-    const userToCreate = { userId: 'petitioner1@example.com' };
+    const userToCreate = { userId: '145b7d39-8fae-4c2f-893c-3c829598bc71' };
 
     await expect(
       createUserInteractor({
@@ -64,7 +65,7 @@ describe('create user', () => {
     applicationContext.getCurrentUser.mockReturnValue({
       name: 'Admin',
       role: ROLES.admin,
-      userId: 'admin',
+      userId: 'ad5b7d39-8fae-4c2f-893c-3c829598bc71',
     });
     applicationContext.getPersistenceGateway().createUser.mockReturnValue({
       barNumber: 'CS20001',
@@ -168,7 +169,7 @@ describe('create user', () => {
     const mockUser = {
       name: 'Test Legacy Judge',
       role: ROLES.legacyJudge,
-      userId: 'legacyJudge1@example.com',
+      userId: '845b7d39-8fae-4c2f-893c-3c829598bc71',
     };
     applicationContext.getCurrentUser.mockReturnValue({
       name: 'Admin',

--- a/shared/src/persistence/dynamo/users/createUser.js
+++ b/shared/src/persistence/dynamo/users/createUser.js
@@ -136,10 +136,13 @@ exports.createUser = async ({
   }
 
   if (disableCognitoUser) {
-    await applicationContext.getCognito().adminDisableUser({
-      UserPoolId: userPoolId,
-      Username: userId,
-    });
+    await applicationContext
+      .getCognito()
+      .adminDisableUser({
+        UserPoolId: userPoolId,
+        Username: userId,
+      })
+      .promise();
   }
 
   return await exports.createUserRecords({

--- a/shared/src/persistence/dynamo/users/createUser.test.js
+++ b/shared/src/persistence/dynamo/users/createUser.test.js
@@ -47,6 +47,10 @@ describe('createUser', () => {
       promise: async () => Promise.resolve(),
     });
 
+    applicationContext.getCognito().adminDisableUser.mockReturnValue({
+      promise: async () => Promise.resolve(),
+    });
+
     applicationContext.getDocumentClient().put.mockReturnValue({
       promise: () => Promise.resolve(null),
     });


### PR DESCRIPTION
We are currently generating a uuid on the user that is being created before calling the persistence method. The persistence method will generate its own id (or fetch an existing user id), and should return that.

Currently, we return that created user entity without updating the userId with the one returned from persistent. This ensures that ID makes it onto the user entity before it's returned in the interactor.