### PR TITLE
6972: treat 'SL' like 'L' and 'P' for eligible cases

### DIFF
--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.js
@@ -17,6 +17,7 @@ exports.formatCase = ({ applicationContext, caseItem }) => {
   const highPrioritySuffixes = [
     DOCKET_NUMBER_SUFFIXES.LIEN_LEVY, // L
     DOCKET_NUMBER_SUFFIXES.PASSPORT, // P
+    DOCKET_NUMBER_SUFFIXES.SMALL_LIEN_LEVY, // SL
   ];
   caseItem.isHighPriority = highPrioritySuffixes.includes(
     caseItem.docketNumberSuffix,

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
@@ -160,11 +160,19 @@ describe('formattedTrialSessionDetails', () => {
     });
   });
 
-  it('formatCase identifies Lien/Levy and Passport as high priority', () => {
+  it('formatCase identifies Small Lien/Levy, Lien/Levy, and Passport as high priority', () => {
     expect(
       formatCase({ applicationContext, caseItem: { docketNumberSuffix: 'W' } })
         .isHighPriority,
     ).toBe(false);
+    expect(
+      formatCase({
+        applicationContext,
+        caseItem: {
+          docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL_LIEN_LEVY,
+        },
+      }).isHighPriority,
+    ).toBe(true);
     expect(
       formatCase({
         applicationContext,


### PR DESCRIPTION
update for ustaxcourt/ef-cms#7459 