### PR TITLE
Explicitly enable dynamo streams for deploying color

### DIFF
--- a/web-client/switch-colors.sh
+++ b/web-client/switch-colors.sh
@@ -16,6 +16,10 @@ if [[ "${MIGRATE_FLAG}" == "false" ]]; then
   aws lambda update-event-source-mapping --uuid "${UUID}" --region us-east-1 --no-enabled
 fi
 
+# explicitly turn on deploying color stream, just in case
+UUID=$(aws lambda list-event-source-mappings --function-name "arn:aws:lambda:us-east-1:${AWS_ACCOUNT_ID}:function:streams_${ENV}_${DEPLOYING_COLOR}" --region us-east-1 | jq -r ".EventSourceMappings[0].UUID")
+aws lambda update-event-source-mapping --uuid "${UUID}" --region us-east-1
+
 node ./web-client/switch-public-ui-colors.js
 node ./web-client/switch-ui-colors.js
 node ./web-client/switch-api-colors.js


### PR DESCRIPTION
In case we accidentally run switch-colors.sh with the wrong deploying/current colors or some other incorrect environment variable, explicitly enable the deploying color dynamo stream each time we switch colors.