### PR TITLE
Pa11y Only Selected URLs

### DIFF
--- a/web-client/pa11y/helpers.js
+++ b/web-client/pa11y/helpers.js
@@ -1,0 +1,11 @@
+const getOnly = urls => {
+  const only = urls.filter(url => url.only);
+  if (only.length) {
+    urls = only;
+  }
+  return urls;
+};
+
+module.exports = {
+  getOnly,
+};

--- a/web-client/pa11y/helpers.test.js
+++ b/web-client/pa11y/helpers.test.js
@@ -1,0 +1,59 @@
+const { getOnly } = require('./helpers');
+
+describe('helpers', () => {
+  describe('getOnly', () => {
+    let urlsWithOnly;
+    let urlsWithoutOnly;
+
+    beforeAll(() => {
+      urlsWithOnly = [
+        {
+          only: true,
+          url: 'http://example.com/2',
+        },
+        {
+          only: true,
+          url: 'http://example.com/5',
+        },
+      ];
+
+      urlsWithoutOnly = [
+        {
+          only: false,
+          url: 'http://example.com/1',
+        },
+
+        'http://example.com/3',
+        'http://example.com/4',
+
+        {
+          only: undefined,
+          url: 'http://example.com/6',
+        },
+        {
+          url: 'http://example.com/7',
+        },
+      ];
+    });
+
+    it('looks at the given array for objects containing a truthy only param and returns those items', () => {
+      const result = getOnly([...urlsWithOnly, ...urlsWithoutOnly]);
+      expect(result).toMatchObject([
+        {
+          only: true,
+          url: 'http://example.com/2',
+        },
+        {
+          only: true,
+          url: 'http://example.com/5',
+        },
+      ]);
+    });
+
+    it('returns all elements in the given array if none have a truthy `only` param', () => {
+      const result = getOnly(urlsWithoutOnly);
+
+      expect(result).toEqual(urlsWithoutOnly);
+    });
+  });
+});

--- a/web-client/pa11y/pa11y-ci.web-client-1.config.js
+++ b/web-client/pa11y/pa11y-ci.web-client-1.config.js
@@ -1,3 +1,5 @@
+const { getOnly } = require('./helpers');
+
 const chambers = require('./pa11y-chambers');
 const docketclerk = require('./pa11y-docketclerk');
 const floater = require('./pa11y-floater');
@@ -35,5 +37,5 @@ const urls = [...initialUrls, ...userUrls].map(jsCheckDecorator);
 
 module.exports = {
   defaults,
-  urls,
+  urls: getOnly(urls),
 };

--- a/web-client/pa11y/pa11y-ci.web-client-2.config.js
+++ b/web-client/pa11y/pa11y-ci.web-client-2.config.js
@@ -1,3 +1,5 @@
+const { getOnly } = require('./helpers');
+
 const irsPractitioner = require('./pa11y-irs-practitioner');
 const petitionsclerk = require('./pa11y-petitionsclerk');
 const privatePractitioner = require('./pa11y-private-practitioner');
@@ -11,5 +13,5 @@ const urls = [
 
 module.exports = {
   defaults,
-  urls,
+  urls: getOnly(urls),
 };

--- a/web-client/pa11y/pa11y-ci.web-client-3.config.js
+++ b/web-client/pa11y/pa11y-ci.web-client-3.config.js
@@ -1,3 +1,5 @@
+const { getOnly } = require('./helpers');
+
 const adc = require('./pa11y-adc');
 const admissionsClerk = require('./pa11y-admissionsclerk');
 const irsSuperuser = require('./pa11y-irs-superuser');
@@ -10,5 +12,5 @@ const urls = [...petitioner, ...adc, ...irsSuperuser, ...admissionsClerk].map(
 
 module.exports = {
   defaults,
-  urls,
+  urls: getOnly(urls),
 };


### PR DESCRIPTION
When debugging pa11y scripts, often times, we'll comment out some of the URL arrays in the given config script we're working in. If you're debugging one URL, you're still running all the URLs in that script.

This creates a nice way of running ONLY the specified tests for a given set (1, 2, or 3).

So you can change:
```
const someUrls = [
  {
    url: 'http://example.com/1 
  }
  {
    url: 'http://example.com/2
  }
  {
    url: 'http://example.com/3 
  }
];
```

to:
```
const someUrls = [
  {
    url: 'http://example.com/1 
  }
  {
    only: true,
    url: 'http://example.com/2
  }
  {
    url: 'http://example.com/3 
  }
];
```

To ONLY run that test in the given config (pa11y:1, pa11y:2, pa11y:3)

#### Caveats
1) It requires more work to make single urls without actions, because you'd have change:
```
const someUrls = [
  'http://example.com/1',
  'http://example.com/2',
]
```
to:
```
const someUrls = [
  { only: true, url: 'http://example.com/1'},
  'http://example.com/2',
]
```
...but you can also just leave it that way, as an object. pa11y don't care.

2) There is potential for accidentally leaving an "only" in pa11y when pushing code up, which would not run all the tests. This could be mitigated with some of our pre-commit checks if someone were so inclined to write such a mechanism (*cough @kkoskelin )