### PR TITLE
6654 - docketEntries was stored on case metadata when it should not be

### DIFF
--- a/shared/src/persistence/dynamo/cases/updateCase.js
+++ b/shared/src/persistence/dynamo/cases/updateCase.js
@@ -361,7 +361,7 @@ exports.updateCase = async ({ applicationContext, caseToUpdate }) => {
         sk: `case|${caseToUpdate.docketNumber}`,
         ...setLeadCase,
         ...omit(caseToUpdate, [
-          'documents',
+          'docketEntries',
           'irsPractitioners',
           'privatePractitioners',
         ]),


### PR DESCRIPTION
we are storing all the docket entries on the case object in dynamo.  For the cases that have 800 docket entries, this means we are storing 800 individual docket-entry| records, plus an array of 800 entires attached to the case which is causing a lot of data to be stored.  We used to omit the documents, but I think this was missed after the docket-entry refactoring.