### PR TITLE
6684 - filter closed cases

### DIFF
--- a/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
+++ b/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
@@ -45,6 +45,9 @@ exports.getCaseInventoryReport = async ({
             { match: { 'pk.S': 'case|' } },
             { match: { 'sk.S': 'case|' } },
           ],
+          must_not: {
+            match: { 'status.S': 'Closed' },
+          },
         },
       },
       size,


### PR DESCRIPTION
- the AC states we do not need to display closed cases on the inventory report, and since there are 900k closed cases, they really slow down the PDF generation...