### PR TITLE
Fixes for clear-env.sh script

### DIFF
--- a/web-api/delete-elasticsearch-index.js
+++ b/web-api/delete-elasticsearch-index.js
@@ -2,9 +2,11 @@
   const AWS = require('aws-sdk');
   const {
     elasticsearchIndexes,
-  } = require('./elasticsearch/elasticsearch-indexes');
+  } = require('./web-api/elasticsearch/elasticsearch-indexes');
   AWS.config.region = 'us-east-1';
-  const { ELASTICSEARCH_API_VERSION } = require('./elasticsearch-settings');
+  const {
+    ELASTICSEARCH_API_VERSION,
+  } = require('./web-api/elasticsearch-settings');
 
   const connectionClass = require('http-aws-es');
   const elasticsearch = require('elasticsearch');
@@ -33,7 +35,7 @@
       region: environment.region,
     },
     apiVersion: ELASTICSEARCH_API_VERSION,
-    connectionClass: connectionClass,
+    connectionClass,
     host: {
       host: environment.elasticsearchEndpoint,
       port: 443,

--- a/web-api/delete-elasticsearch-index.js
+++ b/web-api/delete-elasticsearch-index.js
@@ -2,11 +2,11 @@
   const AWS = require('aws-sdk');
   const {
     elasticsearchIndexes,
-  } = require('./web-api/elasticsearch/elasticsearch-indexes');
+  } = require('./elasticsearch/elasticsearch-indexes');
   AWS.config.region = 'us-east-1';
   const {
     ELASTICSEARCH_API_VERSION,
-  } = require('./web-api/elasticsearch-settings');
+  } = require('./elasticsearch/elasticsearch-settings');
 
   const connectionClass = require('http-aws-es');
   const elasticsearch = require('elasticsearch');

--- a/web-api/setup-cognito-users.sh
+++ b/web-api/setup-cognito-users.sh
@@ -52,7 +52,7 @@ generate_post_data() {
   "lastName": "$lastName",
   "suffix": "$suffix",
   "barNumber": "$barNumber",
-  "admissionsDate": "2019-03-01T21:40:46.415Z",
+  "admissionsDate": "2019-03-01",
   "admissionsStatus": "Active",
   "birthYear": "1950",
   "employer": "$employer",


### PR DESCRIPTION
Fixes errors found when running the `clear-env.sh` script
* Use correct admissions date when creating practitioner users
* Update path in `delete-elasticsearch-index.js`