### PR TITLE
6941: safely check for assigned trial clerk

### DIFF
--- a/shared/src/business/useCaseHelper/trialSessions/createTrialSessionAndWorkingCopy.js
+++ b/shared/src/business/useCaseHelper/trialSessions/createTrialSessionAndWorkingCopy.js
@@ -22,14 +22,26 @@ exports.createTrialSessionAndWorkingCopy = async ({
       trialSession: trialSessionToAdd.validate().toRawObject(),
     });
 
-  const trialSessionWorkingCopyUserId =
-    (trialSessionToAdd.judge && trialSessionToAdd.judge.userId) ||
-    (trialSessionToAdd.trialClerk && trialSessionToAdd.trialClerk.userId);
-
-  if (trialSessionWorkingCopyUserId) {
+  if (trialSessionToAdd.judge && trialSessionToAdd.judge.userId) {
     const trialSessionWorkingCopyEntity = new TrialSessionWorkingCopy({
       trialSessionId: trialSessionToAdd.trialSessionId,
-      userId: trialSessionWorkingCopyUserId,
+      userId: trialSessionToAdd.judge.userId,
+    });
+
+    await applicationContext
+      .getPersistenceGateway()
+      .createTrialSessionWorkingCopy({
+        applicationContext,
+        trialSessionWorkingCopy: trialSessionWorkingCopyEntity
+          .validate()
+          .toRawObject(),
+      });
+  }
+
+  if (trialSessionToAdd.trialClerk && trialSessionToAdd.trialClerk.userId) {
+    const trialSessionWorkingCopyEntity = new TrialSessionWorkingCopy({
+      trialSessionId: trialSessionToAdd.trialSessionId,
+      userId: trialSessionToAdd.trialClerk.userId,
     });
 
     await applicationContext

--- a/shared/src/business/useCaseHelper/trialSessions/createTrialSessionAndWorkingCopy.js
+++ b/shared/src/business/useCaseHelper/trialSessions/createTrialSessionAndWorkingCopy.js
@@ -22,26 +22,14 @@ exports.createTrialSessionAndWorkingCopy = async ({
       trialSession: trialSessionToAdd.validate().toRawObject(),
     });
 
-  if (trialSessionToAdd.judge && trialSessionToAdd.judge.userId) {
+  const trialSessionWorkingCopyUserId =
+    (trialSessionToAdd.judge && trialSessionToAdd.judge.userId) ||
+    (trialSessionToAdd.trialClerk && trialSessionToAdd.trialClerk.userId);
+
+  if (trialSessionWorkingCopyUserId) {
     const trialSessionWorkingCopyEntity = new TrialSessionWorkingCopy({
       trialSessionId: trialSessionToAdd.trialSessionId,
-      userId: trialSessionToAdd.judge.userId,
-    });
-
-    await applicationContext
-      .getPersistenceGateway()
-      .createTrialSessionWorkingCopy({
-        applicationContext,
-        trialSessionWorkingCopy: trialSessionWorkingCopyEntity
-          .validate()
-          .toRawObject(),
-      });
-  }
-
-  if (trialSessionToAdd.trialClerk && trialSessionToAdd.trialClerk.userId) {
-    const trialSessionWorkingCopyEntity = new TrialSessionWorkingCopy({
-      trialSessionId: trialSessionToAdd.trialSessionId,
-      userId: trialSessionToAdd.trialClerk.userId,
+      userId: trialSessionWorkingCopyUserId,
     });
 
     await applicationContext

--- a/shared/src/business/useCaseHelper/trialSessions/createTrialSessionAndWorkingCopy.test.js
+++ b/shared/src/business/useCaseHelper/trialSessions/createTrialSessionAndWorkingCopy.test.js
@@ -41,7 +41,20 @@ describe('createTrialSessionAndWorkingCopy', () => {
     expect(result).toBeDefined();
     expect(
       applicationContext.getPersistenceGateway().createTrialSession,
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create no corresponding trial session working copy without a valid judge userId or trialClerk userId', async () => {
+    delete trialSessionToAdd.judge;
+    delete trialSessionToAdd.trialClerk;
+    await createTrialSessionAndWorkingCopy({
+      applicationContext,
+      trialSessionToAdd,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy,
+    ).not.toHaveBeenCalled();
   });
 
   it('should create a corresponding trial session working copy when it contains a judge with a valid userId', async () => {
@@ -52,12 +65,11 @@ describe('createTrialSessionAndWorkingCopy', () => {
 
     expect(
       applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy,
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(1);
   });
 
   it('should create a corresponding trial session working copy when it contains a trialClerk with a valid userId', async () => {
-    delete trialSessionMetadata.judge;
-    trialSessionMetadata.trialClerk = {
+    trialSessionToAdd.trialClerk = {
       name: 'Test Clerk',
       userId: 'd90e7b8c-c8a1-4b96-9b30-70bd47b63df0',
     };
@@ -65,10 +77,9 @@ describe('createTrialSessionAndWorkingCopy', () => {
       applicationContext,
       trialSessionToAdd,
     });
-
     expect(
       applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy,
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(2);
   });
 
   describe('validation', () => {

--- a/shared/src/business/useCases/trialSessions/getTrialSessionWorkingCopyInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/getTrialSessionWorkingCopyInteractor.test.js
@@ -107,11 +107,12 @@ describe('Get trial session working copy', () => {
       .getUseCases()
       .getJudgeForUserChambersInteractor.mockReturnValue(undefined);
 
-    const result = await getTrialSessionWorkingCopyInteractor({
-      applicationContext,
-      trialSessionId: MOCK_WORKING_COPY.trialSessionId,
-    });
-    expect(result).toBeUndefined();
+    await expect(
+      getTrialSessionWorkingCopyInteractor({
+        applicationContext,
+        trialSessionId: MOCK_WORKING_COPY.trialSessionId,
+      }),
+    ).rejects.toThrow('Trial session working copy not found');
   });
 
   it('correctly returns data from persistence for a trial clerk user', async () => {
@@ -167,7 +168,22 @@ describe('Get trial session working copy', () => {
         });
     });
 
-    it('for current user who is a judge on this trial session', async () => {
+    it('for current user who is a judge on this trial session with no assigned trial clerk', async () => {
+      applicationContext
+        .getPersistenceGateway()
+        .getTrialSessionById.mockReturnValueOnce({
+          judge: {
+            name: 'Jake',
+            userId: 'd7d90c05-f6cd-442c-a168-202db587f16f',
+          },
+          maxCases: 100,
+          sessionType: 'Regular',
+          startDate: '2025-03-01T00:00:00.000Z',
+          term: 'Fall',
+          termYear: '2025',
+          trialClerk: undefined,
+          trialLocation: 'Birmingham, Alabama',
+        });
       applicationContext.getCurrentUser.mockReturnValue({
         role: ROLES.judge,
         userId: 'd7d90c05-f6cd-442c-a168-202db587f16f',


### PR DESCRIPTION
Previous code didn't null-check the trial sessions' assigned trial clerk, resulting in error seen on ustaxcourt/ef-cms#7447 

Also with the pen-testing strategies in mind, should a user identified as having permission to see trial session copy (in general) but *not* associated with the specifically-requested trial session working copy, the result is that a `NotFoundError` will be returned.