### PR TITLE
7287: Update aggregatePartiesForService to include petitioner contact

### DIFF
--- a/shared/src/business/utilities/aggregatePartiesForService.js
+++ b/shared/src/business/utilities/aggregatePartiesForService.js
@@ -37,6 +37,7 @@ const aggregatePartiesForService = caseEntity => {
     ) {
       aggregated.paper.push({
         ...party,
+        ...(party.contact || {}),
       });
     }
   });

--- a/shared/src/business/utilities/aggregatePartiesForService.test.js
+++ b/shared/src/business/utilities/aggregatePartiesForService.test.js
@@ -4,6 +4,10 @@ const { SERVICE_INDICATOR_TYPES } = require('../entities/EntityConstants');
 describe('aggregatePartiesForService', () => {
   let mockCase;
   let irsPractitioners;
+  let privatePractitioners;
+
+  let irsPractitionerWithPaper;
+  let privatePractitionerWithPaper;
 
   const PRIMARY_CONTACT_ID = 'c344c39f-6086-484b-998c-e93e9c7dcff5';
   const SECONDARY_CONTACT_ID = '09ecdf10-359c-4694-a5a8-d15d56796ce1';
@@ -23,6 +27,24 @@ describe('aggregatePartiesForService', () => {
       state: 'CA',
     };
 
+    irsPractitionerWithPaper = {
+      contact: {
+        address1: '123 IRS Way',
+        address2: null,
+        address3: null,
+        city: 'Washington',
+        country: undefined,
+        countryType: 'domestic',
+        phone: '1234567890',
+        postalCode: '48839',
+        state: 'DC',
+      },
+      name: 'Respondent Three',
+      representing: [],
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+      userId: 'r3',
+    };
+
     irsPractitioners = [
       {
         email: 'respondentone@example.com',
@@ -34,9 +56,28 @@ describe('aggregatePartiesForService', () => {
         name: 'Respondent Two',
         serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
       },
+      irsPractitionerWithPaper,
     ];
 
-    const privatePractitioners = [
+    privatePractitionerWithPaper = {
+      contact: {
+        address1: 'Suite 111 1st Floor',
+        address2: '123 Main Street',
+        address3: null,
+        city: 'Somewhere',
+        country: undefined,
+        countryType: 'domestic',
+        phone: '1234567890',
+        postalCode: '48839',
+        state: 'TN',
+      },
+      name: 'Practitioner Three',
+      representing: [],
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+      userId: 'p3',
+    };
+
+    privatePractitioners = [
       {
         email: 'practitionerone@example.com',
         name: 'Practitioner One',
@@ -51,6 +92,7 @@ describe('aggregatePartiesForService', () => {
         serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
         userId: 'p2',
       },
+      privatePractitionerWithPaper,
     ];
 
     mockCase = {
@@ -78,6 +120,11 @@ describe('aggregatePartiesForService', () => {
           name: 'Contact Secondary',
           state: 'CA',
         },
+        {
+          ...privatePractitionerWithPaper,
+          ...privatePractitionerWithPaper.contact,
+        },
+        { ...irsPractitionerWithPaper, ...irsPractitionerWithPaper.contact },
       ],
       electronic: [
         { email: 'practitionerone@example.com', name: 'Practitioner One' },
@@ -93,6 +140,11 @@ describe('aggregatePartiesForService', () => {
           name: 'Contact Secondary',
           state: 'CA',
         },
+        {
+          ...privatePractitionerWithPaper,
+          ...privatePractitionerWithPaper.contact,
+        },
+        { ...irsPractitionerWithPaper, ...irsPractitionerWithPaper.contact },
       ],
     });
   });
@@ -113,6 +165,11 @@ describe('aggregatePartiesForService', () => {
           name: 'Contact Secondary',
           state: 'CA',
         },
+        {
+          ...privatePractitionerWithPaper,
+          ...privatePractitionerWithPaper.contact,
+        },
+        { ...irsPractitionerWithPaper, ...irsPractitionerWithPaper.contact },
       ],
       electronic: [
         { email: 'contactprimary@example.com', name: 'Contact Primary' },
@@ -128,6 +185,11 @@ describe('aggregatePartiesForService', () => {
           name: 'Contact Secondary',
           state: 'CA',
         },
+        {
+          ...privatePractitionerWithPaper,
+          ...privatePractitionerWithPaper.contact,
+        },
+        { ...irsPractitionerWithPaper, ...irsPractitionerWithPaper.contact },
       ],
     });
   });
@@ -148,6 +210,11 @@ describe('aggregatePartiesForService', () => {
           name: 'Contact Secondary',
           state: 'CA',
         },
+        {
+          ...privatePractitionerWithPaper,
+          ...privatePractitionerWithPaper.contact,
+        },
+        { ...irsPractitionerWithPaper, ...irsPractitionerWithPaper.contact },
       ],
       electronic: [
         { email: 'practitionerone@example.com', name: 'Practitioner One' },
@@ -162,14 +229,44 @@ describe('aggregatePartiesForService', () => {
           name: 'Contact Secondary',
           state: 'CA',
         },
+        {
+          ...privatePractitionerWithPaper,
+          ...privatePractitionerWithPaper.contact,
+        },
+        { ...irsPractitionerWithPaper, ...irsPractitionerWithPaper.contact },
       ],
     });
   });
 
-  it('should serve all irsPractitioners electronically', async () => {
-    mockCase.privatePractitioners = [];
+  it('should serve all practitioners with an email address electronically', async () => {
     const result = aggregatePartiesForService(mockCase);
 
-    expect(result.electronic.length).toEqual(irsPractitioners.length + 1);
+    const foundPrivatePractitionerWithPaper = result.electronic.find(
+      user => user.userId === privatePractitionerWithPaper.userId,
+    );
+
+    const foundIrsPractitionerWithPaper = result.electronic.find(
+      user => user.userId === irsPractitionerWithPaper.userId,
+    );
+
+    expect(result.electronic.length).toEqual(5);
+    expect(foundPrivatePractitionerWithPaper).toBeFalsy();
+    expect(foundIrsPractitionerWithPaper).toBeFalsy();
+  });
+
+  it('should serve all practitioners without an email address by paper', async () => {
+    const result = aggregatePartiesForService(mockCase);
+
+    const foundPrivatePractitionerWithPaper = result.paper.find(
+      user => user.userId === privatePractitionerWithPaper.userId,
+    );
+
+    const foundIrsPractitionerWithPaper = result.paper.find(
+      user => user.userId === irsPractitionerWithPaper.userId,
+    );
+
+    expect(result.paper.length).toEqual(3);
+    expect(foundPrivatePractitionerWithPaper).toBeTruthy();
+    expect(foundIrsPractitionerWithPaper).toBeTruthy();
   });
 });


### PR DESCRIPTION
<img width="398" alt="Screen Shot 2021-01-15 at 3 16 08 PM" src="https://user-images.githubusercontent.com/1891789/104784039-a3a7ae00-5744-11eb-8126-9e0f39dc94b0.png">

Address issue with petitioner contact info not displaying in paper service label.