### PR TITLE
Devex 851: replacing more persistence calls with use-case helper

### DIFF
--- a/shared/src/business/useCases/caseConsolidation/addConsolidatedCaseInteractor.js
+++ b/shared/src/business/useCases/caseConsolidation/addConsolidatedCaseInteractor.js
@@ -86,9 +86,9 @@ exports.addConsolidatedCaseInteractor = async ({
     caseEntity.setLeadCase(newLeadCase.docketNumber);
 
     updateCasePromises.push(
-      applicationContext.getPersistenceGateway().updateCase({
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
         applicationContext,
-        caseToUpdate: caseEntity.validate().toRawObject(),
+        caseToUpdate: caseEntity,
       }),
     );
   });

--- a/shared/src/business/useCases/caseConsolidation/removeConsolidatedCasesInteractor.js
+++ b/shared/src/business/useCases/caseConsolidation/removeConsolidatedCasesInteractor.js
@@ -62,9 +62,9 @@ exports.removeConsolidatedCasesInteractor = async ({
       caseEntity.setLeadCase(newLeadCase.docketNumber);
 
       updateCasePromises.push(
-        applicationContext.getPersistenceGateway().updateCase({
+        applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
           applicationContext,
-          caseToUpdate: caseEntity.validate().toRawObject(),
+          caseToUpdate: caseEntity,
         }),
       );
     }
@@ -75,9 +75,9 @@ exports.removeConsolidatedCasesInteractor = async ({
     caseEntity.removeConsolidation();
 
     updateCasePromises.push(
-      applicationContext.getPersistenceGateway().updateCase({
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
         applicationContext,
-        caseToUpdate: caseEntity.validate().toRawObject(),
+        caseToUpdate: caseEntity,
       }),
     );
   }
@@ -100,9 +100,9 @@ exports.removeConsolidatedCasesInteractor = async ({
     caseEntity.removeConsolidation();
 
     updateCasePromises.push(
-      applicationContext.getPersistenceGateway().updateCase({
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
         applicationContext,
-        caseToUpdate: caseEntity.validate().toRawObject(),
+        caseToUpdate: caseEntity,
       }),
     );
   }

--- a/shared/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.js
+++ b/shared/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.js
@@ -51,9 +51,9 @@ exports.createCaseDeadlineInteractor = async ({
       caseEntity,
     });
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    caseToUpdate: caseEntity,
   });
 
   return newCaseDeadline;

--- a/shared/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.js
+++ b/shared/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.js
@@ -44,10 +44,11 @@ exports.deleteCaseDeadlineInteractor = async ({
       caseEntity: updatedCase,
     });
 
-  const updatedCaseRaw = updatedCase.validate().toRawObject();
-  await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: updatedCaseRaw,
-  });
-  return updatedCaseRaw;
+  const result = await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociations({
+      applicationContext,
+      caseToUpdate: updatedCase,
+    });
+  return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/caseNote/deleteCaseNoteInteractor.js
+++ b/shared/src/business/useCases/caseNote/deleteCaseNoteInteractor.js
@@ -30,15 +30,12 @@ exports.deleteCaseNoteInteractor = async ({
     });
 
   delete caseRecord.caseNote;
-  const caseToUpdate = new Case(caseRecord, {
-    applicationContext,
-  })
-    .validate()
-    .toRawObject();
 
-  const result = await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate,
-  });
+  const result = await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociations({
+      applicationContext,
+      caseToUpdate: caseRecord,
+    });
   return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/caseNote/saveCaseNoteInteractor.js
+++ b/shared/src/business/useCases/caseNote/saveCaseNoteInteractor.js
@@ -40,10 +40,12 @@ exports.saveCaseNoteInteractor = async ({
     .validate()
     .toRawObject();
 
-  const result = await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate,
-  });
+  const result = await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociations({
+      applicationContext,
+      caseToUpdate,
+    });
 
   return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/correspondence/archiveCorrespondenceDocumentInteractor.js
+++ b/shared/src/business/useCases/correspondence/archiveCorrespondenceDocumentInteractor.js
@@ -34,14 +34,16 @@ exports.archiveCorrespondenceDocumentInteractor = async ({
     applicationContext,
   });
 
-  await applicationContext.getPersistenceGateway().updateCaseCorrespondence({
-    applicationContext,
-    correspondence: correspondenceToArchive,
-    docketNumber,
-  });
+  await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociationsCorrespondence({
+      applicationContext,
+      correspondence: correspondenceToArchive,
+      docketNumber,
+    });
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    caseToUpdate: caseEntity,
   });
 };

--- a/shared/src/business/useCases/correspondence/archiveCorrespondenceDocumentInteractor.js
+++ b/shared/src/business/useCases/correspondence/archiveCorrespondenceDocumentInteractor.js
@@ -34,13 +34,11 @@ exports.archiveCorrespondenceDocumentInteractor = async ({
     applicationContext,
   });
 
-  await applicationContext
-    .getUseCaseHelpers()
-    .updateCaseAndAssociationsCorrespondence({
-      applicationContext,
-      correspondence: correspondenceToArchive,
-      docketNumber,
-    });
+  await applicationContext.getUseCaseHelpers().updateCaseCorrespondence({
+    applicationContext,
+    correspondence: correspondenceToArchive,
+    docketNumber,
+  });
 
   await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,

--- a/shared/src/business/useCases/correspondence/archiveCorrespondenceDocumentInteractor.js
+++ b/shared/src/business/useCases/correspondence/archiveCorrespondenceDocumentInteractor.js
@@ -34,7 +34,7 @@ exports.archiveCorrespondenceDocumentInteractor = async ({
     applicationContext,
   });
 
-  await applicationContext.getUseCaseHelpers().updateCaseCorrespondence({
+  await applicationContext.getPersistenceGateway().updateCaseCorrespondence({
     applicationContext,
     correspondence: correspondenceToArchive,
     docketNumber,

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.js
@@ -249,9 +249,9 @@ exports.fileAndServeCourtIssuedDocumentInteractor = async ({
     }
   }
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    caseToUpdate: caseEntity,
   });
 
   await applicationContext.getUseCaseHelpers().sendServedPartiesEmails({

--- a/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
@@ -209,9 +209,9 @@ exports.serveCourtIssuedDocumentInteractor = async ({
     }
   }
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    caseToUpdate: caseEntity,
   });
 
   await applicationContext.getUseCaseHelpers().sendServedPartiesEmails({

--- a/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.js
@@ -114,9 +114,9 @@ exports.fileCourtIssuedOrderInteractor = async ({
 
   caseEntity.addDocketEntry(docketEntryEntity);
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    caseToUpdate: caseEntity,
   });
 
   if (documentMetadata.parentMessageId) {

--- a/shared/src/business/useCases/courtIssuedOrder/updateCourtIssuedOrderInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/updateCourtIssuedOrderInteractor.js
@@ -128,5 +128,5 @@ exports.updateCourtIssuedOrderInteractor = async ({
       caseToUpdate: caseEntity,
     });
 
-  new Case(result, { applicationContext }).validate().toRawObject();
+  return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/courtIssuedOrder/updateCourtIssuedOrderInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/updateCourtIssuedOrderInteractor.js
@@ -121,10 +121,12 @@ exports.updateCourtIssuedOrderInteractor = async ({
 
   caseEntity.updateDocketEntry(docketEntryEntity);
 
-  await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const result = await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociations({
+      applicationContext,
+      caseToUpdate: caseEntity,
+    });
 
-  return caseEntity.toRawObject();
+  new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.js
@@ -133,30 +133,31 @@ exports.fileCourtIssuedDocketEntryInteractor = async ({
   });
 
   const saveItems = [
-    applicationContext.getPersistenceGateway().updateCase({
+    applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
       applicationContext,
-      caseToUpdate: caseEntity.validate().toRawObject(),
+      caseToUpdate: caseEntity,
     }),
   ];
 
+  const rawValidWorkItem = workItem.validate().toRawObject();
   if (isUnservable) {
     saveItems.push(
       applicationContext.getPersistenceGateway().putWorkItemInUsersOutbox({
         applicationContext,
         section: user.section,
         userId: user.userId,
-        workItem: workItem.validate().toRawObject(),
+        workItem: rawValidWorkItem,
       }),
     );
   } else {
     saveItems.push(
       applicationContext.getPersistenceGateway().createUserInboxRecord({
         applicationContext,
-        workItem: workItem.validate().toRawObject(),
+        workItem: rawValidWorkItem,
       }),
       applicationContext.getPersistenceGateway().createSectionInboxRecord({
         applicationContext,
-        workItem: workItem.validate().toRawObject(),
+        workItem: rawValidWorkItem,
       }),
     );
   }

--- a/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
@@ -171,9 +171,9 @@ exports.fileDocketEntryInteractor = async ({
       caseEntity,
     });
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    caseToUpdate: caseEntity,
   });
 
   const workItemsSaved = [];

--- a/shared/src/business/useCases/docketEntry/updateCourtIssuedDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateCourtIssuedDocketEntryInteractor.js
@@ -96,18 +96,20 @@ exports.updateCourtIssuedDocketEntryInteractor = async ({
 
   docketEntryEntity.setWorkItem(workItem);
 
+  const rawValidWorkItem = workItem.validate().toRawObject();
+
   const saveItems = [
     applicationContext.getPersistenceGateway().createUserInboxRecord({
       applicationContext,
-      workItem: workItem.validate().toRawObject(),
+      workItem: rawValidWorkItem,
     }),
     applicationContext.getPersistenceGateway().createSectionInboxRecord({
       applicationContext,
-      workItem: workItem.validate().toRawObject(),
+      workItem: rawValidWorkItem,
     }),
-    applicationContext.getPersistenceGateway().updateCase({
+    applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
       applicationContext,
-      caseToUpdate: caseEntity.validate().toRawObject(),
+      caseToUpdate: caseEntity,
     }),
   ];
 

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryInteractor.js
@@ -245,10 +245,12 @@ exports.updateDocketEntryInteractor = async ({
 
   caseEntity.updateDocketEntry(docketEntryEntity);
 
-  await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const result = await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociations({
+      applicationContext,
+      caseToUpdate: caseEntity,
+    });
 
-  return caseEntity.toRawObject();
+  new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryInteractor.js
@@ -252,5 +252,5 @@ exports.updateDocketEntryInteractor = async ({
       caseToUpdate: caseEntity,
     });
 
-  new Case(result, { applicationContext }).validate().toRawObject();
+  return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
@@ -163,10 +163,12 @@ exports.updateDocketEntryMetaInteractor = async ({
     });
   }
 
-  await applicationContext.getPersistenceGateway().updateCase({
-    applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
-  });
+  const result = await applicationContext
+    .getUseCaseHelpers()
+    .updateCaseAndAssociations({
+      applicationContext,
+      caseToUpdate: caseEntity,
+    });
 
-  return caseEntity.toRawObject();
+  return new Case(result, { applicationContext }).validate().toRawObject();
 };

--- a/shared/src/business/useCases/migrateCaseInteractor.js
+++ b/shared/src/business/useCases/migrateCaseInteractor.js
@@ -305,7 +305,7 @@ exports.migrateCaseInteractor = async ({
   // which will link the cases together in DynamoDB
   if (caseToAdd.leadDocketNumber) {
     applicationContext.logger.debug('update case again');
-    await applicationContext.getPersistenceGateway().updateCase({
+    await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
       applicationContext,
       caseToUpdate: caseValidatedRaw,
     });


### PR DESCRIPTION
Chipping away.  Currently the use-case helper is a nearly-transparent wrapper directly to the persistence method.  Once all calls are converted, we can start refactoring the helper/persistence relationship.