### PR TITLE
Restrict USWDS to patch-level versions of ~2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "stylelint-config-standard": "^21.0.0",
     "swagger-cli": "^4.0.4",
     "tmp": "^0.2.1",
-    "uswds": "^2.10.3",
+    "uswds": "~2.10.3",
     "uuid": "^8.3.2",
     "websocket": "^1.0.33",
     "wicg-inert": "^3.1.1",


### PR DESCRIPTION
Upgrading to USWDS version ^2.11.x introduces unexpected changes to icons, so we're keeping it as ~2.10 for now.
Symptom of upgrading to 2.11 seen below:
![image](https://user-images.githubusercontent.com/2445917/111667764-0966f380-87e3-11eb-913c-5fb2cd36ae0f.png)

Related bug/task: https://github.com/flexion/ef-cms/issues/8028