### PR TITLE
7470: Updated printable docket record always show counsel

### DIFF
--- a/shared/src/business/useCases/generateDocketRecordPdfInteractor.js
+++ b/shared/src/business/useCases/generateDocketRecordPdfInteractor.js
@@ -5,7 +5,6 @@ const {
 const { Case, isSealedCase } = require('../entities/cases/Case');
 const { getCaseCaptionMeta } = require('../utilities/getCaseCaptionMeta');
 const { UnauthorizedError } = require('../../errors/errors');
-const { User } = require('../entities/User');
 
 /**
  * generateDocketRecordPdfInteractor
@@ -29,10 +28,6 @@ exports.generateDocketRecordPdfInteractor = async ({
       docketNumber,
       userId: user.userId,
     });
-  const isInternal = User.isInternalUser(user.role);
-
-  const shouldIncludePartyDetail =
-    includePartyDetail && (isAssociated || isInternal);
 
   const caseSource = await applicationContext
     .getPersistenceGateway()
@@ -85,7 +80,7 @@ exports.generateDocketRecordPdfInteractor = async ({
       entries: formattedCaseDetail.formattedDocketEntries.filter(
         d => d.isOnDocketRecord,
       ),
-      includePartyDetail: shouldIncludePartyDetail,
+      includePartyDetail,
     },
   });
 

--- a/shared/src/business/useCases/generateDocketRecordPdfInteractor.test.js
+++ b/shared/src/business/useCases/generateDocketRecordPdfInteractor.test.js
@@ -77,60 +77,6 @@ describe('generateDocketRecordPdfInteractor', () => {
     ).toMatchObject({ includePartyDetail: true });
   });
 
-  describe('party detail is requested', () => {
-    it('user is associated with the case', async () => {
-      applicationContext
-        .getPersistenceGateway()
-        .verifyCaseForUser.mockReturnValue(true);
-      await generateDocketRecordPdfInteractor({
-        applicationContext,
-        docketNumber: caseDetail.docketNumber,
-        includePartyDetail: true,
-      });
-
-      expect(
-        applicationContext.getDocumentGenerators().docketRecord.mock.calls[0][0]
-          .data,
-      ).toMatchObject({ includePartyDetail: true });
-    });
-
-    it('user has an internal role', async () => {
-      applicationContext.getCurrentUser.mockReturnValue(
-        MOCK_USERS['a7d90c05-f6cd-442c-a168-202db587f16f'], // docket clerk
-      );
-      applicationContext
-        .getPersistenceGateway()
-        .verifyCaseForUser.mockReturnValue(false);
-      await generateDocketRecordPdfInteractor({
-        applicationContext,
-        docketNumber: caseDetail.docketNumber,
-        includePartyDetail: true,
-      });
-
-      expect(
-        applicationContext.getDocumentGenerators().docketRecord.mock.calls[0][0]
-          .data,
-      ).toMatchObject({ includePartyDetail: true });
-    });
-
-    it('user is NOT associated with the case and does NOT have an internal role', async () => {
-      applicationContext.getCurrentUser.mockReturnValue({});
-      applicationContext
-        .getPersistenceGateway()
-        .verifyCaseForUser.mockReturnValue(false);
-      await generateDocketRecordPdfInteractor({
-        applicationContext,
-        docketNumber: caseDetail.docketNumber,
-        includePartyDetail: true,
-      });
-
-      expect(
-        applicationContext.getDocumentGenerators().docketRecord.mock.calls[0][0]
-          .data,
-      ).toMatchObject({ includePartyDetail: false });
-    });
-  });
-
   it('Returns a file ID and url to the generated file', async () => {
     const result = await generateDocketRecordPdfInteractor({
       applicationContext,

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.test.js
@@ -34,7 +34,7 @@ describe('CoverSheet', () => {
     const wrapper = shallow(<CoverSheet />);
     const dateReceivedDiv = wrapper.find('#date-received');
 
-    expect(dateReceivedDiv).toEqual({});
+    expect(dateReceivedDiv.length).toEqual(0);
   });
 
   it('renders a filed or lodged label along with the associated date', () => {

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
@@ -164,44 +164,41 @@ export const DocketRecord = ({
         </div>
       )}
 
-      {caseDetail.privatePractitioners.length > 0 &&
-        options.includePartyDetail && (
-          <div className="party-info" id="private-practitioner-contacts">
-            <div className="party-info-header">Petitioner Counsel</div>
-            <div className="party-info-content">
-              {caseDetail.privatePractitioners.map(practitioner => {
-                if (practitioner.formattedName) {
-                  return (
-                    <RenderPractitioner
-                      contactPrimary={caseDetail.contactPrimary}
-                      contactSecondary={caseDetail.contactSecondary}
-                      countryTypes={countryTypes}
-                      key={practitioner.barNumber}
-                      practitioner={practitioner}
-                    />
-                  );
-                }
-              })}
-            </div>
-          </div>
-        )}
-
-      {caseDetail.irsPractitioners.length > 0 && options.includePartyDetail && (
-        <div className="party-info" id="irs-practitioner-contacts">
-          <div className="party-info-header">Respondent Counsel</div>
-          <div className="party-info-content">
-            {caseDetail.irsPractitioners.map(practitioner => {
+      <div className="party-info" id="private-practitioner-contacts">
+        <div className="party-info-header">Petitioner Counsel</div>
+        <div className="party-info-content">
+          {caseDetail.privatePractitioners.length == 0 && 'Pro Se'}
+          {caseDetail.privatePractitioners.map(practitioner => {
+            if (practitioner.formattedName) {
               return (
                 <RenderPractitioner
+                  contactPrimary={caseDetail.contactPrimary}
+                  contactSecondary={caseDetail.contactSecondary}
                   countryTypes={countryTypes}
                   key={practitioner.barNumber}
                   practitioner={practitioner}
                 />
               );
-            })}
-          </div>
+            }
+          })}
         </div>
-      )}
+      </div>
+
+      <div className="party-info" id="irs-practitioner-contacts">
+        <div className="party-info-header">Respondent Counsel</div>
+        <div className="party-info-content">
+          {caseDetail.irsPractitioners.length == 0 && 'None'}
+          {caseDetail.irsPractitioners.map(practitioner => {
+            return (
+              <RenderPractitioner
+                countryTypes={countryTypes}
+                key={practitioner.barNumber}
+                practitioner={practitioner}
+              />
+            );
+          })}
+        </div>
+      </div>
 
       <table id="documents">
         <thead>

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.test.js
@@ -121,21 +121,19 @@ describe('DocketRecord', () => {
     );
     expect(contacts.find('.party-details').length).toEqual(1);
 
-    const contactPrimaryEl = contacts.find('.party-details');
+    const contactPrimaryEl = contacts.find('.party-details').text();
 
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.name);
-    expect(contactPrimaryEl.text()).toContain(
-      `c/o ${contactPrimary.secondaryName}`,
-    );
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.address1);
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.address2);
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.address3);
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.city);
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.state);
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.postalCode);
-    expect(contactPrimaryEl.text()).toContain(contactPrimary.phone);
+    expect(contactPrimaryEl).toContain(contactPrimary.name);
+    expect(contactPrimaryEl).toContain(`c/o ${contactPrimary.secondaryName}`);
+    expect(contactPrimaryEl).toContain(contactPrimary.address1);
+    expect(contactPrimaryEl).toContain(contactPrimary.address2);
+    expect(contactPrimaryEl).toContain(contactPrimary.address3);
+    expect(contactPrimaryEl).toContain(contactPrimary.city);
+    expect(contactPrimaryEl).toContain(contactPrimary.state);
+    expect(contactPrimaryEl).toContain(contactPrimary.postalCode);
+    expect(contactPrimaryEl).toContain(contactPrimary.phone);
 
-    expect(contactPrimaryEl.text()).not.toContain(contactPrimary.country);
+    expect(contactPrimaryEl).not.toContain(contactPrimary.country);
   });
 
   it('does not render the primary contact information when options.includePartyDetail is false', () => {
@@ -151,7 +149,7 @@ describe('DocketRecord', () => {
     );
 
     const contacts = wrapper.find('#petitioner-contacts');
-    expect(contacts).toEqual({});
+    expect(contacts.length).toEqual(0);
   });
 
   it("displays a party's country if international", () => {
@@ -209,11 +207,10 @@ describe('DocketRecord', () => {
     expect(contactPrimaryEl.text()).toContain(`c/o ${contactPrimary.inCareOf}`);
   });
 
-  it('renders private practitioner contact information when present and options.includePartyDetail is true', () => {
-    options.includePartyDetail = true;
+  it('renders "Pro Se" when no private practitioner is given', () => {
     caseDetail.privatePractitioners = []; // No private practitioners
 
-    let wrapper = mount(
+    const wrapper = mount(
       <DocketRecord
         caseDetail={caseDetail}
         countryTypes={COUNTRY_TYPES}
@@ -222,11 +219,16 @@ describe('DocketRecord', () => {
       />,
     );
 
-    expect(wrapper.find('#private-practitioner-contacts').length).toEqual(0);
+    expect(wrapper.find('#private-practitioner-contacts').length).toEqual(1);
 
+    const contacts = wrapper.find('#private-practitioner-contacts');
+    expect(contacts.find('.party-info-content').text()).toEqual('Pro Se');
+  });
+
+  it('renders private practitioner contact info when present', () => {
     caseDetail.privatePractitioners = [privatePractitioner];
 
-    wrapper = mount(
+    const wrapper = mount(
       <DocketRecord
         caseDetail={caseDetail}
         countryTypes={COUNTRY_TYPES}
@@ -236,38 +238,23 @@ describe('DocketRecord', () => {
     );
 
     const contacts = wrapper.find('#private-practitioner-contacts');
+    expect(contacts.length).toEqual(1);
     expect(contacts.find('.party-info-header').text()).toEqual(
       'Petitioner Counsel',
     );
 
-    const contactEl = contacts.find('.party-details');
+    const contactEl = contacts.find('.party-details').text();
 
-    expect(contactEl.text()).toContain(privatePractitioner.formattedName);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.address1);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.address2);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.address3);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.city);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.state);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.postalCode);
-    expect(contactEl.text()).toContain(privatePractitioner.contact.phone);
+    expect(contactEl).toContain(privatePractitioner.formattedName);
+    expect(contactEl).toContain(privatePractitioner.contact.address1);
+    expect(contactEl).toContain(privatePractitioner.contact.address2);
+    expect(contactEl).toContain(privatePractitioner.contact.address3);
+    expect(contactEl).toContain(privatePractitioner.contact.city);
+    expect(contactEl).toContain(privatePractitioner.contact.state);
+    expect(contactEl).toContain(privatePractitioner.contact.postalCode);
+    expect(contactEl).toContain(privatePractitioner.contact.phone);
 
-    expect(contactEl.text()).not.toContain('Representing');
-  });
-
-  it('does not render private practitioner contact information when present and options.includePartyDetail is false', () => {
-    options.includePartyDetail = false;
-    caseDetail.privatePractitioners = [privatePractitioner];
-
-    let wrapper = mount(
-      <DocketRecord
-        caseDetail={caseDetail}
-        countryTypes={COUNTRY_TYPES}
-        entries={entries}
-        options={options}
-      />,
-    );
-
-    expect(wrapper.find('#private-practitioner-contacts')).toEqual({});
+    expect(contactEl).not.toContain('Representing');
   });
 
   it('displays represented parties with each practitioner', () => {
@@ -309,11 +296,10 @@ describe('DocketRecord', () => {
     expect(practitioner2El.text()).toContain(contactSecondary.name);
   });
 
-  it('renders irs practitioner contact information when present and options.includePartyDetail is true', () => {
-    options.includePartyDetail = true;
+  it('renders "None" when no IRS practitioner is given', () => {
     caseDetail.irsPractitioners = []; // No irs practitioners
 
-    let wrapper = mount(
+    const wrapper = mount(
       <DocketRecord
         caseDetail={caseDetail}
         countryTypes={COUNTRY_TYPES}
@@ -322,11 +308,16 @@ describe('DocketRecord', () => {
       />,
     );
 
-    expect(wrapper.find('#irs-practitioner-contacts').length).toEqual(0);
+    expect(wrapper.find('#irs-practitioner-contacts').length).toEqual(1);
 
+    const contacts = wrapper.find('#irs-practitioner-contacts');
+    expect(contacts.find('.party-info-content').text()).toEqual('None');
+  });
+
+  it('renders irs practitioner contact information when present', () => {
     caseDetail.irsPractitioners = [irsPractitioner];
 
-    wrapper = mount(
+    const wrapper = mount(
       <DocketRecord
         caseDetail={caseDetail}
         countryTypes={COUNTRY_TYPES}
@@ -340,34 +331,18 @@ describe('DocketRecord', () => {
       'Respondent Counsel',
     );
 
-    const contactEl = contacts.find('.party-details');
+    const contactEl = contacts.find('.party-details').text();
 
-    expect(contactEl.text()).toContain(irsPractitioner.name);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.address1);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.address2);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.address3);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.city);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.state);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.postalCode);
-    expect(contactEl.text()).toContain(irsPractitioner.contact.phone);
+    expect(contactEl).toContain(irsPractitioner.name);
+    expect(contactEl).toContain(irsPractitioner.contact.address1);
+    expect(contactEl).toContain(irsPractitioner.contact.address2);
+    expect(contactEl).toContain(irsPractitioner.contact.address3);
+    expect(contactEl).toContain(irsPractitioner.contact.city);
+    expect(contactEl).toContain(irsPractitioner.contact.state);
+    expect(contactEl).toContain(irsPractitioner.contact.postalCode);
+    expect(contactEl).toContain(irsPractitioner.contact.phone);
 
-    expect(contactEl.text()).not.toContain('Representing');
-  });
-
-  it('does not render irs practitioner contact information when present and options.includePartyDetail is false', () => {
-    options.includePartyDetail = false;
-    caseDetail.irsPractitioners = [irsPractitioner];
-
-    let wrapper = mount(
-      <DocketRecord
-        caseDetail={caseDetail}
-        countryTypes={COUNTRY_TYPES}
-        entries={entries}
-        options={options}
-      />,
-    );
-
-    expect(wrapper.find('#irs-practitioner-contacts')).toEqual({});
+    expect(contactEl).not.toContain('Representing');
   });
 
   it('renders a table with docket record data', () => {
@@ -383,17 +358,17 @@ describe('DocketRecord', () => {
     const docketRecord = wrapper.find('#documents');
     expect(docketRecord.find('tbody tr').length).toEqual(entries.length);
 
-    const rowEl = docketRecord.find('tbody tr').at(0);
+    const rowEl = docketRecord.find('tbody tr').at(0).text();
 
-    expect(rowEl.text()).toContain(entries[0].index);
-    expect(rowEl.text()).toContain(entries[0].createdAtFormatted);
-    expect(rowEl.text()).toContain(entries[0].eventCode);
-    expect(rowEl.text()).toContain(entries[0].descriptionDisplay);
-    expect(rowEl.text()).toContain(entries[0].filingsAndProceedings);
-    expect(rowEl.text()).toContain(entries[0].filedBy);
-    expect(rowEl.text()).toContain(entries[0].action);
-    expect(rowEl.text()).toContain(entries[0].servedAtFormatted);
-    expect(rowEl.text()).toContain(entries[0].servedPartiesCode);
+    expect(rowEl).toContain(entries[0].index);
+    expect(rowEl).toContain(entries[0].createdAtFormatted);
+    expect(rowEl).toContain(entries[0].eventCode);
+    expect(rowEl).toContain(entries[0].descriptionDisplay);
+    expect(rowEl).toContain(entries[0].filingsAndProceedings);
+    expect(rowEl).toContain(entries[0].filedBy);
+    expect(rowEl).toContain(entries[0].action);
+    expect(rowEl).toContain(entries[0].servedAtFormatted);
+    expect(rowEl).toContain(entries[0].servedPartiesCode);
   });
 
   it('displays the record description, filingsAndProceedings, and additionalInfo2', () => {


### PR DESCRIPTION
Public view without counsel:
<img width="730" alt="Screen Shot 2021-02-26 at 2 59 25 PM" src="https://user-images.githubusercontent.com/66225176/109354375-550d2980-7843-11eb-860d-4e54bedc97ef.png">
Public view with counsel:
<img width="721" alt="Screen Shot 2021-02-26 at 2 42 18 PM" src="https://user-images.githubusercontent.com/66225176/109353974-b8e32280-7842-11eb-8f40-201c4b145a45.png">
Internal view without counsel:
<img width="647" alt="Screen Shot 2021-02-26 at 2 43 00 PM" src="https://user-images.githubusercontent.com/66225176/109353980-ba144f80-7842-11eb-96ff-4fd404c27a8f.png">
Internal view with counsel:
<img width="655" alt="Screen Shot 2021-02-26 at 2 46 06 PM" src="https://user-images.githubusercontent.com/66225176/109353990-baace600-7842-11eb-952d-6f9dfc33f23b.png">

