### PR TITLE
increasing the limit for the number of rest apis received

### DIFF
--- a/web-client/switch-api-colors.js
+++ b/web-client/switch-api-colors.js
@@ -21,7 +21,7 @@ const run = async () => {
       region,
     });
 
-    const { items } = await apigateway.getRestApis({}).promise();
+    const { items } = await apigateway.getRestApis({ limit: 500 }).promise();
 
     const apiGatewayRecord = items.find(
       record => record.name === `gateway_api_${ENV}_${DEPLOYING_COLOR}`,


### PR DESCRIPTION
increasing the limit for the number of rest apis received in order to successfully find the required apiGatewayRecord.