### PR TITLE
Devex 851:refactoring for updateCaseAndAssociations helper

### DIFF
--- a/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
+++ b/shared/src/business/useCases/docketEntry/fileDocketEntryInteractor.js
@@ -188,7 +188,7 @@ exports.fileDocketEntryInteractor = async ({
     workItem,
   });
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
     applicationContext,
     caseToUpdate: caseEntity.validate().toRawObject(),
   });

--- a/shared/src/persistence/dynamo/trialSessions/removeCaseFromHearing.js
+++ b/shared/src/persistence/dynamo/trialSessions/removeCaseFromHearing.js
@@ -1,0 +1,23 @@
+const { delete: remove } = require('../../dynamodbClientService');
+
+/**
+ * removeCaseFromHearing
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext the application context
+ * @param {object} providers.docketNumber docket number of the case to remove
+ * @param {object} providers.trialSessionId trial session ID to remove from hearings association
+ * @returns {Promise} the promise of the call to persistence
+ */
+exports.removeCaseFromHearing = async ({
+  applicationContext,
+  docketNumber,
+  trialSessionId,
+}) =>
+  remove({
+    applicationContext,
+    key: {
+      pk: `case|${docketNumber}`,
+      sk: `hearing|${trialSessionId}`,
+    },
+  });

--- a/shared/src/persistence/dynamo/trialSessions/removeCaseFromHearing.test.js
+++ b/shared/src/persistence/dynamo/trialSessions/removeCaseFromHearing.test.js
@@ -1,0 +1,23 @@
+const {
+  applicationContext,
+} = require('../../../business/test/createTestApplicationContext');
+const { removeCaseFromHearing } = require('./removeCaseFromHearing');
+
+describe('removeCaseFromHearing', () => {
+  it('removes a mapping record for the case / hearing', async () => {
+    await removeCaseFromHearing({
+      applicationContext,
+      docketNumber: '1266-20',
+      trialSessionId: '8987',
+    });
+
+    expect(
+      applicationContext.getDocumentClient().delete.mock.calls[0][0],
+    ).toMatchObject({
+      Key: {
+        pk: 'case|1266-20',
+        sk: 'hearing|8987',
+      },
+    });
+  });
+});


### PR DESCRIPTION
staging changes to be used in the near future. `removeCaseFromHearing` is not yet being called from anywhere, but will be.
Also updated `fileDocketEntryInteractor` as it needs to be calling the helper, not the direct persistence method.