### PR TITLE
modifyRespondentContactInfo -  trying to make this test more reliable

### DIFF
--- a/web-client/integration-tests/journey/respondentUpdatesAddress.js
+++ b/web-client/integration-tests/journey/respondentUpdatesAddress.js
@@ -1,5 +1,3 @@
-const { refreshElasticsearchIndex } = require('../helpers');
-
 export const respondentUpdatesAddress = test => {
   return it('respondent updates address', async () => {
     await test.runSequence('gotoUserContactEditSequence');
@@ -25,6 +23,5 @@ export const respondentUpdatesAddress = test => {
     await test.runSequence('submitUpdateUserContactInformationSequence');
 
     expect(test.getState('validationErrors')).toEqual({});
-    await refreshElasticsearchIndex(5000);
   });
 };

--- a/web-client/integration-tests/journey/respondentViewsCaseDetailNoticeOfChangeOfAddress.js
+++ b/web-client/integration-tests/journey/respondentViewsCaseDetailNoticeOfChangeOfAddress.js
@@ -4,7 +4,7 @@ export const respondentViewsCaseDetailNoticeOfChangeOfAddress = (
   createdDocketNumberIndex,
 ) => {
   return it('respondent views case detail notice of change of address', async () => {
-    await refreshElasticsearchIndex(5000);
+    await refreshElasticsearchIndex();
     await test.runSequence('gotoCaseDetailSequence', {
       docketNumber: test.createdDocketNumbers[createdDocketNumberIndex],
     });

--- a/web-client/integration-tests/modifyRespondentContactInfo.test.js
+++ b/web-client/integration-tests/modifyRespondentContactInfo.test.js
@@ -31,12 +31,17 @@ describe('Modify Respondent Contact Information', () => {
     petitionsClerkAddsRespondentsToCase(test);
   }
 
+  it('wait for ES index', async () => {
+    // waiting for the respondent to be associated with the newly created cases
+    await refreshElasticsearchIndex();
+  });
+
   loginAs(test, 'irsPractitioner@example.com');
   respondentUpdatesAddress(test);
 
   it('wait for ES index', async () => {
     // waiting for the associated cases to be updated, and THEN an index
-    await refreshElasticsearchIndex(15000);
+    await refreshElasticsearchIndex();
   });
 
   for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
Add refresh elasticsearch to wait for respondent to finish being associated with newly created cases. Also try removing time in refreshElasticsearch calls.