### PR TITLE
4661 Notice of change of contact info does not need to be QC'd by Docket, unless there is paper service in the case

### DIFF
--- a/shared/src/business/useCases/users/generateChangeOfAddress.js
+++ b/shared/src/business/useCases/users/generateChangeOfAddress.js
@@ -152,9 +152,7 @@ exports.generateChangeOfAddress = async ({
           userId: user.userId,
         };
 
-        let isPractitioner = false;
         if (user.role === ROLES.privatePractitioner) {
-          isPractitioner = true;
           documentData.privatePractitioners = [
             {
               name,
@@ -162,7 +160,6 @@ exports.generateChangeOfAddress = async ({
             },
           ];
         } else if (user.role === ROLES.irsPractitioner) {
-          isPractitioner = true;
           documentData.partyIrsPractitioner = true;
         }
 
@@ -190,12 +187,10 @@ exports.generateChangeOfAddress = async ({
             userCase.contactSecondary.serviceIndicator ===
               SERVICE_INDICATOR_TYPES.SI_PAPER) ||
           user.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_PAPER;
-        const shouldCreateWorkItemForQC =
-          (isPractitioner && paperServiceRequested) || !isPractitioner;
 
         let workItem = null;
 
-        if (shouldCreateWorkItemForQC) {
+        if (paperServiceRequested) {
           workItem = new WorkItem(
             {
               assigneeId: null,

--- a/shared/src/business/useCases/users/generateChangeOfAddress.js
+++ b/shared/src/business/useCases/users/generateChangeOfAddress.js
@@ -6,12 +6,15 @@ const {
   createISODateString,
 } = require('../../utilities/DateHandler');
 const {
+  CASE_STATUS_TYPES,
+  SERVICE_INDICATOR_TYPES,
+} = require('../../entities/EntityConstants');
+const {
   DOCUMENT_PROCESSING_STATUS_OPTIONS,
   ROLES,
 } = require('../../entities/EntityConstants');
 const { addCoverToPdf } = require('../addCoversheetInteractor');
 const { Case } = require('../../entities/cases/Case');
-const { CASE_STATUS_TYPES } = require('../../entities/EntityConstants');
 const { clone } = require('lodash');
 const { DOCKET_SECTION } = require('../../entities/EntityConstants');
 const { DocketEntry } = require('../../entities/DocketEntry');
@@ -67,7 +70,6 @@ exports.generateChangeOfAddress = async ({
         privatePractitioner.contact = contactInfo;
         privatePractitioner.name = name;
       }
-
       const irsPractitioner = caseEntity.irsPractitioners.find(
         practitioner => practitioner.userId === user.userId,
       );
@@ -150,7 +152,9 @@ exports.generateChangeOfAddress = async ({
           userId: user.userId,
         };
 
+        let isPractitioner = false;
         if (user.role === ROLES.privatePractitioner) {
+          isPractitioner = true;
           documentData.privatePractitioners = [
             {
               name,
@@ -158,6 +162,7 @@ exports.generateChangeOfAddress = async ({
             },
           ];
         } else if (user.role === ROLES.irsPractitioner) {
+          isPractitioner = true;
           documentData.partyIrsPractitioner = true;
         }
 
@@ -177,28 +182,43 @@ exports.generateChangeOfAddress = async ({
           servedParties,
         });
 
-        const workItem = new WorkItem(
-          {
-            assigneeId: null,
-            assigneeName: null,
-            associatedJudge: caseEntity.associatedJudge,
-            caseIsInProgress: caseEntity.inProgress,
-            caseStatus: caseEntity.status,
-            caseTitle: Case.getCaseTitle(Case.getCaseCaption(caseEntity)),
-            docketEntry: {
-              ...changeOfAddressDocketEntry.toRawObject(),
-              createdAt: changeOfAddressDocketEntry.createdAt,
-            },
-            docketNumber: caseEntity.docketNumber,
-            docketNumberWithSuffix: caseEntity.docketNumberWithSuffix,
-            section: DOCKET_SECTION,
-            sentBy: user.name,
-            sentByUserId: user.userId,
-          },
-          { applicationContext },
-        );
+        const paperServiceRequested =
+          userCase.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_PAPER ||
+          userCase.contactPrimary.serviceIndicator ===
+            SERVICE_INDICATOR_TYPES.SI_PAPER ||
+          (userCase.contactSecondary &&
+            userCase.contactSecondary.serviceIndicator ===
+              SERVICE_INDICATOR_TYPES.SI_PAPER) ||
+          user.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_PAPER;
+        const shouldCreateWorkItemForQC =
+          (isPractitioner && paperServiceRequested) || !isPractitioner;
 
-        changeOfAddressDocketEntry.setWorkItem(workItem);
+        let workItem = null;
+
+        if (shouldCreateWorkItemForQC) {
+          workItem = new WorkItem(
+            {
+              assigneeId: null,
+              assigneeName: null,
+              associatedJudge: caseEntity.associatedJudge,
+              caseIsInProgress: caseEntity.inProgress,
+              caseStatus: caseEntity.status,
+              caseTitle: Case.getCaseTitle(Case.getCaseCaption(caseEntity)),
+              docketEntry: {
+                ...changeOfAddressDocketEntry.toRawObject(),
+                createdAt: changeOfAddressDocketEntry.createdAt,
+              },
+              docketNumber: caseEntity.docketNumber,
+              docketNumberWithSuffix: caseEntity.docketNumberWithSuffix,
+              section: DOCKET_SECTION,
+              sentBy: user.name,
+              sentByUserId: user.userId,
+            },
+            { applicationContext },
+          );
+
+          changeOfAddressDocketEntry.setWorkItem(workItem);
+        }
 
         const { pdfData: changeOfAddressPdfWithCover } = await addCoverToPdf({
           applicationContext,
@@ -221,12 +241,15 @@ exports.generateChangeOfAddress = async ({
             applicationContext,
             docketEntryId: changeOfAddressDocketEntry.docketEntryId,
           });
-        await applicationContext
-          .getPersistenceGateway()
-          .saveWorkItemForNonPaper({
-            applicationContext,
-            workItem: workItem.validate().toRawObject(),
-          });
+
+        if (workItem) {
+          await applicationContext
+            .getPersistenceGateway()
+            .saveWorkItemForNonPaper({
+              applicationContext,
+              workItem: workItem.validate().toRawObject(),
+            });
+        }
 
         caseEntity.updateDocketEntry(changeOfAddressDocketEntry);
         docketEntryAdded = true;

--- a/shared/src/business/useCases/users/generateChangeOfAddress.test.js
+++ b/shared/src/business/useCases/users/generateChangeOfAddress.test.js
@@ -379,4 +379,335 @@ describe('generateChangeOfAddress', () => {
       expect.objectContaining({ docketNumber: MOCK_CASE.docketNumber }),
     ]);
   });
+
+  it("should create a work item for an associated practitioner's notice of change of address when paper service is requested on the case", async () => {
+    const mockPaperServiceCase = {
+      ...mockCaseWithPrivatePractitioner,
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+    };
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue(mockPaperServiceCase);
+
+    const cases = await generateChangeOfAddress({
+      applicationContext,
+      contactInfo: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      user: {
+        barNumber: 'PT5432',
+        contact: {
+          address1: '234 Main St!',
+          address2: 'Apartment 4',
+          address3: 'Under the stairs',
+          city: 'Chicago',
+          countryType: COUNTRY_TYPES.DOMESTIC,
+          phone: '+1 (555) 555-5555',
+          postalCode: '61234',
+          state: 'IL',
+        },
+        email: 'privatePractitioner1',
+        name: 'Test Private Practitioner',
+        representingPrimary: true,
+        role: ROLES.privatePractitioner,
+        section: 'privatePractitioner',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        userId: 'ad07b846-8933-4778-9fe2-b5d8ac8ad728',
+      },
+    });
+
+    const docketEntryForNoticeOfChangeOfAddress = cases[0].docketEntries.find(
+      entry => entry.documentTitle.includes('Notice of Change'),
+    );
+
+    expect(
+      applicationContext.getDocumentGenerators().changeOfAddress,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
+    ).toHaveBeenCalled();
+    expect(docketEntryForNoticeOfChangeOfAddress.workItem).toBeDefined();
+    expect(cases).toMatchObject([
+      expect.objectContaining({ docketNumber: MOCK_CASE.docketNumber }),
+    ]);
+  });
+
+  it("should create a work item for an associated practitioner's notice of change of address when paper service is requested by the practitioner", async () => {
+    const mockPaperServiceCase = {
+      ...mockCaseWithPrivatePractitioner,
+      contactPrimary: {
+        ...MOCK_CASE.contactPrimary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      },
+      contactSecondary: {
+        ...MOCK_CASE.contactSecondary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      },
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    };
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue(mockPaperServiceCase);
+
+    const cases = await generateChangeOfAddress({
+      applicationContext,
+      contactInfo: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      user: {
+        barNumber: 'PT5432',
+        contact: {
+          address1: '234 Main St!',
+          address2: 'Apartment 4',
+          address3: 'Under the stairs',
+          city: 'Chicago',
+          countryType: COUNTRY_TYPES.DOMESTIC,
+          phone: '+1 (555) 555-5555',
+          postalCode: '61234',
+          state: 'IL',
+        },
+        email: 'privatePractitioner1',
+        name: 'Test Private Practitioner',
+        representingPrimary: true,
+        role: ROLES.privatePractitioner,
+        section: 'privatePractitioner',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+        userId: 'ad07b846-8933-4778-9fe2-b5d8ac8ad728',
+      },
+    });
+
+    const docketEntryForNoticeOfChangeOfAddress = cases[0].docketEntries.find(
+      entry => entry.documentTitle.includes('Notice of Change'),
+    );
+
+    expect(
+      applicationContext.getDocumentGenerators().changeOfAddress,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
+    ).toHaveBeenCalled();
+    expect(docketEntryForNoticeOfChangeOfAddress.workItem).toBeDefined();
+    expect(cases).toMatchObject([
+      expect.objectContaining({ docketNumber: MOCK_CASE.docketNumber }),
+    ]);
+  });
+
+  it("should create a work item for an associated practitioner's notice of change of address when paper service is requested by a primary contact on the case", async () => {
+    const mockPaperServiceCase = {
+      ...mockCaseWithPrivatePractitioner,
+      contactPrimary: {
+        ...MOCK_CASE.contactPrimary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+      },
+      contactSecondary: {
+        ...MOCK_CASE.contactSecondary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      },
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    };
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue(mockPaperServiceCase);
+
+    const cases = await generateChangeOfAddress({
+      applicationContext,
+      contactInfo: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      user: {
+        barNumber: 'PT5432',
+        contact: {
+          address1: '234 Main St!',
+          address2: 'Apartment 4',
+          address3: 'Under the stairs',
+          city: 'Chicago',
+          countryType: COUNTRY_TYPES.DOMESTIC,
+          phone: '+1 (555) 555-5555',
+          postalCode: '61234',
+          state: 'IL',
+        },
+        email: 'privatePractitioner1',
+        name: 'Test Private Practitioner',
+        representingPrimary: true,
+        role: ROLES.privatePractitioner,
+        section: 'privatePractitioner',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        userId: 'ad07b846-8933-4778-9fe2-b5d8ac8ad728',
+      },
+    });
+
+    const docketEntryForNoticeOfChangeOfAddress = cases[0].docketEntries.find(
+      entry => entry.documentTitle.includes('Notice of Change'),
+    );
+
+    expect(
+      applicationContext.getDocumentGenerators().changeOfAddress,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
+    ).toHaveBeenCalled();
+    expect(docketEntryForNoticeOfChangeOfAddress.workItem).toBeDefined();
+    expect(cases).toMatchObject([
+      expect.objectContaining({ docketNumber: MOCK_CASE.docketNumber }),
+    ]);
+  });
+
+  it("should create a work item for an associated practitioner's notice of change of address when paper service is requested by a secondary contact on the case", async () => {
+    const mockPaperServiceCase = {
+      ...mockCaseWithPrivatePractitioner,
+      contactPrimary: {
+        ...MOCK_CASE.contactPrimary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      },
+      contactSecondary: {
+        ...MOCK_CASE.contactSecondary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+      },
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    };
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue(mockPaperServiceCase);
+
+    const cases = await generateChangeOfAddress({
+      applicationContext,
+      contactInfo: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      user: {
+        barNumber: 'PT5432',
+        contact: {
+          address1: '234 Main St!',
+          address2: 'Apartment 4',
+          address3: 'Under the stairs',
+          city: 'Chicago',
+          countryType: COUNTRY_TYPES.DOMESTIC,
+          phone: '+1 (555) 555-5555',
+          postalCode: '61234',
+          state: 'IL',
+        },
+        email: 'privatePractitioner1',
+        name: 'Test Private Practitioner',
+        representingPrimary: true,
+        role: ROLES.privatePractitioner,
+        section: 'privatePractitioner',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        userId: 'ad07b846-8933-4778-9fe2-b5d8ac8ad728',
+      },
+    });
+
+    const docketEntryForNoticeOfChangeOfAddress = cases[0].docketEntries.find(
+      entry => entry.documentTitle.includes('Notice of Change'),
+    );
+
+    expect(
+      applicationContext.getDocumentGenerators().changeOfAddress,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
+    ).toHaveBeenCalled();
+    expect(docketEntryForNoticeOfChangeOfAddress.workItem).toBeDefined();
+    expect(cases).toMatchObject([
+      expect.objectContaining({ docketNumber: MOCK_CASE.docketNumber }),
+    ]);
+  });
+
+  it("should NOT create a work item for an associated practitioner's the notice of change of address when there is no paper service for the case", async () => {
+    const mockElectronicServiceCase = {
+      ...mockCaseWithPrivatePractitioner,
+      contactPrimary: {
+        ...MOCK_CASE.contactPrimary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      },
+      contactSecondary: {
+        ...MOCK_CASE.contactSecondary,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      },
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    };
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue(mockElectronicServiceCase);
+
+    const cases = await generateChangeOfAddress({
+      applicationContext,
+      contactInfo: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      user: {
+        barNumber: 'PT5432',
+        contact: {
+          address1: '234 Main St!',
+          address2: 'Apartment 4',
+          address3: 'Under the stairs',
+          city: 'Chicago',
+          countryType: COUNTRY_TYPES.DOMESTIC,
+          phone: '+1 (555) 555-5555',
+          postalCode: '61234',
+          state: 'IL',
+        },
+        email: 'privatePractitioner1',
+        name: 'Test Private Practitioner',
+        representingPrimary: true,
+        role: ROLES.privatePractitioner,
+        section: 'privatePractitioner',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        userId: 'ad07b846-8933-4778-9fe2-b5d8ac8ad728',
+      },
+    });
+
+    const docketEntryForNoticeOfChangeOfAddress = cases[0].docketEntries.find(
+      entry => entry.documentTitle.includes('Notice of Change'),
+    );
+
+    expect(
+      applicationContext.getDocumentGenerators().changeOfAddress,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().saveWorkItemForNonPaper,
+    ).not.toHaveBeenCalled();
+    expect(docketEntryForNoticeOfChangeOfAddress.workItem).toBeUndefined();
+    expect(cases).toMatchObject([
+      expect.objectContaining({ docketNumber: MOCK_CASE.docketNumber }),
+    ]);
+  });
 });


### PR DESCRIPTION
- Any Notice of Change of Address/Phone/Both automatically generated by the system by a Practitioner changing his/her information does not need to be QC'd by Docket, unless there is paper service in the case (case, contactPrimary, conatctSecondary, irsPractitioner, privatePractitioner)

![image](https://user-images.githubusercontent.com/20514925/97637579-2cd9ff00-19f8-11eb-86d0-448617f9e2aa.png)
