### PR TITLE
Bug 7010 - Prevent rep:deleting records from triggering a MODIFY event in ES

### DIFF
--- a/shared/src/business/useCases/processStreamRecordsInteractor.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.js
@@ -2,6 +2,24 @@ const AWS = require('aws-sdk');
 const { flattenDeep, get, partition } = require('lodash');
 const { omit } = require('lodash');
 
+const filterRecords = record => {
+  // to prevent global tables writing extra data
+  const NEW_TIME_KEY = 'dynamodb.NewImage.aws:rep:updatetime.N';
+  const OLD_TIME_KEY = 'dynamodb.OldImage.aws:rep:updatetime.N';
+  const IS_DELETING_KEY = 'dynamodb.NewImage.aws:rep:deleting.BOOL';
+
+  const newTime = get(record, NEW_TIME_KEY);
+  const oldTime = get(record, OLD_TIME_KEY);
+  const isDeleting = get(record, IS_DELETING_KEY);
+
+  return (
+    (process.env.NODE_ENV !== 'production' ||
+      (newTime && newTime !== oldTime) ||
+      record.eventName === 'REMOVE') &&
+    !isDeleting
+  );
+};
+
 const partitionRecords = records => {
   const [removeRecords, insertModifyRecords] = partition(
     records,
@@ -321,18 +339,7 @@ exports.processStreamRecordsInteractor = async ({
       useTempBucket: false,
     });
 
-  recordsToProcess = recordsToProcess.filter(record => {
-    // to prevent global tables writing extra data
-    const NEW_TIME_KEY = 'dynamodb.NewImage.aws:rep:updatetime.N';
-    const OLD_TIME_KEY = 'dynamodb.OldImage.aws:rep:updatetime.N';
-    const newTime = get(record, NEW_TIME_KEY);
-    const oldTime = get(record, OLD_TIME_KEY);
-    return (
-      process.env.NODE_ENV !== 'production' ||
-      (newTime && newTime !== oldTime) ||
-      record.eventName === 'REMOVE'
-    );
-  });
+  recordsToProcess = recordsToProcess.filter(filterRecords);
 
   const {
     caseEntityRecords,
@@ -415,6 +422,7 @@ exports.processStreamRecordsInteractor = async ({
   }
 };
 
+exports.filterRecords = filterRecords;
 exports.partitionRecords = partitionRecords;
 exports.processCaseEntries = processCaseEntries;
 exports.processDocketEntries = processDocketEntries;

--- a/shared/src/business/useCases/processStreamRecordsInteractor.test.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.test.js
@@ -1,4 +1,5 @@
 const {
+  filterRecords,
   partitionRecords,
   processCaseEntries,
   processDocketEntries,
@@ -16,6 +17,101 @@ describe('processStreamRecordsInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .bulkIndexRecords.mockReturnValue({ failedRecords: [] });
+  });
+
+  describe('filterRecords', () => {
+    const getMockRecord = ({
+      deleting = false,
+      id = null,
+      newTime = 'newTime',
+      oldTime = 'oldTime',
+      removeRecord = false,
+    }) => {
+      const mockRecord = {
+        dynamodb: {
+          NewImage: {
+            'aws:rep:deleting': {
+              BOOL: deleting,
+            },
+            'aws:rep:updatetime': {
+              N: newTime,
+            },
+          },
+          OldImage: {
+            'aws:rep:deleting': {
+              BOOL: false,
+            },
+            'aws:rep:updatetime': {
+              N: oldTime,
+            },
+          },
+        },
+        eventName: removeRecord ? 'REMOVE' : 'MODIFY',
+        id, // this is just an identifier for the test output and not actually on these records
+      };
+
+      if (removeRecord) {
+        delete mockRecord.dynamodb.NewImage; // remove events do not have a NewImage
+      }
+
+      return mockRecord;
+    };
+
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'; // necessary to evaluate other conditionals
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = undefined; // resetting back after each test
+    });
+
+    it('filters out records with a deleting value of true', () => {
+      const record1 = getMockRecord({ deleting: true, id: '1' }); // should be filtered out
+      const record2 = getMockRecord({ id: '2' }); // should pass filter
+      const recordsToProcess = [record1, record2];
+
+      const result = recordsToProcess.filter(filterRecords);
+
+      expect(result).toMatchObject([record2]);
+    });
+
+    it('filters out records with where the updatetime did not change', () => {
+      const record1 = getMockRecord({
+        id: '1',
+        newTime: 'sameTime',
+        oldTime: 'sameTime',
+      }); // should be filtered out
+      const record2 = getMockRecord({
+        id: '2',
+        newTime: 'someTime',
+        oldTime: 'anotherTime',
+      }); // should pass filter
+      const recordsToProcess = [record1, record2];
+
+      const result = recordsToProcess.filter(filterRecords);
+
+      expect(result).toMatchObject([record2]);
+    });
+
+    it('returns records with a REMOVE event', () => {
+      const record1 = getMockRecord({
+        id: '1',
+        newTime: 'sameTime',
+        oldTime: 'sameTime',
+        removeRecord: false,
+      }); // should be filtered out
+      const record2 = getMockRecord({
+        id: '2',
+        newTime: 'sameTime',
+        oldTime: 'sameTime',
+        removeRecord: true,
+      }); // should pass filter
+      const recordsToProcess = [record1, record2];
+
+      const result = recordsToProcess.filter(filterRecords);
+
+      expect(result).toMatchObject([record2]);
+    });
   });
 
   describe('partitionRecords', () => {


### PR DESCRIPTION
A tricky bug to track down - this is what appears to be happening.

When a WorkItem was deleted in dynamo (specifically inbox mapping records), we weren't actually seeing it get removed in ES. In `processStreamRecordsInteractor`, we do a couple of things with these events:
- We filter them to make sure we're processing records we want to process
- We call separate index/delete actions with groups of records.
The delete (REMOVE) events are processed first, followed by the indexing of other records. 

What we learned was, when deleting a record in dynamo, the event was fired off to ES as expected, BUT there was an update to that record in the global table that sets the `aws:rep:deleting` field to `true`. This was triggering a MODIFY event, which we'd process in the stream right AFTER processing the REMOVE event. So the record would just get added back.

We finally realized this was happening by logging the events in processStreamRecords, identify the conflicting REMOVE and MODIFY records, and doing a diff on the MODIFY record's NewImage and OldImage (effectively trying to work backwards from what had changed). That one `aws:rep:deleting` field was the only thing that was changing, which completely explained why we couldn't see find any other paths by which a race condition was being introduced in our code.

This PR filters out records where the `aws:rep:deleting` field is changed to `true`, effectively ignoring it in ES.