### PR TITLE
Puppeteer lambda layer upgrade for NodeJS 14.x support

### DIFF
--- a/web-api/runtimes/puppeteer/Dockerfile
+++ b/web-api/runtimes/puppeteer/Dockerfile
@@ -10,4 +10,4 @@ COPY package-lock.json /home/build/nodejs/package-lock.json
 RUN cd /home/build/nodejs/ && npm ci
 RUN zip -r puppeteer_lambda_layer.zip nodejs
 
-CMD echo "zip has been created"
+CMD echo "puppeteer zip has been created"

--- a/web-api/runtimes/puppeteer/package-lock.json
+++ b/web-api/runtimes/puppeteer/package-lock.json
@@ -32,9 +32,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "optional": true
     },
     "@types/yauzl": {
@@ -52,9 +52,12 @@
       "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "anymatch": {
       "version": "3.1.1",
@@ -97,6 +100,16 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -163,11 +176,11 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-aws-lambda": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-5.5.0.tgz",
-      "integrity": "sha512-nYSDzTsVEVsvIFaUUAUN53ulXBLKSRXFS+eVYZOLZD5SA1If59rqBAiy4raMgorQwXWqjSsjK1SF4As+qzPLqA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-6.0.0.tgz",
+      "integrity": "sha512-XnFo6AaE5ZYpHYmOmMoj1yCYFeRTx6uFCpJnVuDREWzXevzZvo3gzkyQ6qSKsPW91VGWeQI7wQgnOpW50e+Dzg==",
       "requires": {
-        "lambdafs": "^2.0.0"
+        "lambdafs": "^2.0.2"
       }
     },
     "concat-map": {
@@ -193,9 +206,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg=="
+      "version": "0.0.842839",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.842839.tgz",
+      "integrity": "sha512-iI3v9uuGUW02vPUXTvxl4ijnCPL/RGRVR9I+U8s7+9OG9An/bvExjQ0KrXE9V0QBLra7wANhZctB00FKBSn1gw=="
     },
     "doctypes": {
       "version": "1.1.0",
@@ -316,11 +329,11 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       }
     },
@@ -411,21 +424,20 @@
       }
     },
     "lambdafs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lambdafs/-/lambdafs-2.0.0.tgz",
-      "integrity": "sha512-aLZoFHQGOj1gShKC8xjbVcxkSVMTav6kN/+bAJ/ORTWzTA+TeUKZRjzIIFFER5wUHd2FyJd3KygdFJobH2I9cg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lambdafs/-/lambdafs-2.0.2.tgz",
+      "integrity": "sha512-gr4FQ1eqNZ4k+VmdK1ZzyrcQFv6Hf2MlIgrBq0hXtgMpxU9hG/uKWsNX/FhfugB2aSucJkT4U9NrIVmnVG8NUg==",
       "requires": {
-        "tar-fs": "^2.1.0"
+        "tar-fs": "^2.1.1"
       },
       "dependencies": {
         "base64-js": {
-          "version": "1.3.1",
+          "version": "1.5.1",
           "bundled": true
         },
         "bl": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "bundled": true,
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -433,11 +445,11 @@
           }
         },
         "buffer": {
-          "version": "5.6.0",
+          "version": "5.7.1",
           "bundled": true,
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "chownr": {
@@ -456,7 +468,7 @@
           "bundled": true
         },
         "ieee754": {
-          "version": "1.1.13",
+          "version": "1.2.1",
           "bundled": true
         },
         "inherits": {
@@ -492,7 +504,7 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
+          "version": "5.2.1",
           "bundled": true
         },
         "string_decoder": {
@@ -503,36 +515,24 @@
           }
         },
         "tar-fs": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "mkdirp-classic": "^0.5.2",
             "pump": "^3.0.0",
-            "tar-stream": "^2.0.0"
+            "tar-stream": "^2.1.4"
           }
         },
         "tar-stream": {
-          "version": "2.1.3",
+          "version": "2.1.4",
           "bundled": true,
           "requires": {
-            "bl": "^4.0.1",
+            "bl": "^4.0.3",
             "end-of-stream": "^1.4.1",
             "fs-constants": "^1.0.0",
             "inherits": "^2.0.3",
             "readable-stream": "^3.1.1"
-          },
-          "dependencies": {
-            "bl": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-              "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-              "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-              }
-            }
           }
         },
         "util-deprecate": {
@@ -802,14 +802,14 @@
       }
     },
     "puppeteer-core": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-6.0.0.tgz",
+      "integrity": "sha512-Mm4lVSM8CJUrHSLt2zHjlW9B2D5B3JRbkbmxzGaGTauaB9gTrM+r7gk88xfRWuaBy81pRG+nTtCBdMPzO7pjqg==",
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
+        "devtools-protocol": "0.0.842839",
         "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
@@ -901,27 +901,15 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
       }
     },
     "through": {
@@ -994,9 +982,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/web-api/runtimes/puppeteer/package.json
+++ b/web-api/runtimes/puppeteer/package.json
@@ -12,11 +12,11 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
-    "chrome-aws-lambda": "^5.5.0",
+    "chrome-aws-lambda": "6.0.0",
     "handlebars": "^4.7.6",
     "npm-force-resolutions": "0.0.3",
     "pug": "^3.0.0",
-    "puppeteer-core": "^5.5.0",
+    "puppeteer-core": "6.0.0",
     "sass": "^1.29.0"
   },
   "resolutions": {

--- a/web-api/runtimes/puppeteer/package.json
+++ b/web-api/runtimes/puppeteer/package.json
@@ -12,11 +12,11 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
-    "chrome-aws-lambda": "6.0.0",
+    "chrome-aws-lambda": "^6.0.0",
     "handlebars": "^4.7.6",
     "npm-force-resolutions": "0.0.3",
     "pug": "^3.0.0",
-    "puppeteer-core": "6.0.0",
+    "puppeteer-core": "^6.0.0",
     "sass": "^1.29.0"
   },
   "resolutions": {


### PR DESCRIPTION
- updates `chrome-aws-lambda` to `6.0.0`
- updates `puppeteer-core` to `6.0.0`