### PR TITLE
6654 - adding a flag so we can turn off emails for performance testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,6 +523,9 @@ jobs:
           name: Setup Honeybadger Keys
           command: echo "export CIRCLE_HONEYBADGER_API_KEY='$(./get-honeybadger-keys.sh $CIRCLE_BRANCH)'" >> $BASH_ENV
       - run:
+          name: Setup Disable Emails
+          command: echo "export DISABLE_EMAILS='$(./get-disable-emails.sh $CIRCLE_BRANCH)'" >> $BASH_ENV
+      - run:
           name: 'Deploy - Web API - Terraform'
           command: |
             docker run \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,6 +541,7 @@ jobs:
              -e "IRS_SUPERUSER_EMAIL=${IRS_SUPERUSER_EMAIL}" \
              -e "MIGRATE_FLAG=${MIGRATE_FLAG}" \
              -e "ZONE_NAME=${ZONE_NAME}" \
+             -e "DISABLE_EMAILS=${DISABLE_EMAILS}" \
              --rm efcms /bin/sh -c "cd web-api/terraform/main && ../bin/deploy-app.sh ${ENV}"
       - run:
           name: 'Deploy - Web Client - Terraform'

--- a/get-disable-emails.sh
+++ b/get-disable-emails.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Returns the elasticsearch disable emails variable for each environment
+
+# Usage
+#   ./get-disable-emails.sh develop
+
+# Arguments
+#   - $1 - the branch to check
+
+[ -z "$1" ] && echo "The branch name to check must be provided as the \$1 argument." && exit 1
+
+BRANCH=$1
+
+if [[ $BRANCH == 'develop' ]] ; then
+  echo "${DISABLE_EMAILS_DEV}"
+elif [[ $BRANCH == 'experimental1' ]] ; then
+  echo "${DISABLE_EMAILS_EXP1}"
+elif [[ $BRANCH == 'experimental2' ]] ; then
+  echo "${DISABLE_EMAILS_EXP2}"
+elif [[ $BRANCH == 'experimental3' ]] ; then
+  echo "${DISABLE_EMAILS_EXP3}"
+elif [[ $BRANCH == 'irs' ]] ; then
+  echo "${DISABLE_EMAILS_IRS}"
+elif [[ $BRANCH == 'staging' ]] ; then
+  echo "${DISABLE_EMAILS_STG}"
+elif [[ $BRANCH == 'test' ]] ; then
+  echo "${DISABLE_EMAILS_TEST}"
+elif [[ $BRANCH == 'migration' ]] ; then
+  echo "${DISABLE_EMAILS_MIG}"
+elif [[ $BRANCH == 'master' ]] ; then
+  echo "${DISABLE_EMAILS_MASTER}"
+elif [[ $BRANCH == 'dawson' ]] ; then
+  echo "${DISABLE_EMAILS_DAWSON}"
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo "${DISABLE_EMAILS_PROD}"
+else
+  exit 1;
+fi

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1328,7 +1328,7 @@ module.exports = appContextUser => {
     },
     getDynamoClient,
     getEmailClient: () => {
-      if (process.env.CI) {
+      if (process.env.CI || process.env.DISABLE_EMAILS) {
         return {
           sendBulkTemplatedEmail: params => {
             return {

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -87,6 +87,7 @@ export TF_VAR_green_table_name=$GREEN_TABLE_NAME
 export TF_VAR_blue_elasticsearch_domain=$BLUE_ELASTICSEARCH_DOMAIN
 export TF_VAR_green_elasticsearch_domain=$GREEN_ELASTICSEARCH_DOMAIN
 export TF_VAR_destination_table=$DESTINATION_TABLE
+export TF_VAR_disable_emails=$DISABLE_EMAILS
 
 terraform init -backend=true -backend-config=bucket="${BUCKET}" -backend-config=key="${KEY}" -backend-config=dynamodb_table="${LOCK_TABLE}" -backend-config=region="${REGION}"
 terraform plan

--- a/web-api/terraform/main/main.tf
+++ b/web-api/terraform/main/main.tf
@@ -38,4 +38,5 @@ module "ef-cms_apis" {
   blue_elasticsearch_domain  = var.blue_elasticsearch_domain
   green_elasticsearch_domain = var.green_elasticsearch_domain
   destination_table          = var.destination_table
+  disable_emails             = var.disable_emails
 }

--- a/web-api/terraform/main/variables.tf
+++ b/web-api/terraform/main/variables.tf
@@ -65,3 +65,7 @@ variable "green_elasticsearch_domain" {
 variable "destination_table" {
   type = string
 }
+
+variable "disable_emails" {
+  type = bool
+}

--- a/web-api/terraform/template/locals.tf
+++ b/web-api/terraform/template/locals.tf
@@ -18,5 +18,6 @@ data "null_data_source" "locals" {
     CIRCLE_HONEYBADGER_API_KEY     = var.honeybadger_key
     IRS_SUPERUSER_EMAIL            = var.irs_superuser_email
     COGNITO_SUFFIX                 = var.cognito_suffix
+    DISABLE_EMAILS                 = var.disable_emails
   }
 }

--- a/web-api/terraform/template/variables.tf
+++ b/web-api/terraform/template/variables.tf
@@ -61,3 +61,7 @@ variable "green_elasticsearch_domain" {
 variable "destination_table" {
   type = string
 }
+
+variable "disable_emails" {
+  type = bool
+}


### PR DESCRIPTION
- when doing performance testing, we were sending out a ton of emails to fake email accounts, but some of those accounts were used by real people....  this allows us to disable all emails on our environments

<img width="1027" alt="Screen Shot 2020-10-23 at 1 12 16 PM" src="https://user-images.githubusercontent.com/1868782/97033449-6068e500-1531-11eb-9a61-789142dbebd6.png">
