### PR TITLE
7102 - Doc QC Missing Petition

### DIFF
--- a/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.js
+++ b/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.js
@@ -19,6 +19,13 @@ exports.getDocumentQCInboxForSection = async ({
                 'sk.S': 'work-item|',
               },
             },
+            {
+              term: {
+                'section.S': {
+                  value: section,
+                },
+              },
+            },
           ],
           must_not: {
             exists: {

--- a/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.test.js
+++ b/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.test.js
@@ -35,6 +35,13 @@ describe('getDocumentQCInboxForSection', () => {
                     'sk.S': 'work-item|',
                   },
                 },
+                {
+                  term: {
+                    'section.S': {
+                      value: 'docket',
+                    },
+                  },
+                },
               ],
               must_not: {
                 exists: {

--- a/web-client/integration-tests/journey/practitionerCreatesNewCase.js
+++ b/web-client/integration-tests/journey/practitionerCreatesNewCase.js
@@ -1,4 +1,5 @@
 import { applicationContextForClient as applicationContext } from '../../../shared/src/business/test/createTestApplicationContext';
+import { refreshElasticsearchIndex } from '../helpers';
 import { runCompute } from 'cerebral/test';
 import { startCaseHelper as startCaseHelperComputed } from '../../src/presenter/computeds/startCaseHelper';
 import { withAppContextDecorator } from '../../src/withAppContext';
@@ -195,6 +196,8 @@ export const practitionerCreatesNewCase = (test, fakeFile) => {
     expect(test.getState('alertError')).toBeUndefined();
 
     expect(test.getState('currentPage')).toBe('FilePetitionSuccess');
+
+    await refreshElasticsearchIndex();
 
     await test.runSequence('gotoDashboardSequence');
 


### PR DESCRIPTION
The section QC ES query was a little too greedy, and matching `section|docket` when the query was also looking for `section|petition` and the other way around. We do some front-end filtering, so the non-matching matches don't usually show, but they're in the network request. I think we're hitting the max returned results (currently 1000) and some expected results are simply not showing because it's at, say 1,001+ in the results list.

This ensures results stay scoped to the section in question.