### PR TITLE
7217: wrap header menu items

### DIFF
--- a/web-client/src/styles/nav.scss
+++ b/web-client/src/styles/nav.scss
@@ -171,6 +171,13 @@
         margin-bottom: 0.5rem;
       }
 
+      .ustc-navigation-items {
+        display: block;
+        .usa-nav__primary-item:not(.nav-medium) {
+          display: inline-block;
+        }
+      }
+
       .usa-nav__primary-item {
         .usa-current::after,
         .usa-nav__link::after {


### PR DESCRIPTION
ustaxcourt/ef-cms#7528 
for screens over 1024 whose menus are very long (e.g. judge)
Examples of what this looks like for a screen at 1024px, and also at 800px below.
![Screen Shot 2020-12-08 at 3 27 31 PM](https://user-images.githubusercontent.com/2445917/101544148-d357df00-396a-11eb-95d9-9dd20de49329.png)
![Screen Shot 2020-12-08 at 3 27 54 PM](https://user-images.githubusercontent.com/2445917/101544165-d783fc80-396a-11eb-985b-acd661af5e6e.png)
