### PR TITLE
#6913 -Trial location not displaying in concatenated document title for Request for Place of Trial 

### DIFF
--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -141,6 +141,7 @@ const { formatDollars } = require('../utilities/formatDollars');
 const { getConstants } = require('../../../../web-client/src/getConstants');
 const { getItem } = require('../../persistence/localStorage/getItem');
 const { removeItem } = require('../../persistence/localStorage/removeItem');
+const { replaceBracketed } = require('../utilities/replaceBracketed');
 const { ROLES } = require('../entities/EntityConstants');
 const { setItem } = require('../../persistence/localStorage/setItem');
 const { updateCase } = require('../../persistence/dynamo/cases/updateCase');
@@ -274,6 +275,7 @@ const createTestApplicationContext = ({ user } = {}) => {
     prepareDateFromString: jest
       .fn()
       .mockImplementation(DateHandler.prepareDateFromString),
+    replaceBracketed: jest.fn().mockImplementation(replaceBracketed),
     setServiceIndicatorsForCase: jest
       .fn()
       .mockImplementation(setServiceIndicatorsForCase),

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -174,6 +174,7 @@ import { removeCasePendingItemInteractor } from '../../shared/src/proxies/remove
 import { removeConsolidatedCasesInteractor } from '../../shared/src/proxies/removeConsolidatedCasesProxy';
 import { removeItem } from '../../shared/src/persistence/localStorage/removeItem';
 import { removeItemInteractor } from '../../shared/src/business/useCases/removeItemInteractor';
+import { replaceBracketed } from '../../shared/src/business/utilities/replaceBracketed';
 const {
   removePdfFromDocketEntryInteractor,
 } = require('../../shared/src/proxies/documents/removePdfFromDocketEntryProxy');
@@ -630,6 +631,7 @@ const applicationContext = {
       isStringISOFormatted,
       isValidDateString,
       prepareDateFromString,
+      replaceBracketed,
       setServiceIndicatorsForCase,
       sortDocketEntries,
     };

--- a/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.js
+++ b/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.js
@@ -64,7 +64,15 @@ export const saveCaseDetailInternalEditAction = async ({
             onUploadProgress: progressFunctions[fileKey],
           });
 
-        const { documentTitle, documentType } = INITIAL_DOCUMENT_TYPES[key];
+        let { documentTitle, documentType } = INITIAL_DOCUMENT_TYPES[key];
+
+        if (
+          fileKey === INITIAL_DOCUMENT_TYPES_FILE_MAP.requestForPlaceOfTrial
+        ) {
+          documentTitle = applicationContext
+            .getUtilities()
+            .replaceBracketed(documentTitle, caseToUpdate.preferredTrialCity);
+        }
 
         caseToUpdate.docketEntries.push({
           docketEntryId: newDocketEntryId,

--- a/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.test.js
+++ b/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.test.js
@@ -192,7 +192,46 @@ describe('saveCaseDetailInternalEditAction', () => {
       expect.arrayContaining([
         {
           docketEntryId: mockUploadedKey,
-          documentTitle: 'Request for Place of Trial at [Place]',
+          documentTitle: `Request for Place of Trial at ${MOCK_CASE.preferredTrialCity}`,
+          documentType: 'Request for Place of Trial',
+        },
+      ]),
+    );
+  });
+  it('should compute the RQT documentTitle based on the preferredTrialCity when an RQT already exists on the case', async () => {
+    const mockRqtFile = {
+      docketEntryId: 'b6b81f4d-1e47-423a-8caf-6d2fdc3d3850',
+      documentType: 'Request for Place of Trial',
+      eventCode: 'RQT',
+      filedBy: 'Test Petitioner',
+      userId: '50c62fa0-dd90-4244-b7c7-9cb2302d7688',
+    };
+    const caseDetail = {
+      ...MOCK_CASE,
+      docketEntries: [],
+      preferredTrialCity: 'Atlantis',
+      requestForPlaceOfTrialFile: mockRqtFile,
+      requestForPlaceOfTrialFileSize: 2,
+    };
+
+    await runAction(saveCaseDetailInternalEditAction, {
+      modules: {
+        presenter,
+      },
+      props: { formWithComputedDates: caseDetail },
+    });
+
+    expect(
+      applicationContext.getUtilities().replaceBracketed,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getUseCases().saveCaseDetailInternalEditInteractor.mock
+        .calls[0][0].caseToUpdate.docketEntries,
+    ).toMatchObject(
+      expect.arrayContaining([
+        {
+          docketEntryId: mockUploadedKey,
+          documentTitle: 'Request for Place of Trial at Atlantis',
           documentType: 'Request for Place of Trial',
         },
       ]),


### PR DESCRIPTION
When updating a saved case that previously did not have a preferredTrialCity/RQT file, set document title to correctly include preferredTrialCity when saving the case

![image](https://user-images.githubusercontent.com/20514925/98578438-35d99480-2272-11eb-8e36-0077147eaa67.png)

