### PR TITLE
7807: DOD - remove extra "Petition" on docket record for external user viewing paper case

### DIFF
--- a/shared/src/business/useCases/addCoversheetInteractor.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.js
@@ -227,11 +227,13 @@ exports.addCoversheetInteractor = async ({
   docketEntryEntity.setAsProcessingStatusAsCompleted();
   docketEntryEntity.setNumberOfPages(numberOfPages);
 
+  const updatedDocketEntryEntity = docketEntryEntity.validate();
+
   await applicationContext.getPersistenceGateway().updateDocketEntry({
     applicationContext,
     docketEntryId,
     docketNumber: caseEntity.docketNumber,
-    document: docketEntryEntity.validate().toRawObject(),
+    document: updatedDocketEntryEntity.toRawObject(),
   });
 
   await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
@@ -239,4 +241,6 @@ exports.addCoversheetInteractor = async ({
     document: newPdfData,
     key: docketEntryId,
   });
+
+  return updatedDocketEntryEntity;
 };

--- a/shared/src/business/useCases/addCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/addCoversheetInteractor.test.js
@@ -8,6 +8,7 @@ const {
 } = require('../test/createTestApplicationContext');
 const {
   DOCKET_NUMBER_SUFFIXES,
+  DOCUMENT_PROCESSING_STATUS_OPTIONS,
   PARTY_TYPES,
 } = require('../entities/EntityConstants');
 
@@ -171,6 +172,27 @@ describe('addCoversheetInteractor', () => {
     expect(
       applicationContext.getPersistenceGateway().saveDocumentFromLambda,
     ).toHaveBeenCalled();
+  });
+
+  it('returns the updated docket entry entity', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue({
+        ...testingCaseData,
+      });
+
+    const params = {
+      applicationContext,
+      docketEntryId: 'a6b81f4d-1e47-423a-8caf-6d2fdc3d3859',
+      docketNumber: '101-19',
+    };
+
+    const updatedDocketEntryEntity = await addCoversheetInteractor(params);
+
+    expect(updatedDocketEntryEntity).toMatchObject({
+      numberOfPages: 2,
+      processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
+    });
   });
 
   describe('coversheet data generator', () => {
@@ -776,7 +798,7 @@ describe('addCoversheetInteractor', () => {
       expect(result.dateServed).toBeUndefined();
     });
 
-    it('sets the dateRecieved to dateFiledFormatted when the filingDate has been updated', () => {
+    it('sets the dateReceived to dateFiledFormatted when the filingDate has been updated', () => {
       const result = generateCoverSheetData({
         applicationContext,
         caseEntity: {
@@ -802,7 +824,7 @@ describe('addCoversheetInteractor', () => {
       expect(result.dateReceived).toBe('05/19/19');
     });
 
-    it('sets the dateRecieved to createdAt date when the filingDate has not been updated', () => {
+    it('sets the dateReceived to createdAt date when the filingDate has not been updated', () => {
       const result = generateCoverSheetData({
         applicationContext,
         caseEntity: {

--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
@@ -209,22 +209,19 @@ exports.serveCaseToIrsInteractor = async ({
     applicationContext,
   });
 
-  for (const doc of caseEntityToUpdate.docketEntries) {
+  for (let doc of caseEntityToUpdate.docketEntries) {
     if (doc.isFileAttached) {
-      await applicationContext.getUseCases().addCoversheetInteractor({
-        applicationContext,
-        docketEntryId: doc.docketEntryId,
-        docketNumber: caseEntityToUpdate.docketNumber,
-        replaceCoversheet: !caseEntityToUpdate.isPaper,
-        useInitialData: !caseEntityToUpdate.isPaper,
-      });
-
-      doc.numberOfPages = await applicationContext
-        .getUseCaseHelpers()
-        .countPagesInDocument({
+      const updatedDocketEntry = await applicationContext
+        .getUseCases()
+        .addCoversheetInteractor({
           applicationContext,
           docketEntryId: doc.docketEntryId,
+          docketNumber: caseEntityToUpdate.docketNumber,
+          replaceCoversheet: !caseEntityToUpdate.isPaper,
+          useInitialData: !caseEntityToUpdate.isPaper,
         });
+
+      caseEntityToUpdate.updateDocketEntry(updatedDocketEntry);
     }
   }
 

--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.js
@@ -209,7 +209,7 @@ exports.serveCaseToIrsInteractor = async ({
     applicationContext,
   });
 
-  for (let doc of caseEntityToUpdate.docketEntries) {
+  for (const doc of caseEntityToUpdate.docketEntries) {
     if (doc.isFileAttached) {
       const updatedDocketEntry = await applicationContext
         .getUseCases()

--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
@@ -469,7 +469,7 @@ describe('serveCaseToIrsInteractor', () => {
     ).toEqual('1ccd40c6-a949-43ce-936e-7c92d36aaa40');
   });
 
-  it('should make 2 calls to updateCase, once before adding a coversheet, and once after', async () => {
+  it('should have processingStatus pending when calling updateCase the first time and processingStatus complete when calling updateCase the second time', async () => {
     mockCase = {
       ...MOCK_CASE,
       docketEntries: [

--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
@@ -1,15 +1,20 @@
 const {
+  addCoversheetInteractor,
+} = require('../../../business/useCases/addCoversheetInteractor');
+const {
   addDocketEntryForPaymentStatus,
   serveCaseToIrsInteractor,
 } = require('./serveCaseToIrsInteractor');
 const {
   applicationContext,
+  testPdfDoc,
 } = require('../../test/createTestApplicationContext');
 const {
   CASE_STATUS_TYPES,
   COUNTRY_TYPES,
   DOCKET_NUMBER_SUFFIXES,
   DOCKET_SECTION,
+  DOCUMENT_PROCESSING_STATUS_OPTIONS,
   INITIAL_DOCUMENT_TYPES,
   PARTY_TYPES,
   PAYMENT_STATUS,
@@ -56,12 +61,19 @@ describe('serveCaseToIrsInteractor', () => {
 
   let mockCase;
 
-  beforeAll(() => {
+  beforeEach(() => {
     mockCase = MOCK_CASE;
     mockCase.docketEntries[0].workItem = MOCK_WORK_ITEM;
     applicationContext.getPersistenceGateway().updateWorkItem = jest.fn();
 
     applicationContext.getStorageClient.mockReturnValue({
+      getObject: () => {
+        return {
+          promise: async () => ({
+            Body: testPdfDoc,
+          }),
+        };
+      },
       upload: (params, cb) => {
         return cb(true);
       },
@@ -70,9 +82,13 @@ describe('serveCaseToIrsInteractor', () => {
       .getPersistenceGateway()
       .getDownloadPolicyUrl.mockReturnValue({ url: 'www.example.com' });
 
-    // await applicationContext
-    //   .getUseCases()
-    //   .addCoversheetInteractor.mock
+    applicationContext
+      .getUseCases()
+      .addCoversheetInteractor.mockImplementation(addCoversheetInteractor);
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockImplementation(() => mockCase);
   });
 
   it('should throw unauthorized error when user is unauthorized', async () => {
@@ -102,9 +118,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -121,43 +134,6 @@ describe('serveCaseToIrsInteractor', () => {
     });
   });
 
-  it('should count number of pages for the documents in the case to be served', async () => {
-    mockCase = {
-      ...MOCK_CASE,
-      isPaper: true,
-      mailingDate: 'some day',
-    };
-
-    applicationContext.getCurrentUser.mockReturnValue(
-      new User({
-        name: 'bob',
-        role: ROLES.petitionsClerk,
-        userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
-      }),
-    );
-    expect(mockCase.docketEntries[0].numberOfPages).toBeUndefined();
-
-    applicationContext
-      .getUseCaseHelpers()
-      .countPagesInDocument.mockResolvedValue(2);
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockResolvedValue(mockCase);
-
-    await serveCaseToIrsInteractor({
-      applicationContext,
-      docketNumber: MOCK_CASE.docketNumber,
-    });
-
-    expect(
-      applicationContext.getUseCaseHelpers().countPagesInDocument,
-    ).toHaveBeenCalled();
-    expect(
-      applicationContext.getPersistenceGateway().updateCase.mock.calls[1][0]
-        .caseToUpdate.docketEntries[0],
-    ).toMatchObject({ numberOfPages: 2 });
-  });
-
   it('should replace coversheet on the served petition if the case is not paper', async () => {
     applicationContext.getCurrentUser.mockReturnValue(
       new User({
@@ -166,9 +142,7 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
+    mockCase = MOCK_CASE;
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -193,9 +167,7 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
+    mockCase = MOCK_CASE;
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -240,9 +212,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -283,9 +252,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -311,9 +277,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -338,9 +301,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     const result = await serveCaseToIrsInteractor({
       applicationContext,
@@ -363,9 +323,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     const result = await serveCaseToIrsInteractor({
       applicationContext,
@@ -425,9 +382,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
 
     const result = await serveCaseToIrsInteractor({
       applicationContext,
@@ -501,9 +455,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
     await serveCaseToIrsInteractor({
       applicationContext,
       docketNumber: MOCK_CASE.docketNumber,
@@ -518,8 +469,7 @@ describe('serveCaseToIrsInteractor', () => {
     ).toEqual('1ccd40c6-a949-43ce-936e-7c92d36aaa40');
   });
 
-  it('should make 2 calls to updateCase, once before adding a coversheet and number of pages, and once after', async () => {
-    const mockNumberOfPages = 10;
+  it('should make 2 calls to updateCase, once before adding a coversheet, and once after', async () => {
     mockCase = {
       ...MOCK_CASE,
       docketEntries: [
@@ -558,13 +508,6 @@ describe('serveCaseToIrsInteractor', () => {
         userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
       }),
     );
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(mockCase);
-
-    applicationContext
-      .getUseCaseHelpers()
-      .countPagesInDocument.mockReturnValue(mockNumberOfPages);
 
     await serveCaseToIrsInteractor({
       applicationContext,
@@ -577,13 +520,96 @@ describe('serveCaseToIrsInteractor', () => {
     expect(
       updateCaseCall[0][0].caseToUpdate.docketEntries.find(
         p => p.eventCode === 'A',
-      ).numberOfPages,
-    ).toBeUndefined();
+      ).processingStatus,
+    ).toEqual(DOCUMENT_PROCESSING_STATUS_OPTIONS.PENDING);
     expect(
       updateCaseCall[1][0].caseToUpdate.docketEntries.find(
         p => p.eventCode === 'A',
-      ).numberOfPages,
-    ).toBe(mockNumberOfPages);
+      ).processingStatus,
+    ).toBe(DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE);
+  });
+
+  it('should set isOnDocketRecord true for all intially filed documents except for the petition and stin file', async () => {
+    const mockCaseWithoutServedDocketEntries = {
+      ...MOCK_CASE,
+      docketEntries: [
+        MOCK_CASE.docketEntries[0],
+        {
+          createdAt: '2018-11-21T20:49:28.192Z',
+          docketEntryId: 'ea10afeb-f189-4657-a862-c607a091beaa',
+          docketNumber: '101-18',
+          documentTitle:
+            INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentTitle,
+          documentType:
+            INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentType,
+          eventCode: INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.eventCode,
+          isFileAttached: true,
+          processingStatus: 'pending',
+          userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+        },
+      ],
+      isPaper: true,
+      mailingDate: 'some day',
+    };
+    const mockCaseWithServedDocketEntries = {
+      ...mockCaseWithoutServedDocketEntries,
+      docketEntries: [
+        MOCK_CASE.docketEntries[0],
+        {
+          createdAt: '2018-11-21T20:49:28.192Z',
+          docketEntryId: 'ea10afeb-f189-4657-a862-c607a091beaa',
+          docketNumber: '101-18',
+          documentTitle:
+            INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentTitle,
+          documentType:
+            INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentType,
+          eventCode: INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.eventCode,
+          index: 2,
+          isFileAttached: true,
+          isOnDocketRecord: true,
+          processingStatus: 'pending',
+          userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+        },
+      ],
+    };
+
+    applicationContext.getCurrentUser.mockReturnValue(
+      new User({
+        name: 'bob',
+        role: ROLES.petitionsClerk,
+        userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
+      }),
+    );
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValueOnce(
+        mockCaseWithoutServedDocketEntries,
+      )
+      .mockReturnValueOnce(mockCaseWithServedDocketEntries)
+      .mockReturnValueOnce(mockCaseWithServedDocketEntries);
+
+    await serveCaseToIrsInteractor({
+      applicationContext,
+      docketNumber: MOCK_CASE.docketNumber,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateCase.mock.calls[1][0]
+        .caseToUpdate.docketEntries,
+    ).toMatchObject([
+      {
+        documentTitle: INITIAL_DOCUMENT_TYPES.petition.documentTitle,
+        index: 1,
+        isOnDocketRecord: true,
+      },
+      {
+        documentTitle:
+          INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentTitle,
+        index: 2,
+        isOnDocketRecord: true,
+      },
+    ]);
   });
 });
 
@@ -640,66 +666,5 @@ describe('addDocketEntryForPaymentStatus', () => {
 
     expect(addedDocketRecord).toBeDefined();
     expect(addedDocketRecord.filingDate).toEqual('Today');
-  });
-
-  it('should set isOnDocketRecord true for all intially filed documents except for the petition and stin file', async () => {
-    const mockCase = {
-      ...MOCK_CASE,
-      docketEntries: [
-        MOCK_CASE.docketEntries[0],
-        {
-          createdAt: '2018-11-21T20:49:28.192Z',
-          docketEntryId: 'abc81f4d-1e47-423a-8caf-6d2fdc3d3859',
-          docketNumber: '101-18',
-          documentTitle:
-            INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentTitle,
-          documentType:
-            INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentType,
-          eventCode: INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.eventCode,
-          isFileAttached: true,
-          processingStatus: 'pending',
-          userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
-        },
-      ],
-      isPaper: true,
-      mailingDate: 'some day',
-    };
-
-    applicationContext.getCurrentUser.mockReturnValue(
-      new User({
-        name: 'bob',
-        role: ROLES.petitionsClerk,
-        userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
-      }),
-    );
-
-    applicationContext
-      .getUseCaseHelpers()
-      .countPagesInDocument.mockResolvedValue(2);
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockResolvedValue(mockCase);
-
-    await serveCaseToIrsInteractor({
-      applicationContext,
-      docketNumber: MOCK_CASE.docketNumber,
-    });
-
-    expect(
-      applicationContext.getPersistenceGateway().updateCase.mock.calls[1][0]
-        .caseToUpdate.docketEntries,
-    ).toMatchObject([
-      {
-        documentTitle: INITIAL_DOCUMENT_TYPES.petition.documentTitle,
-        index: 1,
-        isOnDocketRecord: true,
-      },
-      {
-        documentTitle:
-          INITIAL_DOCUMENT_TYPES.requestForPlaceOfTrial.documentTitle,
-        index: 2,
-        isOnDocketRecord: true,
-      },
-    ]);
   });
 });

--- a/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
+++ b/shared/src/business/useCases/serveCaseToIrs/serveCaseToIrsInteractor.test.js
@@ -69,6 +69,10 @@ describe('serveCaseToIrsInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getDownloadPolicyUrl.mockReturnValue({ url: 'www.example.com' });
+
+    // await applicationContext
+    //   .getUseCases()
+    //   .addCoversheetInteractor.mock
   });
 
   it('should throw unauthorized error when user is unauthorized', async () => {


### PR DESCRIPTION
`addCoversheetInteractor` was calling `updateDocketEntry` and updating that docket entry in persistence, but `serveCaseToIrsInteractor` was calling `updateCaseAndAssociations` later without the updated docket entry values and overwriting the `processingStatus` value back to pending.