### PR TITLE
7493 BUG: Create/Send Message modal : Attach document dropdown does not show "Additional Info" as part of the document title

### DIFF
--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -93,6 +93,9 @@ const {
   getDocumentQCInboxForUser: getDocumentQCInboxForUserPersistence,
 } = require('../../persistence/elasticsearch/workitems/getDocumentQCInboxForUser');
 const {
+  getDocumentTitleWithAdditionalInfo,
+} = require('../../../src/business/utilities/getDocumentTitleWithAdditionalInfo');
+const {
   getDocumentTypeForAddressChange,
 } = require('../utilities/generateChangeOfAddressTemplate');
 const {
@@ -253,6 +256,9 @@ const createTestApplicationContext = ({ user } = {}) => {
     getDocQcSectionForUser: jest
       .fn()
       .mockImplementation(getDocQcSectionForUser),
+    getDocumentTitleWithAdditionalInfo: jest
+      .fn()
+      .mockImplementation(getDocumentTitleWithAdditionalInfo),
     getDocumentTypeForAddressChange: jest
       .fn()
       .mockImplementation(getDocumentTypeForAddressChange),

--- a/shared/src/business/utilities/formatAttachments.js
+++ b/shared/src/business/utilities/formatAttachments.js
@@ -19,10 +19,14 @@ export const formatAttachments = ({
     });
 
     if (doc) {
+      const generatedDocumentTitle = applicationContext
+        .getUtilities()
+        .getDocumentTitle({ applicationContext, docketEntry: doc });
+
       return {
         archived: !!doc.archived,
         documentId,
-        documentTitle: doc.documentTitle || doc.documentType,
+        documentTitle: generatedDocumentTitle || doc.documentType,
       };
     } else {
       return {

--- a/shared/src/business/utilities/formatAttachments.js
+++ b/shared/src/business/utilities/formatAttachments.js
@@ -21,7 +21,7 @@ export const formatAttachments = ({
     if (doc) {
       const generatedDocumentTitle = applicationContext
         .getUtilities()
-        .getDocumentTitle({ applicationContext, docketEntry: doc });
+        .getDocumentTitleWithAdditionalInfo({ docketEntry: doc });
 
       return {
         archived: !!doc.archived,

--- a/shared/src/business/utilities/formatAttachments.test.js
+++ b/shared/src/business/utilities/formatAttachments.test.js
@@ -58,7 +58,9 @@ describe('formatAttachments', () => {
 
     applicationContext
       .getUtilities()
-      .getDocumentTitle.mockReturnValueOnce(firstGeneratedTitle)
+      .getDocumentTitleWithAdditionalInfo.mockReturnValueOnce(
+        firstGeneratedTitle,
+      )
       .mockReturnValueOnce(secondGeneratedTitle)
       .mockReturnValueOnce(thirdGeneratedTitle)
       .mockReturnValueOnce(fourthGeneratedTitle);

--- a/shared/src/business/utilities/formatAttachments.test.js
+++ b/shared/src/business/utilities/formatAttachments.test.js
@@ -51,6 +51,18 @@ describe('formatAttachments', () => {
   ];
 
   it('formats docketEntries in the attachments array based on meta from docketEntries in the docketEntries, correspondence, archivedDocketEntries, and archivedCorrespondences arrays', () => {
+    const firstGeneratedTitle = 'Test Document One';
+    const secondGeneratedTitle = 'Test Archived One';
+    const thirdGeneratedTitle = 'Test Archived Correspondence One';
+    const fourthGeneratedTitle = 'Test Archived Correspondence Two';
+
+    applicationContext
+      .getUtilities()
+      .getDocumentTitle.mockReturnValueOnce(firstGeneratedTitle)
+      .mockReturnValueOnce(secondGeneratedTitle)
+      .mockReturnValueOnce(thirdGeneratedTitle)
+      .mockReturnValueOnce(fourthGeneratedTitle);
+
     const result = formatAttachments({
       applicationContext,
       attachments: [
@@ -68,17 +80,17 @@ describe('formatAttachments', () => {
     });
 
     expect(result).toEqual([
-      { archived: false, documentId: '1', documentTitle: 'Test Document One' },
+      { archived: false, documentId: '1', documentTitle: firstGeneratedTitle },
       {
         archived: false,
         documentId: '3',
-        documentTitle: 'Test Correspondence One',
+        documentTitle: secondGeneratedTitle,
       },
-      { archived: true, documentId: '5', documentTitle: 'Test Archived One' },
+      { archived: true, documentId: '5', documentTitle: thirdGeneratedTitle },
       {
         archived: true,
         documentId: '7',
-        documentTitle: 'Test Archived Correspondence One',
+        documentTitle: fourthGeneratedTitle,
       },
     ]);
   });

--- a/shared/src/business/utilities/getDocumentTitleWithAdditionalInfo.js
+++ b/shared/src/business/utilities/getDocumentTitleWithAdditionalInfo.js
@@ -1,0 +1,19 @@
+/**
+ * Gets document title with additionalInfo if addToCoversheet is true
+ *
+ * @param {object} applicationContext the applicationContext
+ * @param {object} docketEntry the docketEntry
+ * @returns {object} the document title
+ */
+const getDocumentTitleWithAdditionalInfo = ({ docketEntry }) => {
+  let { documentTitle } = docketEntry;
+
+  if (docketEntry.addToCoversheet) {
+    documentTitle = `${documentTitle} ${
+      docketEntry.additionalInfo || ''
+    }`.trim();
+  }
+  return documentTitle;
+};
+
+module.exports = { getDocumentTitleWithAdditionalInfo };

--- a/shared/src/business/utilities/getDocumentTitleWithAdditionalInfo.test.js
+++ b/shared/src/business/utilities/getDocumentTitleWithAdditionalInfo.test.js
@@ -1,0 +1,48 @@
+const {
+  getDocumentTitleWithAdditionalInfo,
+} = require('./getDocumentTitleWithAdditionalInfo');
+
+describe('getDocumentTitleWithAdditionalInfo', () => {
+  it('returns the original documentTitle when addToCoversheet is false', () => {
+    const docketEntry = {
+      addToCoversheet: false,
+      additionalInfo: 'some additional info',
+      documentTitle: 'Answer',
+    };
+
+    const generatedDocumentTitle = getDocumentTitleWithAdditionalInfo({
+      docketEntry,
+    });
+
+    expect(generatedDocumentTitle).toEqual(docketEntry.documentTitle);
+  });
+
+  it('returns the documentTitle with additionalInfo when addToCoversheet is true', () => {
+    const docketEntry = {
+      addToCoversheet: true,
+      additionalInfo: 'some additional info',
+      documentTitle: 'Answer',
+    };
+
+    const generatedDocumentTitle = getDocumentTitleWithAdditionalInfo({
+      docketEntry,
+    });
+
+    expect(generatedDocumentTitle).toEqual(
+      `${docketEntry.documentTitle} ${docketEntry.additionalInfo}`,
+    );
+  });
+
+  it('returns the original documentTitle when addToCoversheet is true but additionalInfo is undefined', () => {
+    const docketEntry = {
+      addToCoversheet: true,
+      documentTitle: 'Answer',
+    };
+
+    const generatedDocumentTitle = getDocumentTitleWithAdditionalInfo({
+      docketEntry,
+    });
+
+    expect(generatedDocumentTitle).toEqual(docketEntry.documentTitle);
+  });
+});

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -458,6 +458,9 @@ const {
   getDocumentQCServedForUserInteractor,
 } = require('../../shared/src/business/useCases/workitems/getDocumentQCServedForUserInteractor');
 const {
+  getDocumentTitle,
+} = require('../../shared/src/business/utilities/getDocumentTitle');
+const {
   getDownloadPolicyUrl,
 } = require('../../shared/src/persistence/s3/getDownloadPolicyUrl');
 const {
@@ -1687,6 +1690,7 @@ module.exports = (appContextUser, logger = createLogger()) => {
         formattedTrialSessionDetails,
         getAddressPhoneDiff,
         getDocQcSectionForUser,
+        getDocumentTitle,
         getDocumentTypeForAddressChange,
         getFormattedCaseDetail,
         getWorkQueueFilters,

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -458,9 +458,6 @@ const {
   getDocumentQCServedForUserInteractor,
 } = require('../../shared/src/business/useCases/workitems/getDocumentQCServedForUserInteractor');
 const {
-  getDocumentTitle,
-} = require('../../shared/src/business/utilities/getDocumentTitle');
-const {
   getDownloadPolicyUrl,
 } = require('../../shared/src/persistence/s3/getDownloadPolicyUrl');
 const {
@@ -1690,7 +1687,6 @@ module.exports = (appContextUser, logger = createLogger()) => {
         formattedTrialSessionDetails,
         getAddressPhoneDiff,
         getDocQcSectionForUser,
-        getDocumentTitle,
         getDocumentTypeForAddressChange,
         getFormattedCaseDetail,
         getWorkQueueFilters,

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -27,7 +27,7 @@ import { generatePrintableCaseInventoryReportInteractor } from '../../shared/src
 import { generatePrintablePendingReportInteractor } from '../../shared/src/proxies/pendingItems/generatePrintablePendingReportProxy';
 import { getCompletedMessagesForSectionInteractor } from '../../shared/src/proxies/messages/getCompletedMessagesForSectionProxy';
 import { getCompletedMessagesForUserInteractor } from '../../shared/src/proxies/messages/getCompletedMessagesForUserProxy';
-import { getDocumentTitle } from '../../shared/src/business/utilities/getDocumentTitle';
+import { getDocumentTitleWithAdditionalInfo } from '../../shared/src/business/utilities/getDocumentTitleWithAdditionalInfo';
 const {
   getDocQcSectionForUser,
   getWorkQueueFilters,
@@ -626,7 +626,7 @@ const applicationContext = {
       getAttachmentDocumentById: Case.getAttachmentDocumentById,
       getCaseCaption: Case.getCaseCaption,
       getDocQcSectionForUser,
-      getDocumentTitle,
+      getDocumentTitleWithAdditionalInfo,
       getFilingsAndProceedings,
       getFormattedCaseDetail,
       getJudgeLastName,

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -27,6 +27,7 @@ import { generatePrintableCaseInventoryReportInteractor } from '../../shared/src
 import { generatePrintablePendingReportInteractor } from '../../shared/src/proxies/pendingItems/generatePrintablePendingReportProxy';
 import { getCompletedMessagesForSectionInteractor } from '../../shared/src/proxies/messages/getCompletedMessagesForSectionProxy';
 import { getCompletedMessagesForUserInteractor } from '../../shared/src/proxies/messages/getCompletedMessagesForUserProxy';
+import { getDocumentTitle } from '../../shared/src/business/utilities/getDocumentTitle';
 const {
   getDocQcSectionForUser,
   getWorkQueueFilters,
@@ -625,6 +626,7 @@ const applicationContext = {
       getAttachmentDocumentById: Case.getAttachmentDocumentById,
       getCaseCaption: Case.getCaseCaption,
       getDocQcSectionForUser,
+      getDocumentTitle,
       getFilingsAndProceedings,
       getFormattedCaseDetail,
       getJudgeLastName,

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.js
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.js
@@ -26,7 +26,11 @@ export const updateMessageModalAttachmentsAction = ({
         documentId,
       });
 
-    const documentTitle = document.documentTitle || document.documentType;
+    const generatedDocumentTitle = applicationContext
+      .getUtilities()
+      .getDocumentTitle({ applicationContext, docketEntry: document });
+
+    const documentTitle = generatedDocumentTitle || document.documentType;
 
     if (attachments.length === 0) {
       // This is the first attachment, so we should update the subject

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.js
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.js
@@ -28,7 +28,7 @@ export const updateMessageModalAttachmentsAction = ({
 
     const generatedDocumentTitle = applicationContext
       .getUtilities()
-      .getDocumentTitle({ applicationContext, docketEntry: document });
+      .getDocumentTitleWithAdditionalInfo({ docketEntry: document });
 
     const documentTitle = generatedDocumentTitle || document.documentType;
 

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.test.js
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.test.js
@@ -146,4 +146,39 @@ describe('updateMessageModalAttachmentsAction', () => {
 
     expect(result.state.modal.form.subject).toEqual('Testing');
   });
+
+  it('calls getDocumentTitle and returns a generated document title', async () => {
+    const mockDocumentTitle = 'I was generated';
+    applicationContext
+      .getUtilities()
+      .getDocumentTitle.mockReturnValue(mockDocumentTitle);
+
+    const { state } = await runAction(updateMessageModalAttachmentsAction, {
+      modules: { presenter },
+      props: {
+        documentId: '123',
+      },
+      state: {
+        caseDetail,
+        modal: {
+          form: {
+            attachments: [{}], // already contains one attachment
+            subject: 'Testing',
+          },
+        },
+      },
+    });
+
+    expect(
+      applicationContext.getUtilities().getDocumentTitle,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getUtilities().getDocumentTitle.mock.calls[0][0],
+    ).toMatchObject({
+      docketEntry: { docketEntryId: '123', documentType: 'Petition' },
+    });
+    expect(state.modal.form.attachments[1].documentTitle).toEqual(
+      mockDocumentTitle,
+    );
+  });
 });

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.test.js
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.test.js
@@ -147,11 +147,11 @@ describe('updateMessageModalAttachmentsAction', () => {
     expect(result.state.modal.form.subject).toEqual('Testing');
   });
 
-  it('calls getDocumentTitle and returns a generated document title', async () => {
+  it('calls getDocumentTitleWithAdditionalInfo and returns a generated document title', async () => {
     const mockDocumentTitle = 'I was generated';
     applicationContext
       .getUtilities()
-      .getDocumentTitle.mockReturnValue(mockDocumentTitle);
+      .getDocumentTitleWithAdditionalInfo.mockReturnValue(mockDocumentTitle);
 
     const { state } = await runAction(updateMessageModalAttachmentsAction, {
       modules: { presenter },
@@ -170,10 +170,11 @@ describe('updateMessageModalAttachmentsAction', () => {
     });
 
     expect(
-      applicationContext.getUtilities().getDocumentTitle,
+      applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo,
     ).toHaveBeenCalled();
     expect(
-      applicationContext.getUtilities().getDocumentTitle.mock.calls[0][0],
+      applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo.mock
+        .calls[0][0],
     ).toMatchObject({
       docketEntry: { docketEntryId: '123', documentType: 'Petition' },
     });

--- a/web-client/src/presenter/computeds/formattedCaseDetail.js
+++ b/web-client/src/presenter/computeds/formattedCaseDetail.js
@@ -200,10 +200,9 @@ export const formattedCaseDetail = (get, applicationContext) => {
       entry.isPaper;
 
     if (entry.documentTitle) {
-      formattedResult.descriptionDisplay = entry.documentTitle;
-      if (entry.additionalInfo && entry.addToCoversheet) {
-        formattedResult.descriptionDisplay += ` ${entry.additionalInfo}`;
-      }
+      formattedResult.descriptionDisplay = applicationContext
+        .getUtilities()
+        .getDocumentTitleWithAdditionalInfo({ docketEntry: entry });
     }
 
     formattedResult.showDocumentProcessing =

--- a/web-client/src/presenter/computeds/messageModalHelper.js
+++ b/web-client/src/presenter/computeds/messageModalHelper.js
@@ -27,6 +27,7 @@ export const messageModalHelper = (get, applicationContext) => {
   const documents = [];
   formattedDocketEntries.forEach(entry => {
     if (entry.isFileAttached && entry.isOnDocketRecord) {
+      entry.title = entry.descriptionDisplay || entry.documentType;
       documents.push(entry);
     }
   });

--- a/web-client/src/presenter/computeds/messageModalHelper.test.js
+++ b/web-client/src/presenter/computeds/messageModalHelper.test.js
@@ -1,5 +1,5 @@
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
-import { applicationContext } from '../../applicationContext';
+import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
 import { messageModalHelper as messageModalHelperComputed } from './messageModalHelper';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../withAppContext';
@@ -371,5 +371,46 @@ describe('messageModalHelper', () => {
     });
 
     expect(result.showMessageAttachments).toEqual(false);
+  });
+
+  it('populates documents from formattedDocketEntries and sets a title on each entry', () => {
+    const mockFormattedDocketEntries = [
+      {
+        descriptionDisplay: 'Hello with additional info',
+        isFileAttached: true,
+        isOnDocketRecord: true,
+      },
+      {
+        documentType: 'Hello documentType',
+        isFileAttached: true,
+        isOnDocketRecord: true,
+      },
+    ];
+
+    applicationContext.getUtilities().getFormattedCaseDetail.mockReturnValue({
+      formattedDocketEntries: mockFormattedDocketEntries,
+    });
+
+    const result = runCompute(messageModalHelper, {
+      state: {
+        caseDetail,
+        modal: {
+          form: {
+            attachments: [], // no attachments on form
+          },
+        },
+        screenMetadata: {
+          showAddDocumentForm: false,
+        },
+      },
+    });
+
+    expect(result.documents).toEqual(mockFormattedDocketEntries);
+    expect(result.documents[0].title).toEqual(
+      mockFormattedDocketEntries[0].descriptionDisplay,
+    );
+    expect(result.documents[1].title).toEqual(
+      mockFormattedDocketEntries[1].documentType,
+    );
   });
 });

--- a/web-client/src/views/Messages/MessageModalAttachments.jsx
+++ b/web-client/src/views/Messages/MessageModalAttachments.jsx
@@ -6,10 +6,9 @@ import { sequences, state } from 'cerebral';
 import React from 'react';
 
 const getDocumentOption = doc => {
-  const title = doc.documentTitle || doc.documentType;
   return (
     <option key={doc.docketEntryId} value={`${doc.docketEntryId}`}>
-      {doc.createdAtFormatted} - {title}
+      {doc.createdAtFormatted} - {doc.title}
     </option>
   );
 };


### PR DESCRIPTION
Reply Modal:

![image](https://user-images.githubusercontent.com/20514925/105397720-a68c1e00-5bde-11eb-8305-adb4294cc709.png)

Forward Modal:
![image](https://user-images.githubusercontent.com/20514925/105397791-bb68b180-5bde-11eb-9a04-c3a89776836a.png)

Create Message Modal:
![image](https://user-images.githubusercontent.com/20514925/105397865-d804e980-5bde-11eb-99ab-7f5775230a59.png)
