### PR TITLE
933 devex: use edge with cypress

### DIFF
--- a/cypress-public.json
+++ b/cypress-public.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:5678",
-  "browser": "edge",
+  "browser": "chrome",
   "reporter": "spec",
   "reporterOptions": {
     "toConsole": true

--- a/cypress-public.json
+++ b/cypress-public.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:5678",
+  "browser": "edge",
   "reporter": "spec",
   "reporterOptions": {
     "toConsole": true

--- a/cypress-smoketests-public.json
+++ b/cypress-smoketests-public.json
@@ -1,4 +1,5 @@
 {
+  "browser": "edge",
   "reporter": "spec",
   "reporterOptions": {
     "toConsole": true

--- a/cypress-smoketests-public.json
+++ b/cypress-smoketests-public.json
@@ -1,5 +1,5 @@
 {
-  "browser": "edge",
+  "browser": "chrome",
   "reporter": "spec",
   "reporterOptions": {
     "toConsole": true

--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -1,4 +1,5 @@
 {
+  "browser": "edge",
   "reporter": "spec",
   "reporterOptions": {
     "toConsole": true

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:1234",
+  "browser": "edge",
   "reporter": "spec",
   "reporterOptions": {
     "toConsole": true

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -96,7 +96,7 @@ We use this list when performing a code review to ensure that all tasks have bee
   - [ ] Fetch the pull request for the sprint (e.g., `git fetch origin pull/{PR #}/head:sprint-{Sprint #}`), and then switch to that branch (e.g. `git checkout sprint-{Sprint #}`)
   - [ ] stand up the site locally, with `./docker-run.sh`
 	- [ ] test all functionality in all major browsers, emphasizing the functionality that this pull request addresses
-	- [ ] for internal Court functionality, perform the most thorough testing in Chrome, though also test in Edge and Firefox
+	- [ ] for internal Court functionality, perform the most thorough testing in Edge, though also test in Chrome and Firefox
 	- [ ] for public-facing functionality, test in browsers consistent with [public browser use data](https://analytics.usa.gov/)
 	- [ ] test in Mobile Safari and Mobile Chrome (or an emulator like Chrome DevTools), with the caveat that not all internal Court functionality will be necessary on these platforms
 	- [ ] use an automated audit tool for code quality and practices (recommended: [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/), aka [Lighthouse](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk))

--- a/wikiwiki/Site-Access.md
+++ b/wikiwiki/Site-Access.md
@@ -4,7 +4,7 @@
 * Public-facing pages will be optimized for smaller screens and be fully accessible (tested with screen readers, keyboard navigation, etc)
 * Public-facing pages that are loaded in non-Chrome browsers will see a message that the system is optimized for Chrome and to switch to that browser if possible
 * Internal Court pages will not be tested on smaller screens as their access is limited to laptops or desktops and will only be minimally tested for full accessibility (de-prioritized due to shortened timeframe for MVP)
-* Internal Court pages will be optimized only for Google Chrome and Microsoft Edge, as internal users will be told to access it this way (to eliminate timely cross-browser testing for MVP)
+* Internal Court pages will be optimized only for Microsoft Edge and Google Chrome, as internal users will be told to access it this way (to eliminate timely cross-browser testing for MVP)
 
 # Roles
 ### Internal User Roles


### PR DESCRIPTION
The court has begun issuing new devices on which Edge will be the primary browser.  To support these browsers, we should try to focus our automated testing on usage of Edge where appropriate.

*update: configuring public-facing cypress tests to use chrome, but configuring cypress tests for internal users to be driven by Edge.

https://trello.com/c/XJ4mA4H4/933-use-edge-with-cypress-tests