### PR TITLE
Devex 922: separate applicationContext parameter for getCase

### DIFF
--- a/shared/src/business/test/createCaseFromPaperInteractor.e2e.test.js
+++ b/shared/src/business/test/createCaseFromPaperInteractor.e2e.test.js
@@ -62,8 +62,7 @@ describe('createCaseFromPaperInteractor integration test', () => {
       stinFileId: '72de0fac-f63c-464f-ac71-0f54fd248484',
     });
 
-    const createdCase = await getCaseInteractor({
-      applicationContext,
+    const createdCase = await getCaseInteractor(applicationContext, {
       docketNumber,
     });
 

--- a/shared/src/business/test/createCaseInteractor.e2e.test.js
+++ b/shared/src/business/test/createCaseInteractor.e2e.test.js
@@ -60,8 +60,7 @@ describe('createCase integration test', () => {
       stinFileId: '72de0fac-f63c-464f-ac71-0f54fd248484',
     });
 
-    const createdCase = await getCaseInteractor({
-      applicationContext,
+    const createdCase = await getCaseInteractor(applicationContext, {
       docketNumber,
     });
 

--- a/shared/src/business/test/fileExternalDocumentInteractor.e2e.test.js
+++ b/shared/src/business/test/fileExternalDocumentInteractor.e2e.test.js
@@ -119,8 +119,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
       },
     });
 
-    const caseAfterDocument = await getCaseInteractor({
-      applicationContext,
+    const caseAfterDocument = await getCaseInteractor(applicationContext, {
       docketNumber,
     });
 
@@ -430,8 +429,7 @@ describe('fileExternalDocumentInteractor integration test', () => {
       },
     });
 
-    const caseAfterDocument = await getCaseInteractor({
-      applicationContext,
+    const caseAfterDocument = await getCaseInteractor(applicationContext, {
       docketNumber,
     });
     const filedDocument = caseAfterDocument.docketEntries.find(

--- a/shared/src/business/useCases/getCaseInteractor.js
+++ b/shared/src/business/useCases/getCaseInteractor.js
@@ -90,7 +90,7 @@ const getCaseForExternalUser = async ({
  * @param {string} providers.docketNumber the docket number of the case to get
  * @returns {object} the case data
  */
-exports.getCaseInteractor = async ({ applicationContext, docketNumber }) => {
+exports.getCaseInteractor = async (applicationContext, { docketNumber }) => {
   const caseRecord = await applicationContext
     .getPersistenceGateway()
     .getFullCaseByDocketNumber({

--- a/shared/src/business/useCases/getCaseInteractor.test.js
+++ b/shared/src/business/useCases/getCaseInteractor.test.js
@@ -31,8 +31,7 @@ describe('getCaseInteractor', () => {
       .getPersistenceGateway()
       .getFullCaseByDocketNumber.mockReturnValue(MOCK_CASE);
 
-    await getCaseInteractor({
-      applicationContext,
+    await getCaseInteractor(applicationContext, {
       docketNumber: '000123-19S',
     });
 

--- a/shared/src/business/useCases/getCaseInteractor.test.js
+++ b/shared/src/business/useCases/getCaseInteractor.test.js
@@ -47,8 +47,7 @@ describe('getCaseInteractor', () => {
       );
 
     await expect(
-      getCaseInteractor({
-        applicationContext,
+      getCaseInteractor(applicationContext, {
         docketNumber: '123-19',
       }),
     ).rejects.toThrow('Case 123-19 was not found.');
@@ -69,8 +68,7 @@ describe('getCaseInteractor', () => {
       .getFullCaseByDocketNumber.mockReturnValue(mockInvalidCase);
 
     await expect(
-      getCaseInteractor({
-        applicationContext,
+      getCaseInteractor(applicationContext, {
         docketNumber: '00101-08',
       }),
     ).rejects.toThrow('The Case entity was invalid');
@@ -95,8 +93,7 @@ describe('getCaseInteractor', () => {
         userId: '320fce0e-b050-4e04-8720-db25da3ca598',
       });
 
-    const result = await getCaseInteractor({
-      applicationContext,
+    const result = await getCaseInteractor(applicationContext, {
       docketNumber: '00101-00',
     });
 
@@ -121,8 +118,7 @@ describe('getCaseInteractor', () => {
         }),
       );
 
-    const result = await getCaseInteractor({
-      applicationContext,
+    const result = await getCaseInteractor(applicationContext, {
       docketNumber: '00101-00',
     });
 
@@ -150,8 +146,7 @@ describe('getCaseInteractor', () => {
         userId: '320fce0e-b050-4e04-8720-db25da3ca598',
       });
 
-    const result = await getCaseInteractor({
-      applicationContext,
+    const result = await getCaseInteractor(applicationContext, {
       docketNumber: '00101-00',
     });
 
@@ -181,8 +176,7 @@ describe('getCaseInteractor', () => {
         role: ROLES.docketClerk,
         userId: docketClerkId,
       });
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
       expect(result.contactPrimary.city).toBeDefined();
@@ -206,8 +200,7 @@ describe('getCaseInteractor', () => {
         userId: applicationContext.getUniqueId(),
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 
@@ -259,8 +252,7 @@ describe('getCaseInteractor', () => {
         userId: practitioner2Id,
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 
@@ -287,8 +279,7 @@ describe('getCaseInteractor', () => {
         userId: docketClerkId,
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 
@@ -303,8 +294,7 @@ describe('getCaseInteractor', () => {
         userId: practitionerId,
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 
@@ -339,8 +329,7 @@ describe('getCaseInteractor', () => {
         userId: docketClerkId,
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 
@@ -355,8 +344,7 @@ describe('getCaseInteractor', () => {
         userId: practitionerId,
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 
@@ -371,8 +359,7 @@ describe('getCaseInteractor', () => {
         userId: practitioner2Id,
       });
 
-      const result = await getCaseInteractor({
-        applicationContext,
+      const result = await getCaseInteractor(applicationContext, {
         docketNumber: '101-18',
       });
 

--- a/web-api/src/cases/getCaseLambda.js
+++ b/web-api/src/cases/getCaseLambda.js
@@ -8,8 +8,9 @@ const { genericHandler } = require('../genericHandler');
  */
 exports.getCaseLambda = event =>
   genericHandler(event, async ({ applicationContext }) => {
-    return await applicationContext.getUseCases().getCaseInteractor({
-      applicationContext,
-      docketNumber: event.pathParameters.docketNumber,
-    });
+    return await applicationContext
+      .getUseCases()
+      .getCaseInteractor(applicationContext, {
+        docketNumber: event.pathParameters.docketNumber,
+      });
   });

--- a/web-api/src/v1/getCaseLambda.js
+++ b/web-api/src/v1/getCaseLambda.js
@@ -16,8 +16,7 @@ exports.getCaseLambda = (event, options = {}) =>
       return v1ApiWrapper(async () => {
         const caseObject = await applicationContext
           .getUseCases()
-          .getCaseInteractor({
-            applicationContext,
+          .getCaseInteractor(applicationContext, {
             docketNumber: event.pathParameters.docketNumber,
           });
 

--- a/web-api/src/v2/getCaseLambda.js
+++ b/web-api/src/v2/getCaseLambda.js
@@ -16,8 +16,7 @@ exports.getCaseLambda = (event, options = {}) =>
       return v2ApiWrapper(async () => {
         const caseObject = await applicationContext
           .getUseCases()
-          .getCaseInteractor({
-            applicationContext,
+          .getCaseInteractor(applicationContext, {
             docketNumber: event.pathParameters.docketNumber,
           });
 


### PR DESCRIPTION
https://trello.com/c/3gH4hRRi/922-for-api-lambdas-and-their-interactors-move-applicationcontext-from-the-providers-object-to-their-own-parameter

Starting with a single lambda to confirm the solution with others before moving on. 