### PR TITLE
Devex 837: rename Edit Docket Entry -> Docket Entry Qc

### DIFF
--- a/web-client/integration-tests/docketClerkExternalDocumentQCWorkflow.test.js
+++ b/web-client/integration-tests/docketClerkExternalDocumentQCWorkflow.test.js
@@ -134,7 +134,7 @@ describe('Create a work item', () => {
   });
 
   it('docket clerk QCs a document, updates the document title, and generates a Notice of Docket Change', async () => {
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: decisionWorkItem.docketEntry.docketEntryId,
       docketNumber: caseDetail.docketNumber,
     });
@@ -202,12 +202,12 @@ describe('Create a work item', () => {
       },
     });
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: decisionWorkItem.docketEntry.docketEntryId,
       docketNumber: caseDetail.docketNumber,
     });
 
-    expect(test.getState('currentPage')).toEqual('EditDocketEntry');
+    expect(test.getState('currentPage')).toEqual('DocketEntryQc');
 
     await test.runSequence('updateDocketEntryFormValueSequence', {
       key: 'eventCode',
@@ -310,12 +310,12 @@ describe('Create a work item', () => {
       },
     });
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: ratificationWorkItem.docketEntry.docketEntryId,
       docketNumber: caseDetail.docketNumber,
     });
 
-    expect(test.getState('currentPage')).toEqual('EditDocketEntry');
+    expect(test.getState('currentPage')).toEqual('DocketEntryQc');
 
     await test.runSequence('updateDocketEntryFormValueSequence', {
       key: 'freeText',
@@ -409,12 +409,12 @@ describe('Create a work item', () => {
       },
     });
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: ratificationWorkItem.docketEntry.docketEntryId,
       docketNumber: caseDetail.docketNumber,
     });
 
-    expect(test.getState('currentPage')).toEqual('EditDocketEntry');
+    expect(test.getState('currentPage')).toEqual('DocketEntryQc');
 
     await test.runSequence('updateDocketEntryFormValueSequence', {
       key: 'freeText',

--- a/web-client/integration-tests/documentTitleJourney.test.js
+++ b/web-client/integration-tests/documentTitleJourney.test.js
@@ -101,7 +101,7 @@ describe('Document title journey', () => {
       .getState('caseDetail.docketEntries')
       .find(entry => entry.eventCode === 'EXH');
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: exhibitDocketEntry.docketEntryId,
       docketNumber: test.docketNumber,
     });

--- a/web-client/integration-tests/journey/docketClerkCompletesDocketEntryQcAndSendsMessage.js
+++ b/web-client/integration-tests/journey/docketClerkCompletesDocketEntryQcAndSendsMessage.js
@@ -23,7 +23,7 @@ export const docketClerkCompletesDocketEntryQcAndSendsMessage = test => {
 
     expect(proposedStipulatedDecision.isRead).toBeFalsy();
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: proposedStipulatedDecision.docketEntry.docketEntryId,
       docketNumber: test.docketNumber,
     });

--- a/web-client/integration-tests/journey/docketClerkQCsDocketEntry.js
+++ b/web-client/integration-tests/journey/docketClerkQCsDocketEntry.js
@@ -24,7 +24,7 @@ export const docketClerkQCsDocketEntry = (test, data = {}) => {
       docketEntryId,
     } = caseDetailFormatted.formattedDocketEntriesOnDocketRecord[data.index];
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId,
       docketNumber: caseDetailFormatted.docketNumber,
     });

--- a/web-client/integration-tests/journey/docketClerkQCsNCAForCaseWithPaperService.js
+++ b/web-client/integration-tests/journey/docketClerkQCsNCAForCaseWithPaperService.js
@@ -65,7 +65,7 @@ export const docketClerkQCsNCAForCaseWithPaperService = test => {
       noticeOfChangeOfAddressQCItem.index
     ];
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId,
       docketNumber: caseDetailFormatted.docketNumber,
     });

--- a/web-client/integration-tests/journey/docketClerkViewsAssignedWorkItemEditLink.js
+++ b/web-client/integration-tests/journey/docketClerkViewsAssignedWorkItemEditLink.js
@@ -31,7 +31,7 @@ export const docketClerkViewsAssignedWorkItemEditLink = test => {
 
     expect(inboxWorkItem.editLink).toContain('/edit');
 
-    await test.runSequence('gotoEditDocketEntrySequence', {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: test.docketEntryId,
       docketNumber: test.docketNumber,
     });

--- a/web-client/src/presenter/computeds/docketEntryQcHelper.js
+++ b/web-client/src/presenter/computeds/docketEntryQcHelper.js
@@ -1,6 +1,6 @@
 import { state } from 'cerebral';
 
-export const editDocketEntryHelper = (get, applicationContext) => {
+export const docketEntryQcHelper = (get, applicationContext) => {
   const caseDetail = get(state.caseDetail);
   const docketEntryId = get(state.docketEntryId);
   const { CONTACT_CHANGE_DOCUMENT_TYPES } = applicationContext.getConstants();

--- a/web-client/src/presenter/computeds/docketEntryQcHelper.test.js
+++ b/web-client/src/presenter/computeds/docketEntryQcHelper.test.js
@@ -1,14 +1,14 @@
-import { editDocketEntryHelper as editDocketEntryHelperComputed } from './editDocketEntryHelper';
+import { docketEntryQcHelper as docketEntryQcHelperComputed } from './docketEntryQcHelper';
 import { runCompute } from 'cerebral/test';
-import { withAppContextDecorator } from '../../../src/withAppContext';
+import { withAppContextDecorator } from '../../withAppContext';
 
-const editDocketEntryHelper = withAppContextDecorator(
-  editDocketEntryHelperComputed,
+const docketEntryQcHelper = withAppContextDecorator(
+  docketEntryQcHelperComputed,
 );
 
-describe('editDocketEntryHelper', () => {
+describe('docketEntryQcHelper', () => {
   it('should return false for showPaperServiceWarning if the document is not a contact change document type', () => {
-    const result = runCompute(editDocketEntryHelper, {
+    const result = runCompute(docketEntryQcHelper, {
       state: {
         caseDetail: {
           docketEntries: [
@@ -25,7 +25,7 @@ describe('editDocketEntryHelper', () => {
   });
 
   it('should return false for showPaperServiceWarning if the document is a contact change document type but does not have incomplete qc work items', () => {
-    const result = runCompute(editDocketEntryHelper, {
+    const result = runCompute(docketEntryQcHelper, {
       state: {
         caseDetail: {
           docketEntries: [
@@ -43,7 +43,7 @@ describe('editDocketEntryHelper', () => {
   });
 
   it('should return false for showPaperServiceWarning if the document is a contact change document type and it does not have any work items', () => {
-    const result = runCompute(editDocketEntryHelper, {
+    const result = runCompute(docketEntryQcHelper, {
       state: {
         caseDetail: {
           docketEntries: [
@@ -60,7 +60,7 @@ describe('editDocketEntryHelper', () => {
   });
 
   it('should return true for showPaperServiceWarning if the document is a contact change document type and it has incomplete qc work items', () => {
-    const result = runCompute(editDocketEntryHelper, {
+    const result = runCompute(docketEntryQcHelper, {
       state: {
         caseDetail: {
           docketEntries: [

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -118,11 +118,11 @@ import { gotoContactSequence } from './sequences/gotoContactSequence';
 import { gotoCreateOrderSequence } from './sequences/gotoCreateOrderSequence';
 import { gotoCreatePractitionerUserSequence } from './sequences/gotoCreatePractitionerUserSequence';
 import { gotoDashboardSequence } from './sequences/gotoDashboardSequence';
+import { gotoDocketEntryQcSequence } from './sequences/gotoDocketEntryQcSequence';
 import { gotoEditCorrespondenceDocumentSequence } from './sequences/gotoEditCorrespondenceDocumentSequence';
 import { gotoEditCourtIssuedDocketEntrySequence } from './sequences/gotoEditCourtIssuedDocketEntrySequence';
 import { gotoEditDeficiencyStatisticSequence } from './sequences/gotoEditDeficiencyStatisticSequence';
 import { gotoEditDocketEntryMetaSequence } from './sequences/gotoEditDocketEntryMetaSequence';
-import { gotoEditDocketEntrySequence } from './sequences/gotoEditDocketEntrySequence';
 import { gotoEditOrderSequence } from './sequences/gotoEditOrderSequence';
 import { gotoEditOtherStatisticsSequence } from './sequences/gotoEditOtherStatisticsSequence';
 import { gotoEditPetitionDetailsSequence } from './sequences/gotoEditPetitionDetailsSequence';
@@ -590,11 +590,11 @@ export const presenter = {
     gotoCreateOrderSequence,
     gotoCreatePractitionerUserSequence,
     gotoDashboardSequence,
+    gotoDocketEntryQcSequence,
     gotoEditCorrespondenceDocumentSequence,
     gotoEditCourtIssuedDocketEntrySequence,
     gotoEditDeficiencyStatisticSequence,
     gotoEditDocketEntryMetaSequence,
-    gotoEditDocketEntrySequence,
     gotoEditOrderSequence,
     gotoEditOtherStatisticsSequence,
     gotoEditPetitionDetailsSequence,

--- a/web-client/src/presenter/sequences/fileDocketEntrySequence.js
+++ b/web-client/src/presenter/sequences/fileDocketEntrySequence.js
@@ -40,7 +40,15 @@ const gotoCaseDetail = [
   navigateToCaseDetailAction,
 ];
 
-const caseDetailOrPrintPaperService = [
+const afterEntrySaved = [
+  setCaseAction,
+  closeFileUploadStatusModalAction,
+  setDocketEntryIdAction,
+  getIsSavingForLaterAction,
+  {
+    no: [completeDocketEntryQCAction],
+    yes: [],
+  },
   chooseNextStepAction,
   {
     isElectronic: gotoCaseDetail,
@@ -52,18 +60,6 @@ const caseDetailOrPrintPaperService = [
       },
     ],
   },
-];
-
-const afterEntrySaved = [
-  setCaseAction,
-  closeFileUploadStatusModalAction,
-  setDocketEntryIdAction,
-  getIsSavingForLaterAction,
-  {
-    no: [completeDocketEntryQCAction],
-    yes: [],
-  },
-  caseDetailOrPrintPaperService,
 ];
 
 export const fileDocketEntrySequence = [

--- a/web-client/src/presenter/sequences/gotoDocketEntryQcSequence.js
+++ b/web-client/src/presenter/sequences/gotoDocketEntryQcSequence.js
@@ -16,7 +16,7 @@ import { setWorkItemAsReadAction } from '../actions/setWorkItemAsReadAction';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
 import { updateDocketEntryWizardDataAction } from '../actions/DocketEntry/updateDocketEntryWizardDataAction';
 
-export const gotoEditDocketEntry = [
+export const gotoDocketEntryQc = [
   setCurrentPageAction('Interstitial'),
   stopShowValidationAction,
   clearScansAction,
@@ -30,7 +30,7 @@ export const gotoEditDocketEntry = [
   setDocketEntryIdAction,
   setQCWorkItemIdToMarkAsReadIfNeededAction,
   setTabAction('Document Info'),
-  setCurrentPageAction('EditDocketEntry'),
+  setCurrentPageAction('DocketEntryQc'),
   getShouldMarkReadAction,
   {
     markRead: [setWorkItemAsReadAction],
@@ -38,10 +38,10 @@ export const gotoEditDocketEntry = [
   },
 ];
 
-export const gotoEditDocketEntrySequence = [
+export const gotoDocketEntryQcSequence = [
   isLoggedInAction,
   {
-    isLoggedIn: gotoEditDocketEntry,
+    isLoggedIn: gotoDocketEntryQc,
     unauthorized: [redirectToCognitoAction],
   },
 ];

--- a/web-client/src/presenter/sequences/gotoDocketEntryQcSequence.test.js
+++ b/web-client/src/presenter/sequences/gotoDocketEntryQcSequence.test.js
@@ -1,10 +1,10 @@
 import { CerebralTest } from 'cerebral/test';
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
 import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
-import { gotoEditDocketEntrySequence } from './gotoEditDocketEntrySequence';
+import { gotoDocketEntryQcSequence } from './gotoDocketEntryQcSequence';
 import { presenter } from '../presenter-mock';
 
-describe('gotoEditDocketEntrySequence', () => {
+describe('gotoDocketEntryQcSequence', () => {
   const mockDocketEntryId = '4e544995-92a9-45e4-af0a-149dd9c24458';
   const mockDocketNumber = '999-99';
 
@@ -28,7 +28,7 @@ describe('gotoEditDocketEntrySequence', () => {
     presenter.providers.applicationContext = applicationContext;
 
     presenter.sequences = {
-      gotoEditDocketEntrySequence,
+      gotoDocketEntryQcSequence,
     };
     test = CerebralTest(presenter);
 
@@ -37,16 +37,10 @@ describe('gotoEditDocketEntrySequence', () => {
       docketEntries: [mockDocketEntry],
       docketNumber: mockDocketNumber,
     });
-
-    applicationContext
-      .getUseCases()
-      .generateCourtIssuedDocumentTitleInteractor.mockReturnValue(
-        'Order to do something',
-      );
   });
 
-  it('should set up state for editing court issued docket entry', async () => {
-    await test.runSequence('gotoEditDocketEntrySequence', {
+  it('should set up state for qcing docket entry', async () => {
+    await test.runSequence('gotoDocketEntryQcSequence', {
       docketEntryId: mockDocketEntryId,
       docketNumber: mockDocketNumber,
     });

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -28,11 +28,11 @@ import { createMessageModalHelper } from './computeds/createMessageModalHelper';
 import { createOrderHelper } from './computeds/createOrderHelper';
 import { createPractitionerUserHelper } from './computeds/createPractitionerUserHelper';
 import { dashboardExternalHelper } from './computeds/dashboardExternalHelper';
+import { docketEntryQcHelper } from './computeds/docketEntryQcHelper';
 import { docketRecordHelper } from './computeds/docketRecordHelper';
 import { documentSigningHelper } from './computeds/documentSigningHelper';
 import { documentViewerHelper } from './computeds/documentViewerHelper';
 import { draftDocumentViewerHelper } from './computeds/draftDocumentViewerHelper';
-import { editDocketEntryHelper } from './computeds/editDocketEntryHelper';
 import { editDocketEntryMetaHelper } from './computeds/editDocketEntryMetaHelper';
 import { editPetitionerInformationHelper } from './computeds/editPetitionerInformationHelper';
 import { editStatisticFormHelper } from './computeds/editStatisticFormHelper';
@@ -133,11 +133,11 @@ const helpers = {
   createOrderHelper,
   createPractitionerUserHelper,
   dashboardExternalHelper,
+  docketEntryQcHelper,
   docketRecordHelper,
   documentSigningHelper,
   documentViewerHelper,
   draftDocumentViewerHelper,
-  editDocketEntryHelper,
   editDocketEntryMetaHelper,
   editPetitionerInformationHelper,
   editStatisticFormHelper,

--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -286,9 +286,9 @@ const router = {
       '/case-detail/*/documents/*/edit',
       ifHasAccess((docketNumber, docketEntryId) => {
         setPageTitle(
-          `${getPageTitleDocketPrefix(docketNumber)} Edit docket record`,
+          `${getPageTitleDocketPrefix(docketNumber)} Edit docket entry`,
         );
-        return app.getSequence('gotoEditDocketEntrySequence')({
+        return app.getSequence('gotoDocketEntryQcSequence')({
           docketEntryId,
           docketNumber,
         });

--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -26,9 +26,9 @@ import { DashboardJudge } from './Dashboards/DashboardJudge';
 import { DashboardPetitioner } from './Dashboards/DashboardPetitioner';
 import { DashboardPractitioner } from './Dashboards/DashboardPractitioner';
 import { DashboardRespondent } from './Dashboards/DashboardRespondent';
+import { DocketEntryQc } from './DocketEntryQc';
 import { EditCorrespondenceDocument } from './Correspondence/EditCorrespondenceDocument';
 import { EditDeficiencyStatistic } from './CaseDetail/EditDeficiencyStatistic';
-import { EditDocketEntry } from './EditDocketEntry/EditDocketEntry';
 import { EditDocketEntryMeta } from './EditDocketEntry/EditDocketEntryMeta';
 import { EditOtherStatistics } from './CaseDetail/EditOtherStatistics';
 import { EditPetitionDetails } from './CaseDetail/EditPetitionDetails';
@@ -113,9 +113,9 @@ const pages = {
   DashboardPetitioner,
   DashboardPractitioner,
   DashboardRespondent,
+  DocketEntryQc,
   EditCorrespondenceDocument,
   EditDeficiencyStatistic,
-  EditDocketEntry,
   EditDocketEntryMeta,
   EditOtherStatistics,
   EditPetitionDetails,

--- a/web-client/src/views/DocketEntryQc.jsx
+++ b/web-client/src/views/DocketEntryQc.jsx
@@ -1,30 +1,30 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { CaseDetailHeader } from '../CaseDetail/CaseDetailHeader';
-import { CreateMessageModalDialog } from '../Messages/CreateMessageModalDialog';
-import { DocumentDisplayIframe } from '../DocumentDisplayIframe';
-import { ErrorNotification } from '../ErrorNotification';
-import { FileUploadErrorModal } from '../FileUploadErrorModal';
-import { FileUploadStatusModal } from '../FileUploadStatusModal';
-import { FormCancelModalDialog } from '../FormCancelModalDialog';
-import { Hint } from '../../ustc-ui/Hint/Hint';
-import { PrimaryDocumentForm } from './PrimaryDocumentForm';
-import { SuccessNotification } from '../SuccessNotification';
+import { Button } from '../ustc-ui/Button/Button';
+import { CaseDetailHeader } from './CaseDetail/CaseDetailHeader';
+import { CreateMessageModalDialog } from './Messages/CreateMessageModalDialog';
+import { DocumentDisplayIframe } from './DocumentDisplayIframe';
+import { ErrorNotification } from './ErrorNotification';
+import { FileUploadErrorModal } from './FileUploadErrorModal';
+import { FileUploadStatusModal } from './FileUploadStatusModal';
+import { FormCancelModalDialog } from './FormCancelModalDialog';
+import { Hint } from '../ustc-ui/Hint/Hint';
+import { PrimaryDocumentForm } from './EditDocketEntry/PrimaryDocumentForm';
+import { SuccessNotification } from './SuccessNotification';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React from 'react';
 
-export const EditDocketEntry = connect(
+export const DocketEntryQc = connect(
   {
     completeDocketEntryQCSequence: sequences.completeDocketEntryQCSequence,
-    editDocketEntryHelper: state.editDocketEntryHelper,
+    docketEntryQcHelper: state.docketEntryQcHelper,
     formCancelToggleCancelSequence: sequences.formCancelToggleCancelSequence,
     openCompleteAndSendMessageModalSequence:
       sequences.openCompleteAndSendMessageModalSequence,
     showModal: state.modal.showModal,
   },
-  function EditDocketEntry({
+  function DocketEntryQc({
     completeDocketEntryQCSequence,
-    editDocketEntryHelper,
+    docketEntryQcHelper,
     formCancelToggleCancelSequence,
     openCompleteAndSendMessageModalSequence,
     showModal,
@@ -33,30 +33,30 @@ export const EditDocketEntry = connect(
       <>
         <CaseDetailHeader />
         <section className="usa-section grid-container">
-          {editDocketEntryHelper.showPaperServiceWarning && (
+          {docketEntryQcHelper.showPaperServiceWarning && (
             <Hint exclamation fullWidth>
               This document was automatically generated and requires paper
               service
             </Hint>
           )}
           <h2 className="heading-1">
-            {editDocketEntryHelper.formattedDocketEntry.documentTitle ||
-              editDocketEntryHelper.formattedDocketEntry.documentType}
+            {docketEntryQcHelper.formattedDocketEntry.documentTitle ||
+              docketEntryQcHelper.formattedDocketEntry.documentType}
           </h2>
           <div className="filed-by">
             <div className="padding-bottom-1">
               Filed{' '}
-              {editDocketEntryHelper.formattedDocketEntry.createdAtFormatted}
-              {editDocketEntryHelper.formattedDocketEntry.filedBy &&
-                ` by ${editDocketEntryHelper.formattedDocketEntry.filedBy}`}
+              {docketEntryQcHelper.formattedDocketEntry.createdAtFormatted}
+              {docketEntryQcHelper.formattedDocketEntry.filedBy &&
+                ` by ${docketEntryQcHelper.formattedDocketEntry.filedBy}`}
             </div>
-            {editDocketEntryHelper.formattedDocketEntry.showServedAt && (
+            {docketEntryQcHelper.formattedDocketEntry.showServedAt && (
               <div>
                 Served{' '}
-                {editDocketEntryHelper.formattedDocketEntry.servedAtFormatted}
+                {docketEntryQcHelper.formattedDocketEntry.servedAtFormatted}
               </div>
             )}
-            {editDocketEntryHelper.formattedDocketEntry.showLegacySealed && (
+            {docketEntryQcHelper.formattedDocketEntry.showLegacySealed && (
               <div>Sealed in Blackstone</div>
             )}
           </div>


### PR DESCRIPTION
I'm planning to split AddDocketEntry (for adding a paper filing) into separate add/edit paths so the sequences can be split and complexity reduced. Trying to begin by renaming things to be truthful so we have a less confusing base to start with.