### PR TITLE
DevEx - Fix the ability to re-seed dynamo without restarting the api

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "print:success": "echo 'Build successful. You can access the site at http://localhost:1234'",
     "reindex:elasticsearch": "./reindex-elasticsearch.sh",
     "reset-cases": "./clear-env.sh",
-    "seed:db": "node ./web-api/create-dynamo-tables.js && node ./web-api/seed-dynamo.js",
+    "seed:db": "./seed-dynamo.sh",
     "seed:elasticsearch": "./web-api/seed-elasticsearch.sh",
     "seed:s3:lint": "pushd ./web-api/storage/fixtures && grep documentId seed/*json | ./validate-seed.js && popd",
     "seed:s3": "cp -R ./web-api/storage/fixtures/s3/* ./web-api/storage/s3",

--- a/run-local.sh
+++ b/run-local.sh
@@ -24,17 +24,7 @@ fi
 npm run build:assets
 
 # these exported values expire when script terminates
-export CI=true
-export SKIP_VIRUS_SCAN=true
-export AWS_ACCESS_KEY_ID=S3RVER
-export AWS_SECRET_ACCESS_KEY=S3RVER
-export SLS_DEPLOYMENT_BUCKET=S3RVER
-export MASTER_DYNAMODB_ENDPOINT=http://localhost:8000
-export S3_ENDPOINT=http://localhost:9000
-export DOCUMENTS_BUCKET_NAME=noop-documents-local-us-east-1
-export TEMP_DOCUMENTS_BUCKET_NAME=noop-temp-documents-local-us-east-1
-export AWS_REGION=us-east-1
-export DYNAMODB_TABLE_NAME=efcms-local
+. ./setup-local-env.sh
 
 echo "killing s3rver if already running"
 pkill -f s3rver

--- a/seed-dynamo.sh
+++ b/seed-dynamo.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+export CI=true
+export SKIP_VIRUS_SCAN=true
+export AWS_ACCESS_KEY_ID=S3RVER
+export AWS_SECRET_ACCESS_KEY=S3RVER
+export SLS_DEPLOYMENT_BUCKET=S3RVER
+export MASTER_DYNAMODB_ENDPOINT=http://localhost:8000
+export S3_ENDPOINT=http://localhost:9000
+export DOCUMENTS_BUCKET_NAME=noop-documents-local-us-east-1
+export TEMP_DOCUMENTS_BUCKET_NAME=noop-temp-documents-local-us-east-1
+export AWS_REGION=us-east-1
+export DYNAMODB_TABLE_NAME=efcms-local
+
+node ./web-api/create-dynamo-tables.js 
+node ./web-api/seed-dynamo.js

--- a/seed-dynamo.sh
+++ b/seed-dynamo.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 
-export CI=true
-export SKIP_VIRUS_SCAN=true
-export AWS_ACCESS_KEY_ID=S3RVER
-export AWS_SECRET_ACCESS_KEY=S3RVER
-export SLS_DEPLOYMENT_BUCKET=S3RVER
-export MASTER_DYNAMODB_ENDPOINT=http://localhost:8000
-export S3_ENDPOINT=http://localhost:9000
-export DOCUMENTS_BUCKET_NAME=noop-documents-local-us-east-1
-export TEMP_DOCUMENTS_BUCKET_NAME=noop-temp-documents-local-us-east-1
-export AWS_REGION=us-east-1
-export DYNAMODB_TABLE_NAME=efcms-local
+. ./setup-local-env.sh
 
 node ./web-api/create-dynamo-tables.js 
 node ./web-api/seed-dynamo.js

--- a/setup-local-env.sh
+++ b/setup-local-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export CI=true
+export SKIP_VIRUS_SCAN=true
+export AWS_ACCESS_KEY_ID=S3RVER
+export AWS_SECRET_ACCESS_KEY=S3RVER
+export SLS_DEPLOYMENT_BUCKET=S3RVER
+export MASTER_DYNAMODB_ENDPOINT=http://localhost:8000
+export S3_ENDPOINT=http://localhost:9000
+export DOCUMENTS_BUCKET_NAME=noop-documents-local-us-east-1
+export TEMP_DOCUMENTS_BUCKET_NAME=noop-temp-documents-local-us-east-1
+export AWS_REGION=us-east-1
+export DYNAMODB_TABLE_NAME=efcms-local


### PR DESCRIPTION
`npm run seed:db` will re-seed dynamo and you won't need to restart your server