### PR TITLE
7218 BUG: Migrated cases are Calendared and Blocked

### DIFF
--- a/docs/entities/Case.md
+++ b/docs/entities/Case.md
@@ -3534,163 +3534,6 @@
         - 
           tags: 
             - "Restricted"
-    automaticBlocked: 
-      type: "boolean"
-      flags: 
-        presence: "optional"
-        description: "Temporarily blocked from trial due to a pending item or due date."
-    automaticBlockedDate: 
-      type: "date"
-      flags: 
-        format: 
-          - "YYYY-MM-DDTHH:mm:ss.SSSZ"
-          - "YYYY-MM-DD"
-      whens: 
-        - 
-          ref: 
-            path: 
-              - "automaticBlocked"
-          is: 
-            type: "any"
-            flags: 
-              only: true
-              presence: "required"
-            allow: 
-              - 
-                override: true
-              - true
-          then: 
-            type: "any"
-            flags: 
-              presence: "required"
-          otherwise: 
-            type: "any"
-            flags: 
-              presence: "optional"
-            allow: 
-              - null
-    automaticBlockedReason: 
-      type: "string"
-      flags: 
-        only: true
-        description: "The reason the case was automatically blocked from trial."
-      rules: 
-        - 
-          name: "min"
-          args: 
-            limit: 1
-      allow: 
-        - "Due Date"
-        - "Pending Item"
-        - "Pending Item and Due Date"
-      whens: 
-        - 
-          ref: 
-            path: 
-              - "automaticBlocked"
-          is: 
-            type: "any"
-            flags: 
-              only: true
-              presence: "required"
-            allow: 
-              - 
-                override: true
-              - true
-          then: 
-            type: "any"
-            flags: 
-              presence: "required"
-          otherwise: 
-            type: "any"
-            flags: 
-              presence: "optional"
-            allow: 
-              - null
-    blocked: 
-      type: "boolean"
-      flags: 
-        presence: "optional"
-        description: "Temporarily blocked from trial."
-      metas: 
-        - 
-          tags: 
-            - "Restricted"
-    blockedDate: 
-      type: "date"
-      flags: 
-        format: 
-          - "YYYY-MM-DDTHH:mm:ss.SSSZ"
-          - "YYYY-MM-DD"
-      metas: 
-        - 
-          tags: 
-            - "Restricted"
-      whens: 
-        - 
-          ref: 
-            path: 
-              - "blocked"
-          is: 
-            type: "any"
-            flags: 
-              only: true
-              presence: "required"
-            allow: 
-              - 
-                override: true
-              - true
-          then: 
-            type: "any"
-            flags: 
-              presence: "required"
-          otherwise: 
-            type: "any"
-            flags: 
-              presence: "optional"
-            allow: 
-              - null
-    blockedReason: 
-      type: "string"
-      flags: 
-        description: "Open text field for describing reason for blocking this case from trial."
-      rules: 
-        - 
-          name: "min"
-          args: 
-            limit: 1
-        - 
-          name: "max"
-          args: 
-            limit: 250
-      metas: 
-        - 
-          tags: 
-            - "Restricted"
-      whens: 
-        - 
-          ref: 
-            path: 
-              - "blocked"
-          is: 
-            type: "any"
-            flags: 
-              only: true
-              presence: "required"
-            allow: 
-              - 
-                override: true
-              - true
-          then: 
-            type: "any"
-            flags: 
-              presence: "required"
-          otherwise: 
-            type: "any"
-            flags: 
-              presence: "optional"
-            allow: 
-              - null
     caseCaption: 
       type: "string"
       flags: 
@@ -71669,6 +71512,207 @@
         - 
           tags: 
             - "Restricted"
+    automaticBlocked: 
+      type: "boolean"
+      flags: 
+        presence: "optional"
+        description: "Temporarily blocked from trial due to a pending item or due date."
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "status"
+          is: 
+            type: "any"
+            flags: 
+              only: true
+              presence: "required"
+            allow: 
+              - 
+                override: true
+              - "Calendared"
+          then: 
+            type: "any"
+            invalid: 
+              - true
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
+    automaticBlockedDate: 
+      type: "date"
+      flags: 
+        format: 
+          - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+          - "YYYY-MM-DD"
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "automaticBlocked"
+          is: 
+            type: "any"
+            flags: 
+              only: true
+              presence: "required"
+            allow: 
+              - 
+                override: true
+              - true
+          then: 
+            type: "any"
+            flags: 
+              presence: "required"
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
+            allow: 
+              - null
+    automaticBlockedReason: 
+      type: "string"
+      flags: 
+        only: true
+        description: "The reason the case was automatically blocked from trial."
+      rules: 
+        - 
+          name: "min"
+          args: 
+            limit: 1
+      allow: 
+        - "Due Date"
+        - "Pending Item"
+        - "Pending Item and Due Date"
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "automaticBlocked"
+          is: 
+            type: "any"
+            flags: 
+              only: true
+              presence: "required"
+            allow: 
+              - 
+                override: true
+              - true
+          then: 
+            type: "any"
+            flags: 
+              presence: "required"
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
+            allow: 
+              - null
+    blocked: 
+      type: "boolean"
+      flags: 
+        presence: "optional"
+        description: "Temporarily blocked from trial."
+      metas: 
+        - 
+          tags: 
+            - "Restricted"
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "status"
+          is: 
+            type: "any"
+            flags: 
+              only: true
+              presence: "required"
+            allow: 
+              - 
+                override: true
+              - "Calendared"
+          then: 
+            type: "any"
+            invalid: 
+              - true
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
+    blockedDate: 
+      type: "date"
+      flags: 
+        format: 
+          - "YYYY-MM-DDTHH:mm:ss.SSSZ"
+          - "YYYY-MM-DD"
+      metas: 
+        - 
+          tags: 
+            - "Restricted"
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "blocked"
+          is: 
+            type: "any"
+            flags: 
+              only: true
+              presence: "required"
+            allow: 
+              - 
+                override: true
+              - true
+          then: 
+            type: "any"
+            flags: 
+              presence: "required"
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
+            allow: 
+              - null
+    blockedReason: 
+      type: "string"
+      flags: 
+        description: "Open text field for describing reason for blocking this case from trial."
+      rules: 
+        - 
+          name: "min"
+          args: 
+            limit: 1
+        - 
+          name: "max"
+          args: 
+            limit: 250
+      metas: 
+        - 
+          tags: 
+            - "Restricted"
+      whens: 
+        - 
+          ref: 
+            path: 
+              - "blocked"
+          is: 
+            type: "any"
+            flags: 
+              only: true
+              presence: "required"
+            allow: 
+              - 
+                override: true
+              - true
+          then: 
+            type: "any"
+            flags: 
+              presence: "required"
+          otherwise: 
+            type: "any"
+            flags: 
+              presence: "optional"
+            allow: 
+              - null
     closedDate: 
       type: "date"
       flags: 

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -415,7 +415,7 @@ Case.VALIDATION_RULES = {
     .when('status', {
       is: CASE_STATUS_TYPES.calendared,
       otherwise: joi.optional(),
-      then: joi.valid(false),
+      then: joi.invalid(true),
     })
     .description(
       'Temporarily blocked from trial due to a pending item or due date.',
@@ -444,7 +444,7 @@ Case.VALIDATION_RULES = {
     .when('status', {
       is: CASE_STATUS_TYPES.calendared,
       otherwise: joi.optional(),
-      then: joi.valid(false),
+      then: joi.invalid(true),
     })
     .description('Temporarily blocked from trial.'),
   blockedDate: JoiValidationConstants.ISO_DATE.when('blocked', {

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -412,6 +412,11 @@ Case.VALIDATION_RULES = {
   automaticBlocked: joi
     .boolean()
     .optional()
+    .when('status', {
+      is: CASE_STATUS_TYPES.calendared,
+      otherwise: joi.optional(),
+      then: joi.optional().valid(false),
+    })
     .description(
       'Temporarily blocked from trial due to a pending item or due date.',
     ),
@@ -436,6 +441,11 @@ Case.VALIDATION_RULES = {
     .boolean()
     .optional()
     .meta({ tags: ['Restricted'] })
+    .when('status', {
+      is: CASE_STATUS_TYPES.calendared,
+      otherwise: joi.optional(),
+      then: joi.optional().valid(false),
+    })
     .description('Temporarily blocked from trial.'),
   blockedDate: JoiValidationConstants.ISO_DATE.when('blocked', {
     is: true,

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -415,7 +415,7 @@ Case.VALIDATION_RULES = {
     .when('status', {
       is: CASE_STATUS_TYPES.calendared,
       otherwise: joi.optional(),
-      then: joi.optional().valid(false),
+      then: joi.valid(false),
     })
     .description(
       'Temporarily blocked from trial due to a pending item or due date.',
@@ -444,7 +444,7 @@ Case.VALIDATION_RULES = {
     .when('status', {
       is: CASE_STATUS_TYPES.calendared,
       otherwise: joi.optional(),
-      then: joi.optional().valid(false),
+      then: joi.valid(false),
     })
     .description('Temporarily blocked from trial.'),
   blockedDate: JoiValidationConstants.ISO_DATE.when('blocked', {

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -4070,6 +4070,90 @@ describe('Case entity', () => {
         expect(myCase.getFormattedValidationErrors()).toEqual(null);
       });
     });
+
+    describe('blocked/automatic blocked status validation for calendared cases', () => {
+      const mockTrialSessionId = '9e29b116-58a0-40f5-afe6-e3a0ba4f226a';
+
+      it('fails validation when the case status is calendared and automaticBlocked is true', () => {
+        let blockedCalendaredCase = {
+          ...MOCK_CASE,
+          automaticBlocked: true,
+          automaticBlockedDate: '2019-03-01T21:42:29.073Z',
+          automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+          status: CASE_STATUS_TYPES.calendared,
+          trialSessionId: mockTrialSessionId,
+        };
+        const myCase = new Case(blockedCalendaredCase, { applicationContext });
+        expect(myCase.getFormattedValidationErrors()).toEqual({
+          automaticBlocked: '"automaticBlocked" must be [false]',
+        });
+      });
+
+      it('fails validation when the case status is calendared and blocked is true', () => {
+        let blockedCalendaredCase = {
+          ...MOCK_CASE,
+          blocked: true,
+          blockedDate: '2019-03-01T21:42:29.073Z',
+          blockedReason: 'A reason',
+          status: CASE_STATUS_TYPES.calendared,
+          trialSessionId: mockTrialSessionId,
+        };
+        const myCase = new Case(blockedCalendaredCase, { applicationContext });
+        expect(myCase.getFormattedValidationErrors()).toEqual({
+          blocked: '"blocked" must be [false]',
+        });
+      });
+
+      it('passes validation when the case status is calendared and automaticBlocked is false', () => {
+        let calendaredCase = {
+          ...MOCK_CASE,
+          automaticBlocked: false,
+          status: CASE_STATUS_TYPES.calendared,
+          trialSessionId: mockTrialSessionId,
+        };
+        const myCase = new Case(calendaredCase, { applicationContext });
+        expect(myCase.getFormattedValidationErrors()).toBe(null);
+      });
+
+      it('passes validation when the case status is calendared and blocked is false', () => {
+        let calendaredCase = {
+          ...MOCK_CASE,
+          blocked: false,
+          status: CASE_STATUS_TYPES.calendared,
+          trialSessionId: mockTrialSessionId,
+        };
+        const myCase = new Case(calendaredCase, { applicationContext });
+        expect(myCase.getFormattedValidationErrors()).toBe(null);
+      });
+
+      it('passes validation when the case status is not calendared and automaticBlocked is true', () => {
+        let blockedNewCase = {
+          ...MOCK_CASE,
+          automaticBlocked: true,
+          automaticBlockedDate: '2019-03-01T21:42:29.073Z',
+          automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+          status: CASE_STATUS_TYPES.new,
+          trialSessionId: mockTrialSessionId,
+        };
+        const myCase = new Case(blockedNewCase, { applicationContext });
+        expect(myCase.getFormattedValidationErrors()).toBe(null);
+      });
+
+      it('passes validation when the case status is not calendared and blocked is true', () => {
+        let blockedReadyForTrialCase = {
+          ...MOCK_CASE,
+          blocked: true,
+          blockedDate: '2019-03-01T21:42:29.073Z',
+          blockedReason: 'A reason',
+          status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+          trialSessionId: mockTrialSessionId,
+        };
+        const myCase = new Case(blockedReadyForTrialCase, {
+          applicationContext,
+        });
+        expect(myCase.getFormattedValidationErrors()).toBe(null);
+      });
+    });
   });
 
   describe('hasPartyWithPaperService', () => {

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -4070,89 +4070,102 @@ describe('Case entity', () => {
         expect(myCase.getFormattedValidationErrors()).toEqual(null);
       });
     });
+  });
 
-    describe('blocked/automatic blocked status validation for calendared cases', () => {
-      const mockTrialSessionId = '9e29b116-58a0-40f5-afe6-e3a0ba4f226a';
+  describe('blocked/automatic blocked status validation for calendared cases', () => {
+    const mockTrialSessionId = '9e29b116-58a0-40f5-afe6-e3a0ba4f226a';
 
-      it('fails validation when the case status is calendared and automaticBlocked is true', () => {
-        let blockedCalendaredCase = {
-          ...MOCK_CASE,
-          automaticBlocked: true,
-          automaticBlockedDate: '2019-03-01T21:42:29.073Z',
-          automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
-          status: CASE_STATUS_TYPES.calendared,
-          trialSessionId: mockTrialSessionId,
-        };
-        const myCase = new Case(blockedCalendaredCase, { applicationContext });
-        expect(myCase.getFormattedValidationErrors()).toEqual({
-          automaticBlocked: '"automaticBlocked" must be [false]',
-        });
+    it('fails validation when the case status is calendared and automaticBlocked is true', () => {
+      let blockedCalendaredCase = {
+        ...MOCK_CASE,
+        automaticBlocked: true,
+        automaticBlockedDate: '2019-03-01T21:42:29.073Z',
+        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+        status: CASE_STATUS_TYPES.calendared,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(blockedCalendaredCase, { applicationContext });
+      expect(myCase.getFormattedValidationErrors()).toEqual({
+        automaticBlocked: '"automaticBlocked" contains an invalid value',
       });
+    });
 
-      it('fails validation when the case status is calendared and blocked is true', () => {
-        let blockedCalendaredCase = {
-          ...MOCK_CASE,
-          blocked: true,
-          blockedDate: '2019-03-01T21:42:29.073Z',
-          blockedReason: 'A reason',
-          status: CASE_STATUS_TYPES.calendared,
-          trialSessionId: mockTrialSessionId,
-        };
-        const myCase = new Case(blockedCalendaredCase, { applicationContext });
-        expect(myCase.getFormattedValidationErrors()).toEqual({
-          blocked: '"blocked" must be [false]',
-        });
-      });
+    it('passes validation when the case status is calendared and automaticBlocked is undefined', () => {
+      let blockedCalendaredCase = {
+        ...MOCK_CASE,
+        automaticBlocked: undefined,
+        automaticBlockedDate: '2019-03-01T21:42:29.073Z',
+        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+        status: CASE_STATUS_TYPES.calendared,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(blockedCalendaredCase, { applicationContext });
+      expect(myCase.getFormattedValidationErrors()).toBe(null);
+    });
 
-      it('passes validation when the case status is calendared and automaticBlocked is false', () => {
-        let calendaredCase = {
-          ...MOCK_CASE,
-          automaticBlocked: false,
-          status: CASE_STATUS_TYPES.calendared,
-          trialSessionId: mockTrialSessionId,
-        };
-        const myCase = new Case(calendaredCase, { applicationContext });
-        expect(myCase.getFormattedValidationErrors()).toBe(null);
+    it('fails validation when the case status is calendared and blocked is true', () => {
+      let blockedCalendaredCase = {
+        ...MOCK_CASE,
+        blocked: true,
+        blockedDate: '2019-03-01T21:42:29.073Z',
+        blockedReason: 'A reason',
+        status: CASE_STATUS_TYPES.calendared,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(blockedCalendaredCase, { applicationContext });
+      expect(myCase.getFormattedValidationErrors()).toEqual({
+        blocked: '"blocked" contains an invalid value',
       });
+    });
 
-      it('passes validation when the case status is calendared and blocked is false', () => {
-        let calendaredCase = {
-          ...MOCK_CASE,
-          blocked: false,
-          status: CASE_STATUS_TYPES.calendared,
-          trialSessionId: mockTrialSessionId,
-        };
-        const myCase = new Case(calendaredCase, { applicationContext });
-        expect(myCase.getFormattedValidationErrors()).toBe(null);
-      });
+    it('passes validation when the case status is calendared and automaticBlocked is false', () => {
+      let calendaredCase = {
+        ...MOCK_CASE,
+        automaticBlocked: false,
+        status: CASE_STATUS_TYPES.calendared,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(calendaredCase, { applicationContext });
+      expect(myCase.getFormattedValidationErrors()).toBe(null);
+    });
 
-      it('passes validation when the case status is not calendared and automaticBlocked is true', () => {
-        let blockedNewCase = {
-          ...MOCK_CASE,
-          automaticBlocked: true,
-          automaticBlockedDate: '2019-03-01T21:42:29.073Z',
-          automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
-          status: CASE_STATUS_TYPES.new,
-          trialSessionId: mockTrialSessionId,
-        };
-        const myCase = new Case(blockedNewCase, { applicationContext });
-        expect(myCase.getFormattedValidationErrors()).toBe(null);
-      });
+    it('passes validation when the case status is calendared and blocked is false', () => {
+      let calendaredCase = {
+        ...MOCK_CASE,
+        blocked: false,
+        status: CASE_STATUS_TYPES.calendared,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(calendaredCase, { applicationContext });
+      expect(myCase.getFormattedValidationErrors()).toBe(null);
+    });
 
-      it('passes validation when the case status is not calendared and blocked is true', () => {
-        let blockedReadyForTrialCase = {
-          ...MOCK_CASE,
-          blocked: true,
-          blockedDate: '2019-03-01T21:42:29.073Z',
-          blockedReason: 'A reason',
-          status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
-          trialSessionId: mockTrialSessionId,
-        };
-        const myCase = new Case(blockedReadyForTrialCase, {
-          applicationContext,
-        });
-        expect(myCase.getFormattedValidationErrors()).toBe(null);
+    it('passes validation when the case status is not calendared and automaticBlocked is true', () => {
+      let blockedNewCase = {
+        ...MOCK_CASE,
+        automaticBlocked: true,
+        automaticBlockedDate: '2019-03-01T21:42:29.073Z',
+        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+        status: CASE_STATUS_TYPES.new,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(blockedNewCase, { applicationContext });
+      expect(myCase.getFormattedValidationErrors()).toBe(null);
+    });
+
+    it('passes validation when the case status is not calendared and blocked is true', () => {
+      let blockedReadyForTrialCase = {
+        ...MOCK_CASE,
+        blocked: true,
+        blockedDate: '2019-03-01T21:42:29.073Z',
+        blockedReason: 'A reason',
+        status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+        trialSessionId: mockTrialSessionId,
+      };
+      const myCase = new Case(blockedReadyForTrialCase, {
+        applicationContext,
       });
+      expect(myCase.getFormattedValidationErrors()).toBe(null);
     });
   });
 

--- a/web-api/migration-terraform/main/lambdas/migration-segments.js
+++ b/web-api/migration-terraform/main/lambdas/migration-segments.js
@@ -18,6 +18,9 @@ const {
 const {
   migrateItems: migration0006,
 } = require('./migrations/0006-eservice-indicator-has-eaccess');
+const {
+  migrateItems: migration0007,
+} = require('./migrations/0007-unblock-migrated-calendared-cases');
 const { chunk, isEmpty } = require('lodash');
 
 const MAX_DYNAMO_WRITE_SIZE = 25;
@@ -44,6 +47,7 @@ const migrateRecords = async ({ documentClient, items }) => {
   items = await migration0004(items, documentClient);
   items = await migration0005(items, documentClient);
   items = await migration0006(items, documentClient);
+  items = await migration0007(items, documentClient);
 
   return items;
 };

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.js
@@ -1,4 +1,3 @@
-const cloneDeep = require('lodash');
 const createApplicationContext = require('../../../../src/applicationContext');
 const {
   aggregateCaseItems,
@@ -9,6 +8,7 @@ const {
 const {
   CASE_STATUS_TYPES,
 } = require('../../../../../shared/src/business/entities/EntityConstants');
+const { cloneDeep } = require('lodash');
 const applicationContext = createApplicationContext({});
 
 const migrateItems = async (items, documentClient) => {
@@ -38,25 +38,21 @@ const migrateItems = async (items, documentClient) => {
 
       const caseRecord = aggregateCaseItems(fullCase);
       const itemToModify = cloneDeep(item);
-      console.log('....', itemToModify.automaticBlocked);
 
       if (itemToModify.automaticBlocked) {
-        console.log('....222');
-        itemToModify.automaticBlocked = false;
-        console.log(itemToModify.automaticBlocked);
-        delete itemToModify.automaticBlockedDate;
-        console.log('wtf?????', itemToModify.automaticBlocked);
-        delete itemToModify.automaticBlockedReason;
+        itemToModify.automaticBlocked = undefined;
+        itemToModify.automaticBlockedDate = undefined;
+        itemToModify.automaticBlockedReason = undefined;
       }
 
       if (itemToModify.blocked) {
-        itemToModify.blocked = false;
-        delete itemToModify.blockedDate;
-        delete itemToModify.blockedReason;
+        itemToModify.blocked = undefined;
+        itemToModify.blockedDate = undefined;
+        itemToModify.blockedReason = undefined;
       }
 
       new Case(
-        { ...itemToModify, ...caseRecord },
+        { ...caseRecord, ...itemToModify },
         {
           applicationContext,
         },

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.js
@@ -1,0 +1,68 @@
+const createApplicationContext = require('../../../../src/applicationContext');
+const {
+  aggregateCaseItems,
+} = require('../../../../../shared/src/persistence/dynamo/helpers/aggregateCaseItems');
+const {
+  Case,
+} = require('../../../../../shared/src/business/entities/cases/Case');
+const {
+  CASE_STATUS_TYPES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+
+const applicationContext = createApplicationContext({});
+
+const migrateItems = async (items, documentClient) => {
+  const itemsAfter = [];
+  for (const item of items) {
+    if (
+      item.pk.includes('case|') &&
+      item.sk.includes('case|') &&
+      item.status === CASE_STATUS_TYPES.calendared &&
+      (item.automaticBlocked || item.blocked)
+    ) {
+      const fullCase = await documentClient
+        .query({
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+          },
+          ExpressionAttributeValues: {
+            ':pk': `case|${item.docketNumber}`,
+          },
+          KeyConditionExpression: '#pk = :pk',
+          TableName: process.env.SOURCE_TABLE,
+        })
+        .promise()
+        .then(res => {
+          return res.Items;
+        });
+
+      const caseRecord = aggregateCaseItems(fullCase);
+
+      if (caseRecord.automaticBlocked) {
+        delete caseRecord.automaticBlocked;
+        delete caseRecord.automaticBlockedDate;
+        delete caseRecord.automaticBlockedReason;
+      }
+
+      if (caseRecord.blocked) {
+        delete caseRecord.blocked;
+        delete caseRecord.blockedDate;
+        delete caseRecord.blockedReason;
+      }
+
+      new Case(
+        { ...caseRecord, ...item },
+        {
+          applicationContext,
+        },
+      ).validate();
+
+      itemsAfter.push(item);
+    } else {
+      itemsAfter.push(item);
+    }
+  }
+  return itemsAfter;
+};
+
+exports.migrateItems = migrateItems;

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.js
@@ -1,3 +1,4 @@
+const cloneDeep = require('lodash');
 const createApplicationContext = require('../../../../src/applicationContext');
 const {
   aggregateCaseItems,
@@ -8,7 +9,6 @@ const {
 const {
   CASE_STATUS_TYPES,
 } = require('../../../../../shared/src/business/entities/EntityConstants');
-
 const applicationContext = createApplicationContext({});
 
 const migrateItems = async (items, documentClient) => {
@@ -37,27 +37,32 @@ const migrateItems = async (items, documentClient) => {
         });
 
       const caseRecord = aggregateCaseItems(fullCase);
+      const itemToModify = cloneDeep(item);
+      console.log('....', itemToModify.automaticBlocked);
 
-      if (caseRecord.automaticBlocked) {
-        delete caseRecord.automaticBlocked;
-        delete caseRecord.automaticBlockedDate;
-        delete caseRecord.automaticBlockedReason;
+      if (itemToModify.automaticBlocked) {
+        console.log('....222');
+        itemToModify.automaticBlocked = false;
+        console.log(itemToModify.automaticBlocked);
+        delete itemToModify.automaticBlockedDate;
+        console.log('wtf?????', itemToModify.automaticBlocked);
+        delete itemToModify.automaticBlockedReason;
       }
 
-      if (caseRecord.blocked) {
-        delete caseRecord.blocked;
-        delete caseRecord.blockedDate;
-        delete caseRecord.blockedReason;
+      if (itemToModify.blocked) {
+        itemToModify.blocked = false;
+        delete itemToModify.blockedDate;
+        delete itemToModify.blockedReason;
       }
 
       new Case(
-        { ...caseRecord, ...item },
+        { ...itemToModify, ...caseRecord },
         {
           applicationContext,
         },
       ).validate();
 
-      itemsAfter.push(item);
+      itemsAfter.push(itemToModify);
     } else {
       itemsAfter.push(item);
     }

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.test.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-unblock-migrated-calendared-cases.test.js
@@ -1,0 +1,249 @@
+const {
+  AUTOMATIC_BLOCKED_REASONS,
+  CASE_STATUS_TYPES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+const { migrateItems } = require('./0007-unblock-migrated-calendared-cases');
+const { MOCK_CASE } = require('../../../../../shared/src/test/mockCase');
+
+describe('migrateItems', () => {
+  const mockTrialSessionId = '7c48bc45-7838-4cf0-a059-0a21e5e4d473';
+  const docketEntryWithPendingAndLegacyServed = {
+    archived: false,
+    docketEntryId: '83b77e98-4cf6-4fb4-b8c0-f5f90fd68f3c',
+    documentType: 'Answer',
+    eventCode: 'A',
+    filedBy: 'Test Petitioner',
+    isLegacyServed: true,
+    pending: true,
+    pk: 'case|123-20',
+    sk: 'docket-entry|124',
+    userId: '8bbfcd5a-b02b-4983-8e9c-6cc50d3d566c',
+  };
+
+  let mockCaseItem;
+  let mockCaseRecords;
+  let mockEligibleForTrialItem;
+  let documentClient;
+
+  beforeEach(() => {
+    mockCaseItem = {
+      ...MOCK_CASE,
+      pk: 'case|999-99',
+      sk: 'case|999-99',
+    };
+    mockCaseRecords = [
+      mockCaseItem,
+      {
+        archived: false,
+        docketEntryId: '83b77e98-4cf6-4fb4-b8c0-f5f90fd68f3c',
+        documentType: 'Answer',
+        eventCode: 'A',
+        filedBy: 'Test Petitioner',
+        pk: 'case|123-20',
+        sk: 'docket-entry|124',
+        userId: '8bbfcd5a-b02b-4983-8e9c-6cc50d3d566c',
+      },
+    ];
+
+    documentClient = {
+      query: () => ({
+        promise: async () => ({
+          Items: [],
+        }),
+      }),
+    };
+  });
+
+  it('should return and not modify records that are NOT a case', async () => {
+    const items = [
+      {
+        pk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+        sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          pk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+          sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+        },
+      ]),
+    );
+  });
+
+  it('should return and not modify case records that are not calendared', async () => {
+    const items = [
+      {
+        pk: 'case|999-99',
+        sk: 'case|999-99',
+        status: CASE_STATUS_TYPES.new,
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          pk: 'case|999-99',
+          sk: 'case|999-99',
+          status: CASE_STATUS_TYPES.new,
+        },
+      ]),
+    );
+  });
+
+  it('should return and not modify case records that are calendared but not blocked or automatic blocked', async () => {
+    const items = [
+      {
+        automaticBlocked: false,
+        blocked: false,
+        pk: 'case|999-99',
+        sk: 'case|999-99',
+        status: CASE_STATUS_TYPES.calendared,
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          automaticBlocked: false,
+          blocked: false,
+          pk: 'case|999-99',
+          sk: 'case|999-99',
+          status: CASE_STATUS_TYPES.calendared,
+        },
+      ]),
+    );
+  });
+
+  it('should unset automaticBlocked, automaticBlockedReason and automaticBlockedDate on case records that are calendared and automaticBlocked', async () => {
+    mockCaseItem.automaticBlocked = true;
+    mockCaseItem.automaticBlockedDate = '2019-03-01T21:42:29.073Z';
+    mockCaseItem.automaticBlockedReason = AUTOMATIC_BLOCKED_REASONS.pending;
+    mockCaseItem.status = CASE_STATUS_TYPES.calendared;
+    mockCaseItem.trialSessionId = mockTrialSessionId;
+
+    documentClient.query = jest.fn().mockReturnValueOnce({
+      promise: async () => ({
+        Items: mockCaseRecords,
+      }),
+    });
+
+    const results = await migrateItems([mockCaseItem], documentClient);
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          automaticBlocked: false,
+          automaticBlockedDate: undefined,
+          automaticBlockedReason: undefined,
+          blocked: false,
+          pk: 'case|999-99',
+          sk: 'case|999-99',
+          status: CASE_STATUS_TYPES.calendared,
+        },
+      ]),
+    );
+  });
+
+  describe('automaticBlockedReason', () => {
+    it.skip('should be pendingAndDueDate when the case record is already blocked for dueDate', async () => {
+      mockCaseItem.automaticBlockedReason = AUTOMATIC_BLOCKED_REASONS.dueDate;
+      mockCaseRecords.push(docketEntryWithPendingAndLegacyServed);
+
+      documentClient.query = jest.fn().mockReturnValueOnce({
+        promise: async () => ({
+          Items: mockCaseRecords,
+        }),
+      });
+
+      const results = await migrateItems([mockCaseItem], documentClient);
+
+      expect(results).toEqual([
+        {
+          ...mockCaseItem,
+          automaticBlocked: true,
+          automaticBlockedDate: expect.anything(),
+          automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pendingAndDueDate,
+        },
+      ]);
+    });
+
+    it.skip('should be pending when the case record is not already blocked for any reason', async () => {
+      mockCaseRecords.push(docketEntryWithPendingAndLegacyServed);
+
+      documentClient.query = jest.fn().mockReturnValueOnce({
+        promise: async () => ({
+          Items: mockCaseRecords,
+        }),
+      });
+
+      const results = await migrateItems([mockCaseItem], documentClient);
+
+      expect(results).toMatchObject([
+        {
+          automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+        },
+      ]);
+    });
+  });
+
+  it.skip('should validate the modified case record', async () => {
+    documentClient.query = jest.fn().mockReturnValueOnce({
+      promise: async () => ({
+        Items: [
+          mockCaseRecords[1],
+          { ...mockCaseRecords[0], docketNumber: undefined },
+          docketEntryWithPendingAndLegacyServed,
+        ],
+      }),
+    });
+
+    await expect(
+      migrateItems(
+        [{ ...mockCaseItem, docketNumber: undefined }],
+        documentClient,
+      ),
+    ).rejects.toThrow('The Case entity was invalid.');
+  });
+
+  describe('eligible for trial records', () => {
+    it.skip('should return and not modify eligible for trial records for cases that do not have any docket entries that are both pending and isLegacyServed', async () => {
+      documentClient.query = jest.fn().mockReturnValueOnce({
+        promise: async () => ({
+          Items: mockCaseRecords,
+        }),
+      });
+
+      const results = await migrateItems(
+        [mockEligibleForTrialItem],
+        documentClient,
+      );
+
+      expect(results).toEqual([mockEligibleForTrialItem]);
+    });
+
+    it.skip('should NOT return eligible for trial records for cases that have docket entries that are pending and isLegacyServe', async () => {
+      mockCaseRecords.push(docketEntryWithPendingAndLegacyServed);
+
+      documentClient.query = jest.fn().mockReturnValueOnce({
+        promise: async () => ({
+          Items: mockCaseRecords,
+        }),
+      });
+
+      const results = await migrateItems(
+        [mockEligibleForTrialItem],
+        documentClient,
+      );
+
+      expect(results).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
@matthopson @codyseibert Looks like 7219 will be fixed after the migration script written in this PR runs on prod, as no case that is `Calendared` will be able to be blocked. 