### PR TITLE
Bug #6800 - Left align document title in advanced search results

### DIFF
--- a/web-client/src/styles/buttons.scss
+++ b/web-client/src/styles/buttons.scss
@@ -95,6 +95,10 @@
   }
 }
 
+table.search-results .ustc-button--unstyled {
+  text-align: left;
+}
+
 .button-switch-box {
   font-family: $font-source-sans;
   font-size: 17px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20249233/98604829-45b89f00-2299-11eb-9515-cb9d464c0a09.png)

After:
![image](https://user-images.githubusercontent.com/20249233/98604791-39344680-2299-11eb-8974-1975a6cbcf43.png)
