### PR TITLE
7320: prevent weird event-bubbling

### DIFF
--- a/web-client/src/views/StartCase/Address.jsx
+++ b/web-client/src/views/StartCase/Address.jsx
@@ -238,8 +238,8 @@ export const Address = connect(
           />
         </div>
 
-        <NonMobileCityAndState />
-        <MobileCityAndState />
+        {NonMobileCityAndState()}
+        {MobileCityAndState()}
 
         <FormGroup
           errorText={


### PR DESCRIPTION
#7230 : city field in address inputs would immediately lose focus on keypress, making input very difficult.

Rendering component segments as actual react native made for some very odd event-bubbling that caused the address fields to re-render and blur upon a single keypress when the city field was focused.

Rendering them as `{FuncName()}` instead of `<FuncName/>` seems to resolve it.  If you know why this happens, please let me know.