### PR TITLE
7261: imposing 25em max-width on case title

### DIFF
--- a/web-client/src/styles/tables.scss
+++ b/web-client/src/styles/tables.scss
@@ -246,7 +246,7 @@ table.work-queue {
       max-width: 7rem;
     }
 
-    &.message-queue-document {
+    &.max-width-25 {
       max-width: 25rem;
     }
 

--- a/web-client/src/views/Messages/MessagesIndividualInbox.jsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.jsx
@@ -50,7 +50,7 @@ export const MessagesIndividualInbox = connect(
                       />
                     )}
                   </td>
-                  <td className="message-queue-row message-queue-document message-subject">
+                  <td className="message-queue-row message-subject">
                     <div className="message-document-title">
                       <Button
                         link
@@ -65,7 +65,9 @@ export const MessagesIndividualInbox = connect(
                       {message.message}
                     </div>
                   </td>
-                  <td className="message-queue-row">{message.caseTitle}</td>
+                  <td className="message-queue-row max-width-25">
+                    {message.caseTitle}
+                  </td>
                   <td className="message-queue-row">{message.caseStatus}</td>
                   <td className="message-queue-row from">{message.from}</td>
                   <td className="message-queue-row small">

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.jsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.jsx
@@ -35,7 +35,7 @@ export const MessagesIndividualOutbox = connect(
                       {message.createdAtFormatted}
                     </span>
                   </td>
-                  <td className="message-queue-row message-queue-document message-subject">
+                  <td className="message-queue-row message-subject">
                     <div className="message-document-title">
                       <Button
                         link
@@ -50,7 +50,9 @@ export const MessagesIndividualOutbox = connect(
                       {message.message}
                     </div>
                   </td>
-                  <td className="message-queue-row">{message.caseTitle}</td>
+                  <td className="message-queue-row max-width-25">
+                    {message.caseTitle}
+                  </td>
                   <td className="message-queue-row">{message.caseStatus}</td>
                   <td className="message-queue-row to">{message.to}</td>
                   <td className="message-queue-row small">

--- a/web-client/src/views/Messages/MessagesSectionInbox.jsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.jsx
@@ -36,7 +36,7 @@ export const MessagesSectionInbox = connect(
                       {message.createdAtFormatted}
                     </span>
                   </td>
-                  <td className="message-queue-row message-queue-document message-subject">
+                  <td className="message-queue-row message-subject">
                     <div className="message-document-title">
                       <Button
                         link
@@ -50,7 +50,9 @@ export const MessagesSectionInbox = connect(
                       {message.message}
                     </div>
                   </td>
-                  <td className="message-queue-row">{message.caseTitle}</td>
+                  <td className="message-queue-row max-width-25">
+                    {message.caseTitle}
+                  </td>
                   <td className="message-queue-row">{message.caseStatus}</td>
                   <td className="message-queue-row to">{message.to}</td>
                   <td className="message-queue-row from">{message.from}</td>

--- a/web-client/src/views/Messages/MessagesSectionOutbox.jsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.jsx
@@ -36,7 +36,7 @@ export const MessagesSectionOutbox = connect(
                       {message.createdAtFormatted}
                     </span>
                   </td>
-                  <td className="message-queue-row message-queue-document message-subject">
+                  <td className="message-queue-row message-subject">
                     <div className="message-document-title">
                       <Button
                         link
@@ -51,7 +51,9 @@ export const MessagesSectionOutbox = connect(
                       {message.message}
                     </div>
                   </td>
-                  <td className="message-queue-row">{message.caseTitle}</td>
+                  <td className="message-queue-row max-width-25">
+                    {message.caseTitle}
+                  </td>
                   <td className="message-queue-row">{message.caseStatus}</td>
                   <td className="message-queue-row to">{message.to}</td>
                   <td className="message-queue-row from">{message.from}</td>

--- a/web-client/src/views/WorkQueue/IndividualWorkQueueInProgress.jsx
+++ b/web-client/src/views/WorkQueue/IndividualWorkQueueInProgress.jsx
@@ -46,7 +46,7 @@ export const IndividualWorkQueueInProgress = connect(
                   <td className="message-queue-row message-queue-case-title">
                     {item.caseTitle}
                   </td>
-                  <td className="message-queue-row message-queue-document">
+                  <td className="message-queue-row max-width-25">
                     <div className="message-document-title">
                       <a className="case-link" href={item.editLink}>
                         {item.docketEntry.documentTitle ||

--- a/web-client/src/views/WorkQueue/IndividualWorkQueueInbox.jsx
+++ b/web-client/src/views/WorkQueue/IndividualWorkQueueInbox.jsx
@@ -64,7 +64,7 @@ export const IndividualWorkQueueInbox = connect(
                       />
                     )}
                   </td>
-                  <td className="message-queue-row message-queue-document">
+                  <td className="message-queue-row max-width-25">
                     <div className="message-document-title">
                       <a
                         className={

--- a/web-client/src/views/WorkQueue/SectionWorkQueueInProgress.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueInProgress.jsx
@@ -49,7 +49,7 @@ const SectionWorkQueueInProgressRow = React.memo(
           <td className="message-queue-row message-queue-case-title">
             {item.caseTitle}
           </td>
-          <td className="message-queue-row message-queue-document">
+          <td className="message-queue-row max-width-25">
             <div className="message-document-title">
               <a className="case-link" href={item.editLink}>
                 {item.docketEntry.documentTitle ||

--- a/web-client/src/views/WorkQueue/SectionWorkQueueInbox.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueInbox.jsx
@@ -124,7 +124,7 @@ SectionWorkQueueTable.Row = React.memo(
               )}
             </td>
           )}
-          <td className="message-queue-row message-queue-document">
+          <td className="message-queue-row max-width-25">
             <div className="message-document-title">
               <a className="case-link" href={item.editLink}>
                 {item.docketEntry.descriptionDisplay}


### PR DESCRIPTION
ustaxcourt/ef-cms#7547 
Lifting a `max-width: 25em` rule on the message column, instead allowing it to grow to `35em`. Instead imposting `max-width: 25em` on case title column.

![Screen Shot 2020-12-07 at 4 47 24 PM](https://user-images.githubusercontent.com/2445917/101414573-f40d2f80-38ab-11eb-842e-0345647f5fd9.png)
