### PR TITLE
7863 ux feedback

### DIFF
--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.js
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.js
@@ -64,7 +64,7 @@ export const addCourtIssuedDocketEntryNonstandardHelper = (
   } else if (selectedEventCode === 'NOT') {
     freeTextLabel = 'What is this notice for?';
   } else {
-    freeTextLabel = 'Enter description';
+    freeTextLabel = 'Description';
   }
 
   let dateLabel = 'Date';

--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.test.js
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper.test.js
@@ -180,7 +180,7 @@ describe('addCourtIssuedDocketEntryNonstandardHelper', () => {
       state: testState,
     });
     expect(result).toMatchObject({
-      freeTextLabel: 'Enter description',
+      freeTextLabel: 'Description',
     });
   });
 });

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1550,6 +1550,10 @@ button.change-scanner-button {
   width: 600px;
   max-height: 41px;
   margin: 0.5rem 0;
+
+  &.edit-docket--visible-overflow {
+    overflow: visible;
+  }
 }
 
 #service-parties {

--- a/web-client/src/views/EditDocketEntry/EditDocketEntryMeta.jsx
+++ b/web-client/src/views/EditDocketEntry/EditDocketEntryMeta.jsx
@@ -38,7 +38,7 @@ export const EditDocketEntryMeta = connect(
             </div>
             <div className="grid-col-7">
               <div className="display-flex flex-row flex-justify flex-align-center">
-                <div className="margin-top-1 margin-bottom-1 docket-entry-preview-text">
+                <div className="margin-top-1 margin-bottom-1 docket-entry-preview-text edit-docket--visible-overflow">
                   <span className="text-bold">Docket Entry preview: </span>
                   <EditDocketEntryMetaDocketEntryPreview />
                 </div>


### PR DESCRIPTION
* updated "Edit description" to "Description"
* added css class only on editing a docket entry to fully display the docket entry preview.

on editing a docket entry, entire preview displays: 
![image](https://user-images.githubusercontent.com/16403861/111675504-6ca05800-87da-11eb-96f8-d86230f79576.png)

on adding a new court-issued docket entry, preview partially displays (as before):
![image](https://user-images.githubusercontent.com/16403861/111675558-7e81fb00-87da-11eb-9fa6-fdeea60b4157.png)

