### PR TITLE
5311 - Reconciliation Report Fixes

### DIFF
--- a/shared/src/authorization/authorizationClientService.js
+++ b/shared/src/authorization/authorizationClientService.js
@@ -224,6 +224,10 @@ exports.AUTHORIZATION_MAP = AUTHORIZATION_MAP;
  * @returns {boolean} true if user is authorized, false otherwise
  */
 exports.isAuthorized = (user, action, owner) => {
+  if (!user) {
+    return false;
+  }
+
   if (user.userId && user.userId === owner) {
     return true;
   }

--- a/shared/src/authorization/authorizationClientService.test.js
+++ b/shared/src/authorization/authorizationClientService.test.js
@@ -6,6 +6,9 @@ const {
 const { ROLES } = require('../business/entities/EntityConstants');
 
 describe('Authorization client service', () => {
+  it('returns false for undefined user', () => {
+    expect(isAuthorized(undefined, 'unknown action', 'someUser')).toBeFalsy();
+  });
   it('returns true for any user whose userId matches the 3rd owner argument, in this case "someUser" === "someUser"', () => {
     expect(
       isAuthorized(

--- a/shared/src/business/entities/DocketEntry.js
+++ b/shared/src/business/entities/DocketEntry.js
@@ -5,6 +5,8 @@ const {
   EXTERNAL_DOCUMENT_TYPES,
   NOTICE_OF_CHANGE_CONTACT_INFORMATION_EVENT_CODES,
   PRACTITIONER_ASSOCIATION_DOCUMENT_TYPES,
+  ROLES,
+  SERVED_PARTIES_CODES,
   TRACKED_DOCUMENT_TYPES_EVENT_CODES,
 } = require('./EntityConstants');
 const {
@@ -200,6 +202,7 @@ DocketEntry.prototype.setAsServed = function (servedParties = null) {
 
   if (servedParties) {
     this.servedParties = servedParties;
+    this.servedPartiesCode = getServedPartiesCode(servedParties);
   }
 };
 
@@ -370,4 +373,28 @@ const isServed = function (rawDocketEntry) {
   return !!rawDocketEntry.servedAt || !!rawDocketEntry.isLegacyServed;
 };
 
-module.exports = { DocketEntry: validEntityDecorator(DocketEntry), isServed };
+/**
+ * Determines the servedPartiesCode based on the given servedParties
+ *
+ * @returns {String} served parties code
+ */
+const getServedPartiesCode = servedParties => {
+  let servedPartiesCode = '';
+  if (servedParties && servedParties.length > 0) {
+    if (
+      servedParties.length === 1 &&
+      servedParties[0].role === ROLES.irsSuperuser
+    ) {
+      servedPartiesCode = SERVED_PARTIES_CODES.RESPONDENT;
+    } else {
+      servedPartiesCode = SERVED_PARTIES_CODES.BOTH;
+    }
+  }
+  return servedPartiesCode;
+};
+
+module.exports = {
+  DocketEntry: validEntityDecorator(DocketEntry),
+  getServedPartiesCode,
+  isServed,
+};

--- a/shared/src/business/entities/DocketEntry.test.js
+++ b/shared/src/business/entities/DocketEntry.test.js
@@ -11,10 +11,15 @@ const {
   ORDER_TYPES,
   PETITIONS_SECTION,
   ROLES,
+  SERVED_PARTIES_CODES,
   TRANSCRIPT_EVENT_CODE,
 } = require('./EntityConstants');
+const {
+  DocketEntry,
+  getServedPartiesCode,
+  isServed,
+} = require('./DocketEntry');
 const { applicationContext } = require('../test/createTestApplicationContext');
-const { DocketEntry, isServed } = require('./DocketEntry');
 const { omit } = require('lodash');
 const { WorkItem } = require('./WorkItem');
 
@@ -150,6 +155,48 @@ describe('DocketEntry entity', () => {
       );
 
       expect(isServed(doc1)).toBeTruthy();
+    });
+  });
+
+  describe('getServedPartiesCode', () => {
+    it('returns an empty string if servedParties is undefined', () => {
+      const servedPartiesCode = getServedPartiesCode();
+      expect(servedPartiesCode).toEqual('');
+    });
+
+    it('returns an empty string if servedParties is an empty array', () => {
+      const servedPartiesCode = getServedPartiesCode([]);
+      expect(servedPartiesCode).toEqual('');
+    });
+
+    it('returns the servedParties code for respondent if the only party in the given servedParties array has the irsSuperUser role', () => {
+      const servedPartiesCode = getServedPartiesCode([
+        {
+          role: ROLES.irsSuperuser,
+        },
+      ]);
+      expect(servedPartiesCode).toEqual(SERVED_PARTIES_CODES.RESPONDENT);
+    });
+
+    it('returns the servedParties code for both if the only party in the given servedParties array does not have the irsSuperUser role', () => {
+      const servedPartiesCode = getServedPartiesCode([
+        {
+          role: ROLES.petitioner,
+        },
+      ]);
+      expect(servedPartiesCode).toEqual(SERVED_PARTIES_CODES.BOTH);
+    });
+
+    it('returns the servedParties code for both if the the given servedParties array contains multiple servedParties', () => {
+      const servedPartiesCode = getServedPartiesCode([
+        {
+          role: ROLES.irsSuperuser,
+        },
+        {
+          role: ROLES.petitioner,
+        },
+      ]);
+      expect(servedPartiesCode).toEqual(SERVED_PARTIES_CODES.BOTH);
     });
   });
 

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -956,6 +956,8 @@ Case.prototype.removePrivatePractitioner = function (practitionerToRemove) {
  * @param {object} docketEntryEntity the docket entry to add to the case
  */
 Case.prototype.addDocketEntry = function (docketEntryEntity) {
+  docketEntryEntity.docketNumber = this.docketNumber;
+
   if (docketEntryEntity.isOnDocketRecord) {
     const updateIndex = shouldGenerateDocketRecordIndex({
       caseDetail: this,

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -1576,10 +1576,10 @@ describe('Case entity', () => {
     });
   });
 
-  describe('addDocument', () => {
+  describe('addDocketEntry', () => {
     it('attaches the docket entry to the case', () => {
       const caseToVerify = new Case(
-        {},
+        { docketNumber: '123-45' },
         {
           applicationContext,
         },
@@ -1592,6 +1592,7 @@ describe('Case entity', () => {
       expect(caseToVerify.docketEntries.length).toEqual(1);
       expect(caseToVerify.docketEntries[0]).toMatchObject({
         docketEntryId: '123',
+        docketNumber: '123-45',
         documentType: 'Answer',
         userId: 'irsPractitioner',
       });

--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -66,7 +66,6 @@ const {
   formatCase,
   formatCaseDeadlines,
   formatDocketEntry,
-  getServedPartiesCode,
   sortDocketEntries,
 } = require('../../../src/business/utilities/getFormattedCaseDetail');
 const {
@@ -159,7 +158,7 @@ const { filterEmptyStrings } = require('../utilities/filterEmptyStrings');
 const { formatDollars } = require('../utilities/formatDollars');
 const { getConstants } = require('../../../../web-client/src/getConstants');
 const { getItem } = require('../../persistence/localStorage/getItem');
-const { isServed } = require('../entities/DocketEntry');
+const { getServedPartiesCode, isServed } = require('../entities/DocketEntry');
 const { removeItem } = require('../../persistence/localStorage/removeItem');
 const { replaceBracketed } = require('../utilities/replaceBracketed');
 const { ROLES } = require('../entities/EntityConstants');

--- a/shared/src/business/useCases/getReconciliationReportInteractor.js
+++ b/shared/src/business/useCases/getReconciliationReportInteractor.js
@@ -12,7 +12,6 @@ const {
 const {
   ReconciliationReportEntry,
 } = require('../entities/ReconciliationReportEntry');
-const { map } = require('lodash');
 const { UnauthorizedError } = require('../../errors/errors');
 
 const isValidDate = dateString => {
@@ -89,11 +88,15 @@ const assignCaseCaptionFromPersistence = async (
   applicationContext,
   docketEntries,
 ) => {
-  const docketNumbers = map(docketEntries, 'docketNumber');
+  const docketNumbers = docketEntries.map(e => {
+    const docketNumber = e.docketNumber || e.pk.substr(e.pk.indexOf('|') + 1);
+    e.docketNumber = docketNumber;
+    return e.docketNumber;
+  });
   const casesDetails = await applicationContext
     .getPersistenceGateway()
     .getCasesByDocketNumbers({ applicationContext, docketNumbers });
-  // todo: could there be docket entries for cases that are not in persistence?? accessing "caseCaption" of undefined
+
   docketEntries.forEach(docketEntry => {
     docketEntry.caseCaption = casesDetails.find(
       detail => detail.docketNumber === docketEntry.docketNumber,

--- a/shared/src/business/useCases/getReconciliationReportInteractor.js
+++ b/shared/src/business/useCases/getReconciliationReportInteractor.js
@@ -93,6 +93,7 @@ const assignCaseCaptionFromPersistence = async (
   const casesDetails = await applicationContext
     .getPersistenceGateway()
     .getCasesByDocketNumbers({ applicationContext, docketNumbers });
+  // todo: could there be docket entries for cases that are not in persistence?? accessing "caseCaption" of undefined
   docketEntries.forEach(docketEntry => {
     docketEntry.caseCaption = casesDetails.find(
       detail => detail.docketNumber === docketEntry.docketNumber,

--- a/shared/src/business/useCases/getReconciliationReportInteractor.test.js
+++ b/shared/src/business/useCases/getReconciliationReportInteractor.test.js
@@ -20,6 +20,8 @@ describe('getReconciliationReportInteractor', () => {
         {
           caseCaption: mockCaseCaption,
           docketNumber: '135-20',
+          pk: 'case|135-20',
+          sk: 'case|135-20',
         },
       ]);
     applicationContext.getCurrentUser.mockReturnValue({
@@ -133,5 +135,34 @@ describe('getReconciliationReportInteractor', () => {
       reconciliationDateEnd: '2021-01-02T04:59:59.999Z',
       reconciliationDateStart: '2021-01-01T05:00:00.000Z',
     });
+  });
+
+  it('should call the getCasesByDocketNumbers method with a docket number extracted from pk if the record has no defined value for the docketNumber attribute', async () => {
+    const docketEntries = [
+      {
+        docketEntryId: '3d27e02e-6954-4595-8b3f-0e91bbc1b51e',
+        docketNumber: undefined,
+        documentTitle: 'Petition',
+        eventCode: 'P',
+        filedBy: 'Petr. Kaitlin Chaney',
+        filingDate: '2021-01-05T21:14:09.031Z',
+        pk: 'case|135-20',
+        servedAt: '2021-01-05T21:14:09.031Z',
+      },
+    ];
+
+    applicationContext
+      .getPersistenceGateway()
+      .getReconciliationReport.mockReturnValue(docketEntries);
+
+    const reconciliationDate = '2021-01-01';
+    await getReconciliationReportInteractor(applicationContext, {
+      reconciliationDate,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().getCasesByDocketNumbers.mock
+        .calls[0][0].docketNumbers,
+    ).toEqual(['135-20']);
   });
 });

--- a/shared/src/business/useCases/saveSignedDocumentInteractor.js
+++ b/shared/src/business/useCases/saveSignedDocumentInteractor.js
@@ -93,6 +93,7 @@ exports.saveSignedDocumentInteractor = async (
       {
         createdAt: applicationContext.getUtilities().createISODateString(),
         docketEntryId: signedDocketEntryId,
+        docketNumber: caseRecord.docketNumber,
         documentTitle:
           SIGNED_DOCUMENT_TYPES.signedStipulatedDecision.documentType,
         documentType:

--- a/shared/src/business/useCases/saveSignedDocumentInteractor.test.js
+++ b/shared/src/business/useCases/saveSignedDocumentInteractor.test.js
@@ -1,6 +1,7 @@
 const {
   DOCUMENT_PROCESSING_STATUS_OPTIONS,
   PETITIONS_SECTION,
+  SIGNED_DOCUMENT_TYPES,
 } = require('../entities/EntityConstants');
 const {
   saveSignedDocumentInteractor,
@@ -100,6 +101,12 @@ describe('saveSignedDocumentInteractor', () => {
     );
 
     expect(caseEntity.docketEntries.length).toEqual(MOCK_DOCUMENTS.length + 1);
+    const signedDocument = caseEntity.docketEntries.find(
+      e =>
+        e.documentType ===
+        SIGNED_DOCUMENT_TYPES.signedStipulatedDecision.documentType,
+    );
+    expect(signedDocument.docketNumber).toEqual(caseEntity.docketNumber);
 
     const signedDocketEntryEntity = caseEntity.docketEntries.find(
       doc =>

--- a/shared/src/business/utilities/getFormattedCaseDetail.js
+++ b/shared/src/business/utilities/getFormattedCaseDetail.js
@@ -15,23 +15,7 @@ const {
 } = require('../entities/EntityConstants');
 const { Case } = require('../entities/cases/Case');
 const { cloneDeep, isEmpty, sortBy } = require('lodash');
-const { isServed } = require('../entities/DocketEntry');
-const { ROLES } = require('../entities/EntityConstants');
-
-const getServedPartiesCode = servedParties => {
-  let servedPartiesCode = '';
-  if (servedParties && servedParties.length > 0) {
-    if (
-      servedParties.length === 1 &&
-      servedParties[0].role === ROLES.irsSuperuser
-    ) {
-      servedPartiesCode = SERVED_PARTIES_CODES.RESPONDENT;
-    } else {
-      servedPartiesCode = SERVED_PARTIES_CODES.BOTH;
-    }
-  }
-  return servedPartiesCode;
-};
+const { getServedPartiesCode, isServed } = require('../entities/DocketEntry');
 
 const TRANSCRIPT_AGE_DAYS_MIN = 90;
 const documentMeetsAgeRequirements = doc => {
@@ -596,6 +580,5 @@ module.exports = {
   formatDocketEntry,
   getFilingsAndProceedings,
   getFormattedCaseDetail,
-  getServedPartiesCode,
   sortDocketEntries,
 };

--- a/shared/src/persistence/elasticsearch/getReconciliationReport.js
+++ b/shared/src/persistence/elasticsearch/getReconciliationReport.js
@@ -46,6 +46,7 @@ exports.getReconciliationReport = async ({
     searchParameters: {
       body: {
         _source: [
+          'pk',
           'docketNumber',
           'documentTitle',
           'docketEntryId',

--- a/web-api/migration-terraform/main/lambdas/migration-segments.js
+++ b/web-api/migration-terraform/main/lambdas/migration-segments.js
@@ -2,6 +2,10 @@ const AWS = require('aws-sdk');
 const createApplicationContext = require('../../../src/applicationContext');
 
 const {
+  migrateItems: migration0024,
+} = require('./migrations/0024-docket-entry-docket-number-served-parties-code');
+
+const {
   migrateItems: validationMigration,
 } = require('./migrations/0000-validate-all-items');
 const { chunk, isEmpty } = require('lodash');
@@ -25,7 +29,10 @@ const sqs = new AWS.SQS({ region: 'us-east-1' });
 
 // eslint-disable-next-line no-unused-vars
 const migrateRecords = async ({ documentClient, items }) => {
-  // applicationContext.logger.info('about to run validation migration');
+  applicationContext.logger.info('about to run migration 0024');
+  items = await migration0024(items, documentClient);
+
+  applicationContext.logger.info('about to run validation migration');
   items = await validationMigration(items, documentClient);
 
   return items;

--- a/web-api/migration-terraform/main/lambdas/migrations/0024-docket-entry-docket-number-served-parties-code.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0024-docket-entry-docket-number-served-parties-code.js
@@ -1,0 +1,41 @@
+const createApplicationContext = require('../../../../src/applicationContext');
+const {
+  DocketEntry,
+  getServedPartiesCode,
+} = require('../../../../../shared/src/business/entities/DocketEntry');
+
+const applicationContext = createApplicationContext({});
+
+const migrateItems = async items => {
+  const itemsAfter = [];
+  for (const item of items) {
+    if (item.pk.startsWith('case|') && item.sk.startsWith('docket-entry|')) {
+      if (!item.docketNumber) {
+        const docketNumber = item.pk.substr(item.pk.indexOf('|') + 1);
+        item.docketNumber = docketNumber;
+      }
+
+      if (
+        item.servedParties &&
+        item.servedParties.length > 0 &&
+        !item.servedPartiesCode
+      ) {
+        item.servedPartiesCode = getServedPartiesCode(item.servedParties);
+      }
+
+      new DocketEntry(item, { applicationContext }).validate();
+
+      applicationContext.logger.info(
+        'Updating docketNumber and/or servedPartiesCode for docketEntry',
+        { pk: item.pk, processingStatus: item.processingStatus, sk: item.sk },
+      );
+
+      itemsAfter.push(item);
+    } else {
+      itemsAfter.push(item);
+    }
+  }
+  return itemsAfter;
+};
+
+exports.migrateItems = migrateItems;

--- a/web-api/migration-terraform/main/lambdas/migrations/0024-docket-entry-docket-number-served-parties-code.test.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0024-docket-entry-docket-number-served-parties-code.test.js
@@ -1,0 +1,176 @@
+const {
+  migrateItems,
+} = require('./0024-docket-entry-docket-number-served-parties-code');
+const {
+  ROLES,
+  SERVED_PARTIES_CODES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+
+describe('migrateItems', () => {
+  let mockDocketEntry;
+  beforeEach(() => {
+    mockDocketEntry = {
+      createdAt: '2018-11-21T20:49:28.192Z',
+      docketEntryId: 'c6b81f4d-1e47-423a-8caf-6d2fdc3d3859',
+      documentTitle: 'Order that case is assigned to [Judge name] [Anything]',
+      documentType: 'Order that case is assigned',
+      eventCode: 'OAJ',
+      filedBy: 'Test Petitioner',
+      filingDate: '2018-03-01T00:01:00.000Z',
+      freeText: 'Cheese fries',
+      index: 1,
+      isFileAttached: true,
+      isOnDocketRecord: true,
+      judge: 'Fieri',
+      processingStatus: 'complete',
+      scenario: 'Type B',
+      signedAt: '2018-03-01T00:01:00.000Z',
+      signedByUserId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+      signedJudgeName: 'Judge Guy Fieri',
+      sk: 'docket-entry|c6b81f4d-1e47-423a-8caf-6d2fdc3d3859',
+      userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+    };
+  });
+
+  it('should return and not modify records that are NOT docket entries', async () => {
+    const items = [
+      {
+        ...mockDocketEntry,
+        pk: 'case|000-00',
+        sk: 'case|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        ...mockDocketEntry,
+        pk: 'case|000-00',
+        sk: 'case|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ]);
+  });
+
+  it('should not modify the docketNumber field on records that already have a docketNumber field', async () => {
+    const items = [
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|000-00', // the pk is intentionally not matching the docket number to prove it does not get changed
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|000-00',
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ]);
+  });
+
+  it('should not modify the servedPartiesCode field on records that do not have servedParties', async () => {
+    const items = [
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        servedParties: undefined,
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ]);
+  });
+
+  it('should not modify the servedPartiesCode field on records that have servedParties and a servedPartiesCode already set', async () => {
+    const items = [
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        servedAt: '2018-11-21T20:49:28.192Z',
+        servedParties: [{ name: 'Test Petitioner', role: ROLES.petitioner }],
+        servedPartiesCode: SERVED_PARTIES_CODES.BOTH,
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        servedAt: '2018-11-21T20:49:28.192Z',
+        servedParties: [{ name: 'Test Petitioner', role: ROLES.petitioner }],
+        servedPartiesCode: SERVED_PARTIES_CODES.BOTH,
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ]);
+  });
+
+  it('should set the docketNumber on the given item if it does not exist', async () => {
+    const items = [
+      {
+        ...mockDocketEntry,
+        pk: 'case|123-45',
+        servedParties: undefined,
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ]);
+  });
+
+  it('should set the servedPartiesCode on the given item if there are servedParties but no servedPartiesCode', async () => {
+    const items = [
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        servedAt: '2018-11-21T20:49:28.192Z',
+        servedParties: [{ name: 'IRS Superuser', role: ROLES.irsSuperuser }],
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        ...mockDocketEntry,
+        docketNumber: '123-45',
+        pk: 'case|123-45',
+        servedAt: '2018-11-21T20:49:28.192Z',
+        servedParties: [{ name: 'IRS Superuser', role: ROLES.irsSuperuser }],
+        servedPartiesCode: SERVED_PARTIES_CODES.RESPONDENT,
+        sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ]);
+  });
+});

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -5,6 +5,7 @@ import {
 } from '../../shared/src/business/entities/cases/Case';
 import {
   DocketEntry,
+  getServedPartiesCode,
   isServed,
 } from '../../shared/src/business/entities/DocketEntry';
 import { ErrorFactory } from './presenter/errors/ErrorFactory';
@@ -116,7 +117,6 @@ import {
   formatDocketEntry,
   getFilingsAndProceedings,
   getFormattedCaseDetail,
-  getServedPartiesCode,
   sortDocketEntries,
 } from '../../shared/src/business/utilities/getFormattedCaseDetail';
 import { forwardMessageInteractor } from '../../shared/src/proxies/messages/forwardMessageProxy';


### PR DESCRIPTION
Address issues where either expected results are NOT returned due to the servedPartiesCode not being explicitly set on a docketEntry record OR an error is thrown due to a missing docketNumber on a docketEntry returned in the query. 

Currently docketNumber is not required on DocketEntry entities, but a DevEx task has been created to address this.

*NOTE: Requires migration