### PR TITLE
5311: remove match predicates on pk/sk

### DIFF
--- a/shared/src/persistence/elasticsearch/getReconciliationReport.js
+++ b/shared/src/persistence/elasticsearch/getReconciliationReport.js
@@ -37,8 +37,6 @@ exports.getReconciliationReport = async ({
             },
           },
         },
-        { match: { 'pk.S': 'case|' } },
-        { match: { 'sk.S': 'docket-entry|' } },
       ],
     },
   };


### PR DESCRIPTION
elasticsearch indexes should no longer contain "match" queries for pk or sk because column types have changed.