### PR TITLE
7678 - Additional Integration Tests

### DIFF
--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.js
@@ -173,13 +173,16 @@ exports.updateDocketEntryMetaInteractor = async ({
       document: docketEntryEntity.validate(),
     });
 
-    // servedAt or filingDate has changed, generate a new coversheet
-    await applicationContext.getUseCases().addCoversheetInteractor({
-      applicationContext,
-      docketEntryId: originalDocketEntry.docketEntryId,
-      docketNumber: caseEntity.docketNumber,
-      filingDateUpdated,
-    });
+    const updatedDocketEntry = await applicationContext
+      .getUseCases()
+      .addCoversheetInteractor({
+        applicationContext,
+        docketEntryId: originalDocketEntry.docketEntryId,
+        docketNumber: caseEntity.docketNumber,
+        filingDateUpdated,
+      });
+
+    caseEntity.updateDocketEntry(updatedDocketEntry);
   }
 
   const result = await applicationContext

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.test.js
@@ -128,6 +128,25 @@ describe('updateDocketEntryMetaInteractor', () => {
       .getCaseByDocketNumber.mockImplementation(({ docketNumber }) => {
         return caseByDocketNumber[docketNumber];
       });
+
+    applicationContext
+      .getUseCases()
+      .addCoversheetInteractor.mockImplementation(() => ({
+        createdAt: '2011-02-22T00:01:00.000Z',
+        docketEntryId: 'e110995d-b825-4f7e-899e-1773aa8e7016',
+        documentTitle: 'Summary Opinion',
+        documentType: 'Summary Opinion',
+        entityName: 'DocketEntry',
+        eventCode: 'SOP',
+        filingDate: '2011-02-22T00:01:00.000Z',
+        index: 7,
+        isDraft: false,
+        isMinuteEntry: false,
+        isOnDocketRecord: false,
+        judge: 'Buch',
+        processingStatus: 'complete',
+        userId: mockUserId,
+      }));
   });
 
   it('should throw an Unauthorized error if the user is not authorized', async () => {

--- a/web-client/integration-tests/journey/docketClerkNavigatesToEditDocketEntryCertificateOfService.js
+++ b/web-client/integration-tests/journey/docketClerkNavigatesToEditDocketEntryCertificateOfService.js
@@ -8,6 +8,8 @@ export const docketClerkNavigatesToEditDocketEntryCertificateOfService = (
       docketRecordIndex,
     });
 
+    expect(test.getState('form.numberOfPages')).toEqual(2);
+
     expect(test.getState('currentPage')).toEqual('EditDocketEntryMeta');
     expect(test.getState('screenMetadata.documentTitlePreview')).toEqual(
       'Certificate of Service of Petition 03-03-2003',
@@ -31,5 +33,74 @@ export const docketClerkNavigatesToEditDocketEntryCertificateOfService = (
       'Certificate of Service of Petition 05-10-2005',
     );
     expect(test.getState('form.serviceDate')).toEqual('2005-05-10');
+
+    await test.runSequence('submitEditDocketEntryMetaSequence', {
+      docketNumber: test.docketNumber,
+    });
+
+    expect(test.getState('validationErrors')).toEqual({});
+
+    expect(test.getState('alertSuccess')).toMatchObject({
+      message: 'Docket entry changes saved.',
+    });
+
+    await test.runSequence('gotoEditDocketEntryMetaSequence', {
+      docketNumber: test.docketNumber,
+      docketRecordIndex,
+    });
+
+    expect(test.getState('form.numberOfPages')).toEqual(3);
+
+    await test.runSequence('updateDocketEntryMetaDocumentFormValueSequence', {
+      key: 'filingDateDay',
+      value: '13',
+    });
+    await test.runSequence('updateDocketEntryMetaDocumentFormValueSequence', {
+      key: 'filingDateMonth',
+      value: '07',
+    });
+    await test.runSequence('updateDocketEntryMetaDocumentFormValueSequence', {
+      key: 'filingDateYear',
+      value: '2002',
+    });
+
+    await test.runSequence('submitEditDocketEntryMetaSequence', {
+      docketNumber: test.docketNumber,
+    });
+
+    expect(test.getState('validationErrors')).toEqual({});
+
+    expect(test.getState('alertSuccess')).toMatchObject({
+      message: 'Docket entry changes saved.',
+    });
+
+    await test.runSequence('gotoEditDocketEntryMetaSequence', {
+      docketNumber: test.docketNumber,
+      docketRecordIndex,
+    });
+
+    expect(test.getState('form.numberOfPages')).toEqual(4);
+
+    await test.runSequence('updateDocketEntryMetaDocumentFormValueSequence', {
+      key: 'eventCode',
+      value: 'BND',
+    });
+
+    await test.runSequence('submitEditDocketEntryMetaSequence', {
+      docketNumber: test.docketNumber,
+    });
+
+    expect(test.getState('validationErrors')).toEqual({});
+
+    expect(test.getState('alertSuccess')).toMatchObject({
+      message: 'Docket entry changes saved.',
+    });
+
+    await test.runSequence('gotoEditDocketEntryMetaSequence', {
+      docketNumber: test.docketNumber,
+      docketRecordIndex,
+    });
+
+    expect(test.getState('form.numberOfPages')).toEqual(5);
   });
 };


### PR DESCRIPTION
Adding integration tests to verify that when certain fields (filedAt, servedAt, documentType) changes, that a new coversheet is added to the document.