### PR TITLE
6833 - return accurate counts of case inventory report

### DIFF
--- a/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
+++ b/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
@@ -49,6 +49,7 @@ exports.getCaseInventoryReport = async ({
       },
       size,
       sort: [{ 'sortableDocketNumber.N.keyword': { order: 'asc' } }],
+      track_total_hits: true, // to allow the count on the case inventory report UI to be accurate
     },
     index: 'efcms-case',
   };

--- a/web-api/elasticsearch/elasticsearch-settings.js
+++ b/web-api/elasticsearch/elasticsearch-settings.js
@@ -48,6 +48,7 @@ module.exports = {
         },
       },
       'mapping.total_fields.limit': '1000',
+      max_result_window: 20000,
       number_of_replicas: 1,
       number_of_shards: 1,
     },

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1294,7 +1294,7 @@ module.exports = appContextUser => {
       }
     },
     getConstants: () => ({
-      CASE_INVENTORY_MAX_PAGE_SIZE: 5000,
+      CASE_INVENTORY_MAX_PAGE_SIZE: 20000, // the Chief Judge will have ~15k records, so setting to 20k to be safe
       OPEN_CASE_STATUSES: Object.values(CASE_STATUS_TYPES).filter(
         status => status !== CASE_STATUS_TYPES.closed,
       ),

--- a/web-client/src/presenter/computeds/caseInventoryReportHelper.js
+++ b/web-client/src/presenter/computeds/caseInventoryReportHelper.js
@@ -1,4 +1,5 @@
 import { state } from 'cerebral';
+import { without } from 'lodash';
 
 export const caseInventoryReportHelper = (get, applicationContext) => {
   const {
@@ -52,7 +53,7 @@ export const caseInventoryReportHelper = (get, applicationContext) => {
   }
 
   return {
-    caseStatuses: Object.values(STATUS_TYPES),
+    caseStatuses: without(Object.values(STATUS_TYPES), 'Closed'),
     formattedReportData,
     judges,
     nextPageSize,

--- a/web-client/src/presenter/computeds/caseInventoryReportHelper.test.js
+++ b/web-client/src/presenter/computeds/caseInventoryReportHelper.test.js
@@ -2,6 +2,7 @@ import { applicationContextForClient as applicationContext } from '../../../../s
 import { caseInventoryReportHelper as caseInventoryReportHelperComputed } from './caseInventoryReportHelper';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../withAppContext';
+import { without } from 'lodash';
 
 describe('caseInventoryReportHelper', () => {
   const {
@@ -29,14 +30,16 @@ describe('caseInventoryReportHelper', () => {
     userId: '5d66d122-8417-427b-9048-c1ba8ab1ea68',
   });
 
-  it('should return all case statuses', () => {
+  it('should return all case statuses except Closed', () => {
     const result = runCompute(caseInventoryReportHelper, {
       state: {
         screenMetadata: {},
       },
     });
 
-    expect(result.caseStatuses).toEqual(Object.values(STATUS_TYPES));
+    expect(result.caseStatuses).toEqual(
+      without(Object.values(STATUS_TYPES), 'Closed'),
+    );
   });
 
   it('should return all judges from state along with Chief Judge sorted alphabetically', () => {


### PR DESCRIPTION
- removing "Closed" as a status option
- adding the `track_total_hits` flag so that the count displayed in the UI isn't rounded down to 10000 for very large search queries
- bumping `CASE_INVENTORY_MAX_PAGE_SIZE` up to 20,000 since the Chief Judge might have around 15k cases that would need to be displayed (also so that the PDF has all the expected cases)

<img width="1620" alt="Screen Shot 2020-10-26 at 3 37 57 PM" src="https://user-images.githubusercontent.com/1868782/97223142-be056780-17a5-11eb-9a6a-805e1e29d9ba.png">
