### PR TITLE
7287 Practitioner Service Indicator

### DIFF
--- a/shared/src/business/entities/IrsPractitioner.js
+++ b/shared/src/business/entities/IrsPractitioner.js
@@ -11,6 +11,7 @@ const {
   userDecorator,
   VALIDATION_ERROR_MESSAGES,
 } = require('./User');
+const { Practitioner } = require('./Practitioner');
 const { ROLES, SERVICE_INDICATOR_TYPES } = require('./EntityConstants');
 
 const entityName = 'IrsPractitioner';
@@ -29,7 +30,8 @@ IrsPractitioner.prototype.init = function init(rawUser) {
   userDecorator(this, rawUser);
   this.barNumber = rawUser.barNumber;
   this.serviceIndicator =
-    rawUser.serviceIndicator || SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
+    rawUser.serviceIndicator ||
+    Practitioner.getDefaultServiceIndicator(rawUser);
 };
 
 IrsPractitioner.validationName = 'IrsPractitioner';

--- a/shared/src/business/entities/IrsPractitioner.test.js
+++ b/shared/src/business/entities/IrsPractitioner.test.js
@@ -1,4 +1,9 @@
-const { COUNTRY_TYPES, ROLES } = require('./EntityConstants');
+const {
+  COUNTRY_TYPES,
+  ROLES,
+  SERVICE_INDICATOR_TYPES,
+  US_STATES,
+} = require('./EntityConstants');
 const { IrsPractitioner } = require('./IrsPractitioner');
 
 describe('IrsPractitioner', () => {
@@ -31,5 +36,103 @@ describe('IrsPractitioner', () => {
     });
 
     expect(user.isValid()).toBeFalsy();
+  });
+
+  it('should default the serviceIndicator to paper if the user does not have an email address and no serviceIndicator value is already set', () => {
+    const user = new IrsPractitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      employer: 'IRS',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual(SERVICE_INDICATOR_TYPES.SI_PAPER);
+  });
+
+  it('should default the serviceIndicator to electronic if the user does have an email address and no serviceIndicator value is already set', () => {
+    const user = new IrsPractitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      email: 'test.irs.practitioner@example.com',
+      employer: 'IRS',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
+  });
+
+  it('should default the serviceIndicator to the already existing serviceIndicator value if present', () => {
+    const user = new IrsPractitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      email: 'test.irs.practitioner@example.com',
+      employer: 'IRS',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      serviceIndicator: 'CARRIER_PIGEON',
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual('CARRIER_PIGEON');
   });
 });

--- a/shared/src/business/entities/Practitioner.js
+++ b/shared/src/business/entities/Practitioner.js
@@ -50,7 +50,8 @@ Practitioner.prototype.init = function init(rawUser) {
   this.section = this.role;
   this.suffix = rawUser.suffix;
   this.serviceIndicator =
-    rawUser.serviceIndicator || SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
+    rawUser.serviceIndicator ||
+    Practitioner.getDefaultServiceIndicator(rawUser);
   if (this.admissionsStatus === 'Active') {
     this.role = roleMap[this.employer];
   } else {
@@ -188,6 +189,18 @@ Practitioner.getFullName = function (practitionerData) {
   const suffix = practitionerData.suffix ? ' ' + practitionerData.suffix : '';
 
   return `${firstName}${middleName} ${lastName}${suffix}`;
+};
+
+/**
+ * returns a default service indicator based on whether the presence of an email address
+ *
+ * @param {object} practitionerData data where an email may exist
+ * @returns {string} the service indicator for the given condition
+ */
+Practitioner.getDefaultServiceIndicator = function (practitionerData) {
+  return practitionerData.email
+    ? SERVICE_INDICATOR_TYPES.SI_ELECTRONIC
+    : SERVICE_INDICATOR_TYPES.SI_PAPER;
 };
 
 module.exports = {

--- a/shared/src/business/entities/Practitioner.test.js
+++ b/shared/src/business/entities/Practitioner.test.js
@@ -1,4 +1,9 @@
-const { COUNTRY_TYPES, ROLES, US_STATES } = require('./EntityConstants');
+const {
+  COUNTRY_TYPES,
+  ROLES,
+  SERVICE_INDICATOR_TYPES,
+  US_STATES,
+} = require('./EntityConstants');
 const { Practitioner } = require('./Practitioner');
 
 describe('Practitioner', () => {
@@ -260,6 +265,104 @@ describe('Practitioner', () => {
     expect(user.name).toEqual('Test Middle Practitioner Sfx');
   });
 
+  it('should default the serviceIndicator to paper if the user does not have an email address and no serviceIndicator value is already set', () => {
+    const user = new Practitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      employer: 'Private',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual(SERVICE_INDICATOR_TYPES.SI_PAPER);
+  });
+
+  it('should default the serviceIndicator to electronic if the user does have an email address and no serviceIndicator value is already set', () => {
+    const user = new Practitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      email: 'test.practitioner@example.com',
+      employer: 'Private',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
+  });
+
+  it('should default the serviceIndicator to the already existing serviceIndicator value if present', () => {
+    const user = new Practitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      email: 'test.practitioner@example.com',
+      employer: 'Private',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      serviceIndicator: 'CARRIER_PIGEON',
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual('CARRIER_PIGEON');
+  });
+
   describe('getFullName', () => {
     let userData;
 
@@ -310,6 +413,22 @@ describe('Practitioner', () => {
       expect(Practitioner.getFullName(userData)).toEqual(
         'Test Foo Practitioner Bar',
       );
+    });
+  });
+
+  describe('getDefaultServiceIndicator', () => {
+    it('returns electronic when an email address is present in the given practitioner data', () => {
+      expect(
+        Practitioner.getDefaultServiceIndicator({
+          email: 'test.practitioner@example.com',
+        }),
+      ).toEqual(SERVICE_INDICATOR_TYPES.SI_ELECTRONIC);
+    });
+
+    it('returns paper when an email address is NOT present in the given practitioner data', () => {
+      expect(
+        Practitioner.getDefaultServiceIndicator({ email: undefined }),
+      ).toEqual(SERVICE_INDICATOR_TYPES.SI_PAPER);
     });
   });
 });

--- a/shared/src/business/entities/PrivatePractitioner.js
+++ b/shared/src/business/entities/PrivatePractitioner.js
@@ -6,6 +6,7 @@ const {
   joiValidationDecorator,
   validEntityDecorator,
 } = require('../../utilities/JoiValidationDecorator');
+const { Practitioner } = require('./Practitioner');
 const { ROLES } = require('./EntityConstants');
 const { SERVICE_INDICATOR_TYPES } = require('./EntityConstants');
 const { USER_CONTACT_VALIDATION_RULES, userDecorator } = require('./User');
@@ -28,7 +29,8 @@ PrivatePractitioner.prototype.init = function init(rawUser) {
   this.firmName = rawUser.firmName;
   this.representing = rawUser.representing || [];
   this.serviceIndicator =
-    rawUser.serviceIndicator || SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
+    rawUser.serviceIndicator ||
+    Practitioner.getDefaultServiceIndicator(rawUser);
 };
 
 PrivatePractitioner.validationName = 'PrivatePractitioner';

--- a/shared/src/business/entities/PrivatePractitioner.test.js
+++ b/shared/src/business/entities/PrivatePractitioner.test.js
@@ -1,4 +1,9 @@
-const { COUNTRY_TYPES, ROLES } = require('./EntityConstants');
+const {
+  COUNTRY_TYPES,
+  ROLES,
+  SERVICE_INDICATOR_TYPES,
+  US_STATES,
+} = require('./EntityConstants');
 const { PrivatePractitioner } = require('./PrivatePractitioner');
 
 describe('PrivatePractitioner', () => {
@@ -56,6 +61,104 @@ describe('PrivatePractitioner', () => {
 
     expect(user.firmName).toBe(mockFirmName);
     expect(user.isValid()).toBeTruthy();
+  });
+
+  it('should default the serviceIndicator to paper if the user does not have an email address and no serviceIndicator value is already set', () => {
+    const user = new PrivatePractitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      employer: 'Private',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual(SERVICE_INDICATOR_TYPES.SI_PAPER);
+  });
+
+  it('should default the serviceIndicator to electronic if the user does have an email address and no serviceIndicator value is already set', () => {
+    const user = new PrivatePractitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      email: 'test.private.practitioner@example.com',
+      employer: 'Private',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
+  });
+
+  it('should default the serviceIndicator to the already existing serviceIndicator value if present', () => {
+    const user = new PrivatePractitioner({
+      admissionsDate: '2019-03-01T21:40:46.415Z',
+      admissionsStatus: 'Active',
+      barNumber: 'PT20001',
+      birthYear: 2019,
+      contact: {
+        address1: '234 Main St',
+        address2: 'Apartment 4',
+        address3: 'Under the stairs',
+        city: 'Chicago',
+        country: 'Brazil',
+        countryType: COUNTRY_TYPES.INTERNATIONAL,
+        phone: '+1 (555) 555-5555',
+        postalCode: '61234',
+        state: 'IL',
+      },
+      email: 'test.private.practitioner@example.com',
+      employer: 'Private',
+      firmName: 'GW Law Offices',
+      firstName: 'Test',
+      lastName: 'Practitioner',
+      name: 'Test Practitioner',
+      originalBarState: US_STATES.IL,
+      practitionerType: 'Attorney',
+      role: ROLES.privatePractitioner,
+      serviceIndicator: 'CARRIER_PIGEON',
+      userId: 'ec4fe2e7-52cf-4084-84de-d8e8d151e927',
+    });
+
+    expect(user.serviceIndicator).toEqual('CARRIER_PIGEON');
   });
 
   describe('getRepresentingPrimary', () => {

--- a/shared/src/business/entities/caseAssociation/AddIrsPractitioner.js
+++ b/shared/src/business/entities/caseAssociation/AddIrsPractitioner.js
@@ -1,8 +1,12 @@
 const joi = require('joi');
 const {
+  JoiValidationConstants,
+} = require('../../../utilities/JoiValidationConstants');
+const {
   joiValidationDecorator,
   validEntityDecorator,
 } = require('../../../utilities/JoiValidationDecorator');
+const { SERVICE_INDICATOR_TYPES } = require('../EntityConstants');
 
 /**
  *
@@ -12,15 +16,38 @@ const {
 function AddIrsPractitioner() {}
 AddIrsPractitioner.prototype.init = function init(rawProps) {
   Object.assign(this, {
+    email: rawProps.user?.email,
+    serviceIndicator: rawProps.serviceIndicator,
     user: rawProps.user,
   });
 };
 
 AddIrsPractitioner.VALIDATION_ERROR_MESSAGES = {
+  serviceIndicator: [
+    {
+      contains: 'must be one of',
+      message:
+        'No email found for electronic service. Select a valid service preference.',
+    },
+    'Select service type',
+  ],
   user: 'Select a respondent counsel',
 };
 
 AddIrsPractitioner.schema = joi.object().keys({
+  email: joi.optional(),
+  serviceIndicator: joi
+    .when('email', {
+      is: joi.exist().not(null),
+      otherwise: JoiValidationConstants.STRING.valid(
+        SERVICE_INDICATOR_TYPES.SI_NONE,
+        SERVICE_INDICATOR_TYPES.SI_PAPER,
+      ),
+      then: JoiValidationConstants.STRING.valid(
+        ...Object.values(SERVICE_INDICATOR_TYPES),
+      ),
+    })
+    .required(),
   user: joi.object().required(),
 });
 

--- a/shared/src/business/entities/caseAssociation/AddIrsPractitioner.test.js
+++ b/shared/src/business/entities/caseAssociation/AddIrsPractitioner.test.js
@@ -1,19 +1,34 @@
 const { AddIrsPractitioner } = require('./AddIrsPractitioner');
+const { SERVICE_INDICATOR_TYPES } = require('../EntityConstants');
+
+const errorMessages = AddIrsPractitioner.VALIDATION_ERROR_MESSAGES;
 
 describe('AddIrsPractitioner', () => {
   describe('validation', () => {
     it('should have error messages for missing fields', () => {
       const entity = new AddIrsPractitioner({});
       expect(entity.getFormattedValidationErrors()).toEqual({
+        serviceIndicator: errorMessages.serviceIndicator[1],
         user: AddIrsPractitioner.VALIDATION_ERROR_MESSAGES.user,
       });
     });
 
     it('should be valid when all fields are present', () => {
       const entity = new AddIrsPractitioner({
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
         user: { userId: '02323349-87fe-4d29-91fe-8dd6916d2fda' },
       });
       expect(entity.getFormattedValidationErrors()).toEqual(null);
+    });
+  });
+
+  it('should not be valid if no email is given and the service preference is electronic', () => {
+    const entity = new AddIrsPractitioner({
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+      user: { userId: '02323349-87fe-4d29-91fe-8dd6916d2fda' },
+    });
+    expect(entity.getFormattedValidationErrors()).toEqual({
+      serviceIndicator: errorMessages.serviceIndicator[0].message,
     });
   });
 });

--- a/shared/src/business/entities/caseAssociation/AddPrivatePractitionerFactory.test.js
+++ b/shared/src/business/entities/caseAssociation/AddPrivatePractitionerFactory.test.js
@@ -1,6 +1,7 @@
 const {
   AddPrivatePractitionerFactory,
 } = require('./AddPrivatePractitionerFactory');
+const { SERVICE_INDICATOR_TYPES } = require('../EntityConstants');
 
 const errorMessages = AddPrivatePractitionerFactory.VALIDATION_ERROR_MESSAGES;
 
@@ -10,6 +11,7 @@ describe('AddPrivatePractitionerFactory', () => {
       const entity = AddPrivatePractitionerFactory.get({});
       expect(entity.getFormattedValidationErrors()).toEqual({
         representingPrimary: errorMessages.representingPrimary,
+        serviceIndicator: errorMessages.serviceIndicator[1],
         user: errorMessages.user,
       });
     });
@@ -17,6 +19,7 @@ describe('AddPrivatePractitionerFactory', () => {
     it('should be valid when all fields are present', () => {
       const entity = AddPrivatePractitionerFactory.get({
         representingPrimary: true,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
         user: { userId: '02323349-87fe-4d29-91fe-8dd6916d2fda' },
       });
       expect(entity.getFormattedValidationErrors()).toEqual(null);
@@ -25,10 +28,22 @@ describe('AddPrivatePractitionerFactory', () => {
     it('should not be valid if representingPrimary is false and representingSecondary is not present', () => {
       const entity = AddPrivatePractitionerFactory.get({
         representingPrimary: false,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
         user: { userId: '02323349-87fe-4d29-91fe-8dd6916d2fda' },
       });
       expect(entity.getFormattedValidationErrors()).toEqual({
         representingPrimary: errorMessages.representingPrimary,
+      });
+    });
+
+    it('should not be valid if no email is given and the service preference is electronic', () => {
+      const entity = AddPrivatePractitionerFactory.get({
+        representingPrimary: true,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        user: { userId: '02323349-87fe-4d29-91fe-8dd6916d2fda' },
+      });
+      expect(entity.getFormattedValidationErrors()).toEqual({
+        serviceIndicator: errorMessages.serviceIndicator[0].message,
       });
     });
   });

--- a/shared/src/business/useCases/caseAssociation/validateAddIrsPractitionerInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociation/validateAddIrsPractitionerInteractor.test.js
@@ -7,6 +7,7 @@ const {
 const {
   validateAddIrsPractitionerInteractor,
 } = require('./validateAddIrsPractitionerInteractor');
+const { SERVICE_INDICATOR_TYPES } = require('../../entities/EntityConstants');
 
 describe('validateAddIrsPractitionerInteractor', () => {
   it('returns the expected errors object on an empty add irsPractitioner', () => {
@@ -23,7 +24,10 @@ describe('validateAddIrsPractitionerInteractor', () => {
   it('returns null when no errors occur', () => {
     const errors = validateAddIrsPractitionerInteractor({
       applicationContext,
-      counsel: { representingPrimary: true, user: {} },
+      counsel: {
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+        user: {},
+      },
     });
 
     expect(errors).toEqual(null);

--- a/shared/src/business/useCases/caseAssociation/validateAddPrivatePractitionerInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociation/validateAddPrivatePractitionerInteractor.test.js
@@ -4,6 +4,7 @@ const {
 const {
   validateAddPrivatePractitionerInteractor,
 } = require('./validateAddPrivatePractitionerInteractor');
+const { SERVICE_INDICATOR_TYPES } = require('../../entities/EntityConstants');
 
 describe('validateAddPrivatePractitionerInteractor', () => {
   it('returns the expected errors object on an empty add practitioner', () => {
@@ -12,13 +13,21 @@ describe('validateAddPrivatePractitionerInteractor', () => {
       counsel: {},
     });
 
-    expect(Object.keys(errors)).toEqual(['user', 'representingPrimary']);
+    expect(Object.keys(errors)).toEqual([
+      'serviceIndicator',
+      'user',
+      'representingPrimary',
+    ]);
   });
 
   it('returns null when no errors occur', () => {
     const errors = validateAddPrivatePractitionerInteractor({
       applicationContext,
-      counsel: { representingPrimary: true, user: {} },
+      counsel: {
+        representingPrimary: true,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+        user: {},
+      },
     });
 
     expect(errors).toEqual(null);

--- a/shared/src/business/useCases/practitioners/getPractitionerByBarNumberInteractor.test.js
+++ b/shared/src/business/useCases/practitioners/getPractitionerByBarNumberInteractor.test.js
@@ -4,7 +4,11 @@ const {
 const {
   getPractitionerByBarNumberInteractor,
 } = require('./getPractitionerByBarNumberInteractor');
-const { ROLES, US_STATES } = require('../../entities/EntityConstants');
+const {
+  ROLES,
+  SERVICE_INDICATOR_TYPES,
+  US_STATES,
+} = require('../../entities/EntityConstants');
 const { User } = require('../../entities/User');
 
 describe('getPractitionerByBarNumberInteractor', () => {
@@ -80,7 +84,7 @@ describe('getPractitionerByBarNumberInteractor', () => {
       practitionerType: 'Attorney',
       role: ROLES.privatePractitioner,
       section: ROLES.privatePractitioner,
-      serviceIndicator: 'Electronic',
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
       suffix: undefined,
       token: undefined,
       userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
@@ -139,7 +143,7 @@ describe('getPractitionerByBarNumberInteractor', () => {
       practitionerType: 'Attorney',
       role: ROLES.privatePractitioner,
       section: 'irsPractitioner',
-      serviceIndicator: 'Electronic',
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
       suffix: undefined,
       token: undefined,
       userId: '6805d1ab-18d0-43ec-bafb-654e83405416',

--- a/web-client/integration-tests/admissionsClerkPractitionerJourney.test.js
+++ b/web-client/integration-tests/admissionsClerkPractitionerJourney.test.js
@@ -1,3 +1,4 @@
+import { admissionsClerVerifiesPractitionerServiceIndicator } from './journey/admissionsClerVerifiesPractitionerServiceIndicator';
 import { admissionsClerkAddsNewPractitioner } from './journey/admissionsClerkAddsNewPractitioner';
 import { admissionsClerkAddsPractitionerEmail } from './journey/admissionsClerkAddsPractitionerEmail';
 import { admissionsClerkEditsPractitionerInfo } from './journey/admissionsClerkEditsPractitionerInfo';
@@ -17,7 +18,11 @@ import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCase
 const test = setupTest();
 
 describe('admissions clerk practitioner journey', () => {
-  const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
+  const {
+    COUNTRY_TYPES,
+    PARTY_TYPES,
+    SERVICE_INDICATOR_TYPES,
+  } = applicationContext.getConstants();
 
   beforeAll(() => {
     jest.setTimeout(30000);
@@ -73,6 +78,10 @@ describe('admissions clerk practitioner journey', () => {
 
   loginAs(test, 'admissionsclerk@example.com');
   admissionsClerkMigratesPractitionerWithoutEmail(test);
+  admissionsClerVerifiesPractitionerServiceIndicator(
+    test,
+    SERVICE_INDICATOR_TYPES.SI_PAPER,
+  );
 
   loginAs(test, 'petitionsclerk@example.com');
   petitionsClerkViewsCaseDetail(test);
@@ -84,4 +93,8 @@ describe('admissions clerk practitioner journey', () => {
 
   loginAs(test, 'admissionsclerk@example.com');
   admissionsClerkAddsPractitionerEmail(test);
+  admissionsClerVerifiesPractitionerServiceIndicator(
+    test,
+    SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+  );
 });

--- a/web-client/integration-tests/journey/admissionsClerVerifiesPractitionerServiceIndicator.js
+++ b/web-client/integration-tests/journey/admissionsClerVerifiesPractitionerServiceIndicator.js
@@ -1,0 +1,14 @@
+export const admissionsClerVerifiesPractitionerServiceIndicator = (
+  test,
+  expectedServiceIndicator,
+) => {
+  return it('admissions clerk verifies practitioner service preference', async () => {
+    await test.runSequence('gotoPractitionerDetailSequence', {
+      barNumber: test.barNumber,
+    });
+
+    expect(test.getState('practitionerDetail').serviceIndicator).toEqual(
+      expectedServiceIndicator,
+    );
+  });
+};

--- a/web-client/integration-tests/journey/petitionsClerkAddsPractitionersToCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkAddsPractitionersToCase.js
@@ -46,6 +46,10 @@ export const petitionsClerkAddsPractitionersToCase = (test, skipSecondary) => {
       value: true,
     });
 
+    expect(
+      test.getState('validationErrors.practitionerSearchError'),
+    ).toBeUndefined();
+
     await test.runSequence('associatePrivatePractitionerWithCaseSequence');
 
     expect(test.getState('caseDetail.privatePractitioners.length')).toEqual(1);

--- a/web-client/src/presenter/actions/getDefaultServiceIndicatorForPractitionerMatchesAction.js
+++ b/web-client/src/presenter/actions/getDefaultServiceIndicatorForPractitionerMatchesAction.js
@@ -1,0 +1,37 @@
+import { state } from 'cerebral';
+
+/**
+ * gets the default serviceIndicator for the selected practitioner
+ *
+ * @param {string} matchesKey the key on state.modal from where to fetch practitioners
+ * @returns {Function} the cerebral action
+ */
+export const getDefaultServiceIndicatorForPractitionerMatchesAction = matchesKey => {
+  /**
+   * @param {object} providers the providers object
+   * @param {object} providers.applicationContext the application context
+   * @param {object} providers.get the cerebral get method
+   * @returns {object} props object containing defaultServiceIndicator
+   */
+  return ({ applicationContext, get }) => {
+    const { SERVICE_INDICATOR_TYPES } = applicationContext.getConstants();
+    const matches = get(state.modal[matchesKey]);
+    const selectedPractitionerId = get(state.modal.user.userId);
+
+    let defaultStateForSelected = null;
+
+    if (matches && selectedPractitionerId) {
+      const selectedPractitioner = matches.find(
+        respondent => respondent.userId === selectedPractitionerId,
+      );
+
+      defaultStateForSelected = selectedPractitioner.email
+        ? SERVICE_INDICATOR_TYPES.SI_ELECTRONIC
+        : SERVICE_INDICATOR_TYPES.SI_PAPER;
+    }
+
+    return {
+      defaultServiceIndicator: defaultStateForSelected,
+    };
+  };
+};

--- a/web-client/src/presenter/actions/getDefaultServiceIndicatorForPractitionerMatchesAction.test.js
+++ b/web-client/src/presenter/actions/getDefaultServiceIndicatorForPractitionerMatchesAction.test.js
@@ -1,0 +1,119 @@
+import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
+import { getDefaultServiceIndicatorForPractitionerMatchesAction } from './getDefaultServiceIndicatorForPractitionerMatchesAction';
+import { presenter } from '../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('getDefaultServiceIndicatorForPractitionerMatchesAction', () => {
+  const { SERVICE_INDICATOR_TYPES } = applicationContext.getConstants();
+
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
+  it('returns electronic if the selected practitioner has an email address', async () => {
+    const result = await runAction(
+      getDefaultServiceIndicatorForPractitionerMatchesAction('practitioners'),
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          modal: {
+            practitioners: [
+              { email: 'test1@example.com', userId: '1' },
+              { email: 'test2@example.com', userId: '2' },
+              { userId: '3' },
+            ],
+            user: {
+              userId: '2',
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.output).toEqual({
+      defaultServiceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    });
+  });
+
+  it('returns paper if the selected practitioner does NOT have an email address', async () => {
+    const result = await runAction(
+      getDefaultServiceIndicatorForPractitionerMatchesAction('practitioners'),
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          modal: {
+            practitioners: [
+              { email: 'test1@example.com', userId: '1' },
+              { email: 'test2@example.com', userId: '2' },
+              { userId: '3' },
+            ],
+            user: {
+              userId: '3',
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.output).toEqual({
+      defaultServiceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+    });
+  });
+
+  it('returns null if there are no matches', async () => {
+    const result = await runAction(
+      getDefaultServiceIndicatorForPractitionerMatchesAction(
+        'definitely_not_a_match',
+      ),
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          modal: {
+            practitioners: [
+              { email: 'test1@example.com', userId: '1' },
+              { email: 'test2@example.com', userId: '2' },
+              { userId: '3' },
+            ],
+            user: {
+              userId: '1',
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.output).toEqual({
+      defaultServiceIndicator: null,
+    });
+  });
+  it('returns null if there is no selected practitioner', async () => {
+    const result = await runAction(
+      getDefaultServiceIndicatorForPractitionerMatchesAction('practitioners'),
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          modal: {
+            practitioners: [
+              { email: 'test1@example.com', userId: '1' },
+              { email: 'test2@example.com', userId: '2' },
+              { userId: '3' },
+            ],
+            user: {},
+          },
+        },
+      },
+    );
+
+    expect(result.output).toEqual({
+      defaultServiceIndicator: null,
+    });
+  });
+});

--- a/web-client/src/presenter/actions/setDefaultServiceIndicatorAction.js
+++ b/web-client/src/presenter/actions/setDefaultServiceIndicatorAction.js
@@ -12,11 +12,16 @@ export const setDefaultServiceIndicatorAction = key => {
    * @param {object} providers.applicationContext the application context
    * @param {object} providers.store the cerebral store used for setting the service indicator
    */
-  return ({ applicationContext, store }) => {
-    const { SERVICE_INDICATOR_TYPES } = applicationContext.getConstants();
-    store.set(
-      state[key].serviceIndicator,
-      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-    );
+  return ({ applicationContext, props, store }) => {
+    let serviceIndicator;
+
+    if (props.defaultServiceIndicator) {
+      serviceIndicator = props.defaultServiceIndicator;
+    } else {
+      const { SERVICE_INDICATOR_TYPES } = applicationContext.getConstants();
+      serviceIndicator = SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
+    }
+
+    store.set(state[key].serviceIndicator, serviceIndicator);
   };
 };

--- a/web-client/src/presenter/actions/setDefaultServiceIndicatorAction.test.js
+++ b/web-client/src/presenter/actions/setDefaultServiceIndicatorAction.test.js
@@ -10,7 +10,26 @@ describe('setDefaultServiceIndicatorAction', () => {
     presenter.providers.applicationContext = applicationContext;
   });
 
-  it('sets the default serviceIndicator for the key', async () => {
+  it('sets the default serviceIndicator to the props.defaultServiceIndicator for the given key', async () => {
+    const { state } = await runAction(
+      setDefaultServiceIndicatorAction('testKey'),
+      {
+        modules: {
+          presenter,
+        },
+        props: {
+          defaultServiceIndicator: 'foo',
+        },
+        state: {
+          testKey: null, // the key that will be set
+        },
+      },
+    );
+
+    expect(state['testKey'].serviceIndicator).toEqual('foo');
+  });
+
+  it('sets the default serviceIndicator to electronic for the given key if no props.defaultServiceIndicator is given', async () => {
     const { state } = await runAction(
       setDefaultServiceIndicatorAction('testKey'),
       {

--- a/web-client/src/presenter/computeds/caseDetailPractitionerSearchHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailPractitionerSearchHelper.js
@@ -32,16 +32,42 @@ export const caseDetailPractitionerSearchHelper = get => {
     });
   }
 
+  const practitionerSearchResultsCount =
+    modalState &&
+    modalState.practitionerMatches &&
+    modalState.practitionerMatches.length;
+
+  const respondentSearchResultsCount =
+    modalState &&
+    modalState.respondentMatches &&
+    modalState.respondentMatches.length;
+
+  let showOnePractitioner = false;
+  let showMultiplePractitioners = false;
+
+  if (practitionerSearchResultsCount === 1) {
+    showOnePractitioner = true;
+  } else if (practitionerSearchResultsCount > 1) {
+    showMultiplePractitioners = true;
+  }
+
+  let showOneRespondent = false;
+  let showMultipleRespondents = false;
+
+  if (respondentSearchResultsCount === 1) {
+    showOneRespondent = true;
+  } else if (respondentSearchResultsCount > 1) {
+    showMultipleRespondents = true;
+  }
+
   return {
     practitionerMatchesFormatted,
-    practitionerSearchResultsCount:
-      modalState &&
-      modalState.practitionerMatches &&
-      modalState.practitionerMatches.length,
+    practitionerSearchResultsCount,
     respondentMatchesFormatted,
-    respondentSearchResultsCount:
-      modalState &&
-      modalState.respondentMatches &&
-      modalState.respondentMatches.length,
+    respondentSearchResultsCount,
+    showMultiplePractitioners,
+    showMultipleRespondents,
+    showOnePractitioner,
+    showOneRespondent,
   };
 };

--- a/web-client/src/presenter/computeds/caseDetailPractitionerSearchHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailPractitionerSearchHelper.test.js
@@ -211,4 +211,112 @@ describe('caseDetailPractitionerSearchHelper', () => {
     });
     expect(result.respondentSearchResultsCount).toBeUndefined();
   });
+
+  it('should return showMultiplePractitioners true and showOnePractitioner false if practitioner search results count is greater than one', () => {
+    const user = {
+      role: ROLES.privatePractitioner,
+      userId: '123',
+    };
+    const result = runCompute(caseDetailPractitionerSearchHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { docketEntries: [] },
+        form: {},
+        modal: { practitionerMatches: [{ name: '1' }, { name: '2' }] },
+      },
+    });
+
+    expect(result.showMultiplePractitioners).toEqual(true);
+    expect(result.showOnePractitioner).toEqual(false);
+  });
+
+  it('should return showOnePractitioner true and showMultiplePractitioners false if practitioner search results count is only one', () => {
+    const user = {
+      role: ROLES.privatePractitioner,
+      userId: '123',
+    };
+    const result = runCompute(caseDetailPractitionerSearchHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { docketEntries: [] },
+        form: {},
+        modal: { practitionerMatches: [{ name: '1' }] },
+      },
+    });
+
+    expect(result.showOnePractitioner).toEqual(true);
+    expect(result.showMultiplePractitioners).toEqual(false);
+  });
+
+  it('should return showOnePractitioner false and showMultiplePractitioners false if there are no practitioner search results', () => {
+    const user = {
+      role: ROLES.privatePractitioner,
+      userId: '123',
+    };
+    const result = runCompute(caseDetailPractitionerSearchHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { docketEntries: [] },
+        form: {},
+        modal: {},
+      },
+    });
+
+    expect(result.showOnePractitioner).toEqual(false);
+    expect(result.showMultiplePractitioners).toEqual(false);
+  });
+
+  it('should return showMultipleRespondents true and showOneRespondent false if respondent search results count is greater than one', () => {
+    const user = {
+      role: ROLES.privatePractitioner,
+      userId: '123',
+    };
+    const result = runCompute(caseDetailPractitionerSearchHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { docketEntries: [] },
+        form: {},
+        modal: { respondentMatches: [{ name: '1' }, { name: '2' }] },
+      },
+    });
+
+    expect(result.showMultipleRespondents).toEqual(true);
+    expect(result.showOneRespondent).toEqual(false);
+  });
+
+  it('should return showOneRespondent true and showMultipleRespondents false if respondent search results count is only one', () => {
+    const user = {
+      role: ROLES.privatePractitioner,
+      userId: '123',
+    };
+    const result = runCompute(caseDetailPractitionerSearchHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { docketEntries: [] },
+        form: {},
+        modal: { respondentMatches: [{ name: '1' }] },
+      },
+    });
+
+    expect(result.showOneRespondent).toEqual(true);
+    expect(result.showMultipleRespondents).toEqual(false);
+  });
+
+  it('should return showOneRespondent false and showMultipleRespondents false if there are no respondent search results', () => {
+    const user = {
+      role: ROLES.privatePractitioner,
+      userId: '123',
+    };
+    const result = runCompute(caseDetailPractitionerSearchHelper, {
+      state: {
+        ...getBaseState(user),
+        caseDetail: { docketEntries: [] },
+        form: {},
+        modal: {},
+      },
+    });
+
+    expect(result.showOneRespondent).toEqual(false);
+    expect(result.showMultipleRespondents).toEqual(false);
+  });
 });

--- a/web-client/src/presenter/sequences/openAddIrsPractitionerModalSequence.js
+++ b/web-client/src/presenter/sequences/openAddIrsPractitionerModalSequence.js
@@ -1,5 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
+import { getDefaultServiceIndicatorForPractitionerMatchesAction } from '../actions/getDefaultServiceIndicatorForPractitionerMatchesAction';
 import { getIrsPractitionersBySearchKeyAction } from '../actions/ManualAssociation/getIrsPractitionersBySearchKeyAction';
 import { isRespondentInCaseAction } from '../actions/isRespondentInCaseAction';
 import { setDefaultServiceIndicatorAction } from '../actions/setDefaultServiceIndicatorAction';
@@ -18,6 +19,10 @@ export const openAddIrsPractitionerModalSequence = showProgressSequenceDecorator
       error: [setValidationErrorsAction],
       success: [
         setRespondentsAction,
+        getDefaultServiceIndicatorForPractitionerMatchesAction(
+          'practitionerMatches',
+        ),
+        setDefaultServiceIndicatorAction('modal'),
         isRespondentInCaseAction,
         {
           no: [setShowModalFactoryAction('AddIrsPractitionerModal')],

--- a/web-client/src/presenter/sequences/openAddIrsPractitionerModalSequence.js
+++ b/web-client/src/presenter/sequences/openAddIrsPractitionerModalSequence.js
@@ -20,7 +20,7 @@ export const openAddIrsPractitionerModalSequence = showProgressSequenceDecorator
       success: [
         setRespondentsAction,
         getDefaultServiceIndicatorForPractitionerMatchesAction(
-          'practitionerMatches',
+          'respondentMatches',
         ),
         setDefaultServiceIndicatorAction('modal'),
         isRespondentInCaseAction,

--- a/web-client/src/presenter/sequences/openAddPrivatePractitionerModalSequence.js
+++ b/web-client/src/presenter/sequences/openAddPrivatePractitionerModalSequence.js
@@ -1,5 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
+import { getDefaultServiceIndicatorForPractitionerMatchesAction } from '../actions/getDefaultServiceIndicatorForPractitionerMatchesAction';
 import { getPrivatePractitionersBySearchKeyAction } from '../actions/ManualAssociation/getPrivatePractitionersBySearchKeyAction';
 import { isPractitionerInCaseAction } from '../actions/isPractitionerInCaseAction';
 import { setDefaultServiceIndicatorAction } from '../actions/setDefaultServiceIndicatorAction';
@@ -12,12 +13,15 @@ export const openAddPrivatePractitionerModalSequence = showProgressSequenceDecor
   [
     clearAlertsAction,
     clearModalStateAction,
-    setDefaultServiceIndicatorAction('modal'),
     getPrivatePractitionersBySearchKeyAction,
     {
       error: [setValidationErrorsAction],
       success: [
         setPractitionersAction,
+        getDefaultServiceIndicatorForPractitionerMatchesAction(
+          'practitionerMatches',
+        ),
+        setDefaultServiceIndicatorAction('modal'),
         isPractitionerInCaseAction,
         {
           no: [setShowModalFactoryAction('AddPrivatePractitionerModal')],

--- a/web-client/src/views/CaseDetail/AddIrsPractitionerModal.jsx
+++ b/web-client/src/views/CaseDetail/AddIrsPractitionerModal.jsx
@@ -45,8 +45,7 @@ export const AddIrsPractitionerModal = connect(
                 counsel match(es) found
               </legend>
 
-              {caseDetailPractitionerSearchHelper.respondentSearchResultsCount ===
-                1 && (
+              {caseDetailPractitionerSearchHelper.showOneRespondent && (
                 <span>
                   {
                     caseDetailPractitionerSearchHelper
@@ -66,8 +65,7 @@ export const AddIrsPractitionerModal = connect(
                 </span>
               )}
               <div className="respondent-matches">
-                {caseDetailPractitionerSearchHelper.respondentSearchResultsCount >
-                  1 &&
+                {caseDetailPractitionerSearchHelper.showMultipleRespondents &&
                   caseDetailPractitionerSearchHelper.respondentMatchesFormatted.map(
                     (counsel, idx) => (
                       <div

--- a/web-client/src/views/CaseDetail/AddPrivatePractitionerModal.jsx
+++ b/web-client/src/views/CaseDetail/AddPrivatePractitionerModal.jsx
@@ -47,8 +47,7 @@ export const AddPrivatePractitionerModal = connect(
                 Counsel match(es) found
               </legend>
 
-              {caseDetailPractitionerSearchHelper.practitionerSearchResultsCount ===
-                1 && (
+              {caseDetailPractitionerSearchHelper.showOnePractitioner && (
                 <span>
                   {
                     caseDetailPractitionerSearchHelper
@@ -68,8 +67,7 @@ export const AddPrivatePractitionerModal = connect(
                 </span>
               )}
               <div className="practitioner-matches">
-                {caseDetailPractitionerSearchHelper.practitionerSearchResultsCount >
-                  1 &&
+                {caseDetailPractitionerSearchHelper.showMultiplePractitioners &&
                   caseDetailPractitionerSearchHelper.practitionerMatchesFormatted.map(
                     (counsel, idx) => (
                       <div

--- a/web-client/src/views/ServiceIndicatorRadios.jsx
+++ b/web-client/src/views/ServiceIndicatorRadios.jsx
@@ -21,6 +21,13 @@ export const ServiceIndicatorRadios = connect(
     validateSequence,
     validationErrors,
   }) {
+    const selectElectronic =
+      bindObject.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
+    const selectPaper =
+      bindObject.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_PAPER;
+    const selectNone =
+      bindObject.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_NONE;
+
     return (
       <FormGroup
         className="margin-bottom-0"
@@ -40,10 +47,7 @@ export const ServiceIndicatorRadios = connect(
           <div className="usa-radio usa-radio__inline">
             <input
               aria-describedby={`service-type-radios-${bindKey}`}
-              checked={
-                bindObject.serviceIndicator ===
-                SERVICE_INDICATOR_TYPES.SI_ELECTRONIC
-              }
+              checked={selectElectronic}
               className="usa-radio__input"
               id={`service-type-electronic-${bindKey}`}
               name={`${bindKey}.serviceIndicator`}
@@ -68,9 +72,7 @@ export const ServiceIndicatorRadios = connect(
           <div className="usa-radio usa-radio__inline">
             <input
               aria-describedby={`service-type-radios-${bindKey}`}
-              checked={
-                bindObject.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_PAPER
-              }
+              checked={selectPaper}
               className="usa-radio__input"
               id={`service-type-paper-${bindKey}`}
               name={`${bindKey}.serviceIndicator`}
@@ -95,9 +97,7 @@ export const ServiceIndicatorRadios = connect(
           <div className="usa-radio usa-radio__inline">
             <input
               aria-describedby={`service-type-radios-${bindKey}`}
-              checked={
-                bindObject.serviceIndicator === SERVICE_INDICATOR_TYPES.SI_NONE
-              }
+              checked={selectNone}
               className="usa-radio__input"
               id={`service-type-none-${bindKey}`}
               name={`${bindKey}.serviceIndicator`}


### PR DESCRIPTION
In most cases a practitioner should have an email address and should automatically receive electronic service. This prevents a practitioner without an email address from getting electronic service by adding validation on the respective practitioner entities as well as defaulting the UI to the appropriate service type (electronic or paper) when being added to a case.