### PR TITLE
7639: update message helper to return empty object

### DIFF
--- a/web-client/src/presenter/computeds/messageDocumentHelper.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.js
@@ -6,8 +6,9 @@ export const messageDocumentHelper = (get, applicationContext) => {
   const viewerDocumentIdToDisplay = get(
     state.viewerDocumentToDisplay.documentId,
   );
+
   if (!viewerDocumentIdToDisplay) {
-    return null;
+    return {};
   }
 
   const {

--- a/web-client/src/presenter/computeds/messageDocumentHelper.test.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.test.js
@@ -57,7 +57,7 @@ describe('messageDocumentHelper', () => {
     docketEntries: [],
   };
 
-  it('return null if viewerDocumentToDisplay is not set', () => {
+  it('return empty object if viewerDocumentToDisplay is not set', () => {
     applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);
 
     const result = runCompute(messageDocumentHelper, {
@@ -70,8 +70,9 @@ describe('messageDocumentHelper', () => {
       },
     });
 
-    expect(result).toEqual(null);
+    expect(result).toEqual({});
   });
+
   describe('showAddDocketEntryButton', () => {
     it('return showAddDocketEntryButton true for user role of docketClerk and a document that is not on the docket record', () => {
       applicationContext.getCurrentUser.mockReturnValue(docketClerkUser);


### PR DESCRIPTION
Ensure that message helper returns an empty object if no document id is selected.