### PR TITLE
6962 BUG Not Served showing in Document View

### DIFF
--- a/web-client/src/presenter/computeds/documentViewerHelper.test.js
+++ b/web-client/src/presenter/computeds/documentViewerHelper.test.js
@@ -295,6 +295,60 @@ describe('documentViewerHelper', () => {
 
       expect(result.showNotServed).toEqual(false);
     });
+
+    it('should be false when the document is a legacy served document', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId,
+                documentTitle: 'Some Stuff',
+                documentType: 'Order',
+                eventCode: 'O',
+                isLegacyServed: true,
+                isOnDocketRecord: true,
+              },
+            ],
+          },
+          permissions: {
+            SERVE_DOCUMENT: false,
+          },
+          viewerDocumentToDisplay: {
+            docketEntryId,
+          },
+        },
+      });
+
+      expect(result.showNotServed).toEqual(false);
+    });
+
+    it('should be true when the document is not a legacy served document and has no servedAt date', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId,
+                documentTitle: 'Some Stuff',
+                documentType: 'Order',
+                eventCode: 'O',
+                isLegacyServed: false,
+                isOnDocketRecord: true,
+              },
+            ],
+          },
+          permissions: {
+            SERVE_DOCUMENT: false,
+          },
+          viewerDocumentToDisplay: {
+            docketEntryId,
+          },
+        },
+      });
+
+      expect(result.showNotServed).toEqual(true);
+    });
   });
 
   describe('showServeCourtIssuedDocumentButton', () => {
@@ -405,6 +459,60 @@ describe('documentViewerHelper', () => {
 
       expect(result.showServeCourtIssuedDocumentButton).toEqual(false);
     });
+
+    it('should be false when the document is a legacy served document', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId,
+                documentTitle: 'Some Stuff',
+                documentType: 'Order',
+                eventCode: 'O',
+                isLegacyServed: true,
+                isOnDocketRecord: true,
+              },
+            ],
+          },
+          permissions: {
+            SERVE_DOCUMENT: true,
+          },
+          viewerDocumentToDisplay: {
+            docketEntryId,
+          },
+        },
+      });
+
+      expect(result.showServeCourtIssuedDocumentButton).toEqual(false);
+    });
+
+    it('should be true when the document is not a legacy served document and has no servedAt date', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId,
+                documentTitle: 'Some Stuff',
+                documentType: 'Order',
+                eventCode: 'O',
+                isLegacyServed: false,
+                isOnDocketRecord: true,
+              },
+            ],
+          },
+          permissions: {
+            SERVE_DOCUMENT: true,
+          },
+          viewerDocumentToDisplay: {
+            docketEntryId,
+          },
+        },
+      });
+
+      expect(result.showServeCourtIssuedDocumentButton).toEqual(true);
+    });
   });
 
   describe('showServePaperFiledDocumentButton', () => {
@@ -513,6 +621,60 @@ describe('documentViewerHelper', () => {
       });
 
       expect(result.showServePaperFiledDocumentButton).toEqual(false);
+    });
+
+    it('should be false when the document is a legacy served document', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId,
+                documentTitle: 'Entry of Appearance',
+                documentType: 'Entry of Appearance',
+                eventCode: 'EA',
+                isLegacyServed: true,
+                isOnDocketRecord: true,
+              },
+            ],
+          },
+          permissions: {
+            SERVE_DOCUMENT: true,
+          },
+          viewerDocumentToDisplay: {
+            docketEntryId,
+          },
+        },
+      });
+
+      expect(result.showServePaperFiledDocumentButton).toEqual(false);
+    });
+
+    it('should be true when the document is not a legacy served document and has no servedAt date', () => {
+      const result = runCompute(documentViewerHelper, {
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId,
+                documentTitle: 'Entry of Appearance',
+                documentType: 'Entry of Appearance',
+                eventCode: 'EA',
+                isLegacyServed: false,
+                isOnDocketRecord: true,
+              },
+            ],
+          },
+          permissions: {
+            SERVE_DOCUMENT: true,
+          },
+          viewerDocumentToDisplay: {
+            docketEntryId,
+          },
+        },
+      });
+
+      expect(result.showServePaperFiledDocumentButton).toEqual(true);
     });
   });
 

--- a/web-client/src/presenter/computeds/getShowNotServedForDocument.js
+++ b/web-client/src/presenter/computeds/getShowNotServedForDocument.js
@@ -19,7 +19,11 @@ export const getShowNotServedForDocument = ({
       draftDocuments &&
       !!draftDocuments.find(draft => draft.docketEntryId === docketEntryId);
 
-    showNotServed = !isUnservable && !caseDocument.servedAt && !isDraftDocument;
+    showNotServed =
+      !isUnservable &&
+      !caseDocument.servedAt &&
+      !caseDocument.isLegacyServed &&
+      !isDraftDocument;
   }
 
   return showNotServed;

--- a/web-client/src/presenter/computeds/getShowNotServedForDocument.test.js
+++ b/web-client/src/presenter/computeds/getShowNotServedForDocument.test.js
@@ -116,5 +116,45 @@ describe('getShowNotServedForDocument', () => {
 
       expect(showNotServed).toEqual(false);
     });
+
+    it('should return true when the document is a legacy document that has not been served and has no servedAt', () => {
+      const showNotServed = getShowNotServedForDocument({
+        UNSERVABLE_EVENT_CODES,
+        caseDetail: {
+          docketEntries: [
+            {
+              docketEntryId,
+              documentTitle: 'Some Stuff',
+              documentType: 'Order',
+              eventCode: 'O',
+              isLegacyServed: false,
+            },
+          ],
+        },
+        docketEntryId,
+      });
+
+      expect(showNotServed).toEqual(true);
+    });
+
+    it('should return false when the document is a legacy document that has been served', () => {
+      const showNotServed = getShowNotServedForDocument({
+        UNSERVABLE_EVENT_CODES,
+        caseDetail: {
+          docketEntries: [
+            {
+              docketEntryId,
+              documentTitle: 'Some Stuff',
+              documentType: 'Order',
+              eventCode: 'O',
+              isLegacyServed: true,
+            },
+          ],
+        },
+        docketEntryId,
+      });
+
+      expect(showNotServed).toEqual(false);
+    });
   });
 });


### PR DESCRIPTION
Documents with isLegacyServed true should not show 'Not Served' on document viewer page, also should not display the 'Serve' button