### PR TITLE
6654 - refactor so that processStreamRecordsLambda does not use genericHandler

### DIFF
--- a/web-api/src/streams/processStreamRecordsLambda.js
+++ b/web-api/src/streams/processStreamRecordsLambda.js
@@ -1,4 +1,4 @@
-const { genericHandler } = require('../genericHandler');
+const createApplicationContext = require('../applicationContext');
 
 /**
  * used for processing stream records from persistence
@@ -6,21 +6,12 @@ const { genericHandler } = require('../genericHandler');
  * @param {object} event the AWS event object
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
-exports.processStreamRecordsLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      const recordsToProcess = event.Records;
-
-      return await applicationContext
-        .getUseCases()
-        .processStreamRecordsInteractor({
-          applicationContext,
-          recordsToProcess,
-        });
-    },
-    {
-      logUser: false,
-      user: {},
-    },
-  );
+exports.processStreamRecordsLambda = async event => {
+  const applicationContext = createApplicationContext({});
+  applicationContext.logger.info('received a stream event of', event);
+  const recordsToProcess = event.Records;
+  return await applicationContext.getUseCases().processStreamRecordsInteractor({
+    applicationContext,
+    recordsToProcess,
+  });
+};

--- a/web-api/src/streams/processStreamRecordsLambda.test.js
+++ b/web-api/src/streams/processStreamRecordsLambda.test.js
@@ -6,7 +6,6 @@ describe('processStreamRecordsLambda', () => {
     try {
       await processStreamRecordsLambda({});
     } catch (err) {
-      console.log('error', err);
       error = err;
     }
     expect(error).toBeDefined();

--- a/web-api/src/streams/processStreamRecordsLambda.test.js
+++ b/web-api/src/streams/processStreamRecordsLambda.test.js
@@ -1,0 +1,14 @@
+const { processStreamRecordsLambda } = require('./processStreamRecordsLambda');
+
+describe('processStreamRecordsLambda', () => {
+  it('should throw an exception if the interactor throws an exception', async () => {
+    let error;
+    try {
+      await processStreamRecordsLambda({});
+    } catch (err) {
+      console.log('error', err);
+      error = err;
+    }
+    expect(error).toBeDefined();
+  });
+});


### PR DESCRIPTION
- the generic handler was swallowing up exceptions preventing the lambda from being retried during processing