### PR TITLE
BUG 6778 - Filings and proceedings columns not left aligned

### DIFF
--- a/web-client/src/styles/buttons.scss
+++ b/web-client/src/styles/buttons.scss
@@ -99,6 +99,10 @@ table.search-results .ustc-button--unstyled {
   text-align: left;
 }
 
+table.docket-record .ustc-button--unstyled {
+  text-align: left;
+}
+
 .button-switch-box {
   font-family: $font-source-sans;
   font-size: 17px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20249233/99476837-2b6c6a00-2906-11eb-8ee4-25db862b487f.png)

After:
![image](https://user-images.githubusercontent.com/20249233/99476818-1e4f7b00-2906-11eb-905f-38a381ae40a8.png)
