### PR TITLE
7650 - Bug: Completed Messages in Section Inbox

### DIFF
--- a/shared/src/persistence/elasticsearch/messages/getSectionInboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getSectionInboxMessages.js
@@ -14,6 +14,9 @@ exports.getSectionInboxMessages = async ({ applicationContext, section }) => {
             {
               match: { 'isRepliedTo.BOOL': false },
             },
+            {
+              match: { 'isCompleted.BOOL': false },
+            },
           ],
         },
       },

--- a/shared/src/persistence/elasticsearch/messages/getSectionInboxMessages.test.js
+++ b/shared/src/persistence/elasticsearch/messages/getSectionInboxMessages.test.js
@@ -20,4 +20,25 @@ describe('getSectionInboxMessages', () => {
     expect(search).toHaveBeenCalledTimes(1);
     expect(results).toMatchObject(['some', 'matches']);
   });
+
+  it('should filter out completed messages', async () => {
+    search.mockReturnValue({ results: ['some', 'matches'], total: 0 });
+
+    await getSectionInboxMessages({
+      applicationContext,
+      section: PETITIONS_SECTION,
+    });
+
+    expect(
+      search.mock.calls[0][0].searchParameters.body.query.bool.must,
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          match: {
+            'isCompleted.BOOL': false,
+          },
+        },
+      ]),
+    );
+  });
 });

--- a/web-client/integration-tests/journey/petitionsClerkVerifiesCompletedMessageNotInSection.js
+++ b/web-client/integration-tests/journey/petitionsClerkVerifiesCompletedMessageNotInSection.js
@@ -1,0 +1,16 @@
+export const petitionsClerkVerifiesCompletedMessageNotInSection = test => {
+  return it('petitions clerk verifies the completed message is not in their inbox', async () => {
+    await test.runSequence('gotoMessagesSequence', {
+      box: 'inbox',
+      queue: 'section',
+    });
+
+    const messages = test.getState('messages');
+
+    const foundMessage = messages.find(
+      message => message.subject === test.testMessageSubject,
+    );
+
+    expect(foundMessage).toBeUndefined();
+  });
+};

--- a/web-client/integration-tests/messagesJourney.test.js
+++ b/web-client/integration-tests/messagesJourney.test.js
@@ -8,7 +8,12 @@ import { docketClerkRemovesSignatureFromMessage } from './journey/docketClerkRem
 import { docketClerkUpdatesCaseStatusToReadyForTrial } from './journey/docketClerkUpdatesCaseStatusToReadyForTrial';
 import { docketClerkViewsCompletedMessagesOnCaseDetail } from './journey/docketClerkViewsCompletedMessagesOnCaseDetail';
 import { docketClerkViewsForwardedMessageInInbox } from './journey/docketClerkViewsForwardedMessageInInbox';
-import { loginAs, setupTest, uploadPetition } from './helpers';
+import {
+  loginAs,
+  refreshElasticsearchIndex,
+  setupTest,
+  uploadPetition,
+} from './helpers';
 import { petitionsClerk1CreatesNoticeFromMessageDetail } from './journey/petitionsClerk1CreatesNoticeFromMessageDetail';
 import { petitionsClerk1RepliesToMessage } from './journey/petitionsClerk1RepliesToMessage';
 import { petitionsClerk1VerifiesCaseStatusOnMessage } from './journey/petitionsClerk1VerifiesCaseStatusOnMessage';
@@ -20,6 +25,7 @@ import { petitionsClerkCreatesOrderFromMessage } from './journey/petitionsClerkC
 import { petitionsClerkForwardsMessageToDocketClerk } from './journey/petitionsClerkForwardsMessageToDocketClerk';
 import { petitionsClerkForwardsMessageWithAttachment } from './journey/petitionsClerkForwardsMessageWithAttachment';
 import { petitionsClerkVerifiesCompletedMessageNotInInbox } from './journey/petitionsClerkVerifiesCompletedMessageNotInInbox';
+import { petitionsClerkVerifiesCompletedMessageNotInSection } from './journey/petitionsClerkVerifiesCompletedMessageNotInSection';
 import { petitionsClerkViewsInProgressMessagesOnCaseDetail } from './journey/petitionsClerkViewsInProgressMessagesOnCaseDetail';
 import { petitionsClerkViewsRepliesAndCompletesMessageInInbox } from './journey/petitionsClerkViewsRepliesAndCompletesMessageInInbox';
 import { petitionsClerkViewsReplyInInbox } from './journey/petitionsClerkViewsReplyInInbox';
@@ -95,5 +101,9 @@ describe('messages journey', () => {
   petitionsClerkViewsRepliesAndCompletesMessageInInbox(test);
 
   loginAs(test, 'petitionsclerk@example.com');
+  it('wait for ES index', async () => {
+    await refreshElasticsearchIndex();
+  });
   petitionsClerkVerifiesCompletedMessageNotInInbox(test);
+  petitionsClerkVerifiesCompletedMessageNotInSection(test);
 });


### PR DESCRIPTION
Standing on the shoulders of giants (#7452), this addresses completed messages showing in the section inbox by adding additional query parameters to ES to filter out completed messages.