### PR TITLE
7678 - Coversheet not updating

### DIFF
--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
@@ -645,7 +645,7 @@ describe('updateDocketEntryMetaInteractor', () => {
       expect(result).toBe(true);
     });
 
-    it('should return true when the documentTitle changes', async () => {
+    it('should return false if nothing related to the coversheet has changed on the metadata', async () => {
       mockDocketEntry.isMinuteEntry = false;
       shouldAddNewCoverSheet = false;
       entryRequiresCoverSheet = true;

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
@@ -609,5 +609,62 @@ describe('updateDocketEntryMetaInteractor', () => {
 
       expect(result).toBe(true);
     });
+
+    it('should return true when the certificateOfService changes', async () => {
+      mockDocketEntry.isMinuteEntry = false;
+      shouldAddNewCoverSheet = false;
+      entryRequiresCoverSheet = true;
+
+      const result = shouldGenerateCoversheetForDocketEntry({
+        certificateOfServiceUpdated: true,
+        entryRequiresCoverSheet,
+        filingDateUpdated,
+        originalDocketEntry,
+        servedAtUpdated,
+        shouldAddNewCoverSheet,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when the documentTitle changes', async () => {
+      mockDocketEntry.isMinuteEntry = false;
+      shouldAddNewCoverSheet = false;
+      entryRequiresCoverSheet = true;
+
+      const result = shouldGenerateCoversheetForDocketEntry({
+        certificateOfServiceUpdated: false,
+        documentTitleUpdated: true,
+        entryRequiresCoverSheet,
+        filingDateUpdated,
+        originalDocketEntry,
+        servedAtUpdated,
+        shouldAddNewCoverSheet,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when the documentTitle changes', async () => {
+      mockDocketEntry.isMinuteEntry = false;
+      shouldAddNewCoverSheet = false;
+      entryRequiresCoverSheet = true;
+      servedAtUpdated = false;
+      filingDateUpdated = false;
+      servedAtUpdated = false;
+      shouldAddNewCoverSheet = false;
+
+      const result = shouldGenerateCoversheetForDocketEntry({
+        certificateOfServiceUpdated: false,
+        documentTitleUpdated: false,
+        entryRequiresCoverSheet,
+        filingDateUpdated,
+        originalDocketEntry,
+        servedAtUpdated,
+        shouldAddNewCoverSheet,
+      });
+
+      expect(result).toBe(false);
+    });
   });
 });

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.js
@@ -39,8 +39,6 @@ const getNeedsNewCoversheet = ({ currentDocketEntry, updatedDocketEntry }) => {
       currentDocketEntry.receivedAt,
       updatedDocketEntry.receivedAt,
     ) !== 0;
-  const filedByUpdated =
-    currentDocketEntry.filedBy !== updatedDocketEntry.filedBy;
   const certificateOfServiceUpdated =
     currentDocketEntry.certificateOfService !==
     updatedDocketEntry.certificateOfService;
@@ -49,10 +47,7 @@ const getNeedsNewCoversheet = ({ currentDocketEntry, updatedDocketEntry }) => {
     getDocumentTitleWithAdditionalInfo({ docketEntry: updatedDocketEntry });
 
   return (
-    receivedAtUpdated ||
-    filedByUpdated ||
-    certificateOfServiceUpdated ||
-    documentTitleUpdated
+    receivedAtUpdated || certificateOfServiceUpdated || documentTitleUpdated
   );
 };
 

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
@@ -676,7 +676,7 @@ describe('completeDocketEntryQCInteractor', () => {
       expect(needsNewCoversheet).toBeTruthy();
     });
 
-    it('should return true when filedBy is updated', () => {
+    it('should return false when filedBy is updated', () => {
       const needsNewCoversheet = getNeedsNewCoversheet({
         currentDocketEntry: {
           filedBy: 'petitioner.smith',
@@ -688,7 +688,7 @@ describe('completeDocketEntryQCInteractor', () => {
         },
       });
 
-      expect(needsNewCoversheet).toBeTruthy();
+      expect(needsNewCoversheet).toBeFalsy();
     });
 
     it('should return true when documentTitle is updated', () => {


### PR DESCRIPTION
The edit meta interactor was not checking to see if the document title or certificate of service had changed to recreate the coversheet.  Also fixed a bug with the completeQC generating a new coversheet when filedBy was changed.