### PR TITLE
7808 feedback

### DIFF
--- a/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.test.js
@@ -163,11 +163,11 @@ describe('deleteCounselFromCaseInteractor', () => {
     );
 
     expect(getContactPrimary(updatedCase).serviceIndicator).toEqual(
-      'Electronic',
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
     );
   });
 
-  it('should set the contactPrimary.serviceIndicator to Paper if the case was paper', async () => {
+  it('should set the contactPrimary.serviceIndicator to electronic when the contactPrimary has an email', async () => {
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockReturnValue({
@@ -191,7 +191,9 @@ describe('deleteCounselFromCaseInteractor', () => {
       },
     );
 
-    expect(getContactPrimary(updatedCase).serviceIndicator).toEqual('Paper');
+    expect(getContactPrimary(updatedCase).serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
   });
 
   it('should set the contactSecondary.serviceIndicator to Paper if the case was paper and the contactSecondary has no email', async () => {

--- a/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
+++ b/shared/src/business/useCases/editDocketEntry/completeDocketEntryQCInteractor.test.js
@@ -10,6 +10,7 @@ const {
   DOCUMENT_PROCESSING_STATUS_OPTIONS,
   PARTY_TYPES,
   ROLES,
+  SERVICE_INDICATOR_TYPES,
 } = require('../../entities/EntityConstants');
 const {
   completeDocketEntryQCInteractor,
@@ -199,16 +200,20 @@ describe('completeDocketEntryQCInteractor', () => {
   });
 
   it('serves the document for electronic-only parties if a notice of docket change is generated', async () => {
-    caseRecord.contactPrimary = {
-      address1: '123 Main St',
-      city: 'Somewhere',
-      countryType: COUNTRY_TYPES.DOMESTIC,
-      email: 'test@example.com',
-      name: 'Test Petitioner',
-      phone: '1234567890',
-      postalCode: '12345',
-      state: 'AK',
-    };
+    caseRecord.petitioners = [
+      {
+        address1: '123 Main St',
+        city: 'Somewhere',
+        contactType: CONTACT_TYPES.primary,
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        email: 'test@example.com',
+        name: 'Test Petitioner',
+        phone: 'n/a',
+        postalCode: '12345',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        state: 'AK',
+      },
+    ];
 
     const result = await completeDocketEntryQCInteractor(applicationContext, {
       entryMetadata: {
@@ -433,14 +438,19 @@ describe('completeDocketEntryQCInteractor', () => {
   });
 
   it('serves the document for parties with paper service if a notice of docket change is generated', async () => {
-    caseRecord.contactPrimary = {
-      address1: '123 Main St',
-      city: 'Somewhere',
-      countryType: COUNTRY_TYPES.DOMESTIC,
-      name: 'Test Petitioner',
-      postalCode: '12345',
-      state: 'AK',
-    };
+    caseRecord.petitioners = [
+      {
+        address1: '123 Main St',
+        city: 'Somewhere',
+        contactType: CONTACT_TYPES.primary,
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        name: 'Test Petitioner',
+        phone: 'n/a',
+        postalCode: '12345',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+        state: 'AK',
+      },
+    ];
     caseRecord.isPaper = true;
     caseRecord.mailingDate = '2019-03-01T21:40:46.415Z';
 
@@ -492,14 +502,19 @@ describe('completeDocketEntryQCInteractor', () => {
   });
 
   it('generates a document for paper service if the document is a Notice of Change of Address and the case has paper service parties', async () => {
-    caseRecord.contactPrimary = {
-      address1: '123 Main St',
-      city: 'Somewhere',
-      countryType: COUNTRY_TYPES.DOMESTIC,
-      name: 'Test Petitioner',
-      postalCode: '12345',
-      state: 'AK',
-    };
+    caseRecord.petitioners = [
+      {
+        address1: '123 Main St',
+        city: 'Somewhere',
+        contactType: CONTACT_TYPES.primary,
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        name: 'Test Petitioner',
+        phone: 'n/a',
+        postalCode: '12345',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+        state: 'AK',
+      },
+    ];
     caseRecord.isPaper = true;
     caseRecord.mailingDate = '2019-03-01T21:40:46.415Z';
 
@@ -530,16 +545,20 @@ describe('completeDocketEntryQCInteractor', () => {
   });
 
   it('does not generate a document for paper service if the document is a Notice of Change of Address and the case has no paper service parties', async () => {
-    caseRecord.contactPrimary = {
-      address1: '123 Main St',
-      city: 'Somewhere',
-      countryType: COUNTRY_TYPES.DOMESTIC,
-      email: 'test@example.com',
-      name: 'Test Petitioner',
-      phone: '123 456 1234',
-      postalCode: '12345',
-      state: 'AK',
-    };
+    caseRecord.petitioners = [
+      {
+        address1: '123 Main St',
+        city: 'Somewhere',
+        contactType: CONTACT_TYPES.primary,
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        email: 'test@example.com',
+        name: 'Test Petitioner',
+        phone: 'n/a',
+        postalCode: '12345',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        state: 'AK',
+      },
+    ];
 
     const result = await completeDocketEntryQCInteractor(applicationContext, {
       entryMetadata: {

--- a/shared/src/business/utilities/aggregatePartiesForService.test.js
+++ b/shared/src/business/utilities/aggregatePartiesForService.test.js
@@ -2,6 +2,10 @@ const {
   CONTACT_TYPES,
   SERVICE_INDICATOR_TYPES,
 } = require('../entities/EntityConstants');
+const {
+  getContactPrimary,
+  getContactSecondary,
+} = require('../entities/cases/Case');
 const { aggregatePartiesForService } = require('./aggregatePartiesForService');
 
 describe('aggregatePartiesForService', () => {
@@ -177,7 +181,11 @@ describe('aggregatePartiesForService', () => {
   });
 
   it('should serve an unrepresented primary and secondary contact by paper if filed by paper', async () => {
-    mockCase.isPaper = true;
+    mockCase.petitioners = [
+      { ...getContactPrimary(mockCase), email: null },
+      { ...getContactSecondary(mockCase) },
+    ];
+
     const result = aggregatePartiesForService(mockCase);
 
     expect(result).toMatchObject({

--- a/shared/src/business/utilities/setServiceIndicatorsForCase.js
+++ b/shared/src/business/utilities/setServiceIndicatorsForCase.js
@@ -10,7 +10,7 @@ const { SERVICE_INDICATOR_TYPES } = require('../entities/EntityConstants');
  * @returns {object} service indicators for petitioner, privatePractitioners, and irsPractitioners
  */
 const setServiceIndicatorsForCase = caseDetail => {
-  const { isPaper, petitioners } = caseDetail;
+  const { petitioners } = caseDetail;
 
   petitioners?.forEach(petitioner => {
     if (!petitioner.serviceIndicator) {
@@ -22,7 +22,7 @@ const setServiceIndicatorsForCase = caseDetail => {
       ) {
         petitioner.serviceIndicator = SERVICE_INDICATOR_TYPES.SI_NONE;
       } else {
-        const serviceIsPaper = isPaper || !petitioner.email;
+        const serviceIsPaper = !petitioner.email;
         petitioner.serviceIndicator = serviceIsPaper
           ? SERVICE_INDICATOR_TYPES.SI_PAPER
           : SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;

--- a/shared/src/business/utilities/setServiceIndicatorsForCase.test.js
+++ b/shared/src/business/utilities/setServiceIndicatorsForCase.test.js
@@ -51,10 +51,11 @@ describe('setServiceIndicatorsForCases', () => {
     };
   });
 
-  it(`should return ${SERVICE_INDICATOR_TYPES.SI_PAPER} for a Petitioner (contactPrimary) with no representing counsel filing by paper`, async () => {
+  it(`should return ${SERVICE_INDICATOR_TYPES.SI_PAPER} for a Petitioner without an email (contactPrimary) with no representing counsel filing by paper`, async () => {
     const caseDetail = {
       ...baseCaseDetail,
       isPaper: true,
+      petitioners: [{ ...baseCaseDetail.petitioners[0], email: undefined }],
     };
 
     const result = setServiceIndicatorsForCase(caseDetail);
@@ -95,7 +96,7 @@ describe('setServiceIndicatorsForCases', () => {
     );
   });
 
-  it(`should return ${SERVICE_INDICATOR_TYPES.SI_ELECTRONIC} for a Petitioner (contactSecondary) with an email and no representing counsel`, async () => {
+  it(`should return ${SERVICE_INDICATOR_TYPES.SI_ELECTRONIC} for a Petitioner (contactSecondary) with an email and no representing counsel on a paper case`, async () => {
     const caseDetail = {
       ...baseCaseDetail,
       isPaper: true,

--- a/shared/src/business/utilities/setServiceIndicatorsForCase.test.js
+++ b/shared/src/business/utilities/setServiceIndicatorsForCase.test.js
@@ -95,6 +95,28 @@ describe('setServiceIndicatorsForCases', () => {
     );
   });
 
+  it(`should return ${SERVICE_INDICATOR_TYPES.SI_ELECTRONIC} for a Petitioner (contactSecondary) with an email and no representing counsel`, async () => {
+    const caseDetail = {
+      ...baseCaseDetail,
+      isPaper: true,
+      petitioners: [
+        ...baseCaseDetail.petitioners,
+        {
+          contactType: CONTACT_TYPES.secondary,
+          email: 'petitioner2@example.com',
+          name: 'Test Petitioner2',
+        },
+      ],
+      privatePractitioners: [{ ...basePractitioner }],
+    };
+
+    const result = setServiceIndicatorsForCase(caseDetail);
+
+    expect(getContactSecondary(result).serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
+  });
+
   it(`should return ${SERVICE_INDICATOR_TYPES.SI_NONE} for a Petitioner (contactPrimary) with ${SERVICE_INDICATOR_TYPES.SI_NONE} already set as an override`, async () => {
     const caseDetail = {
       ...baseCaseDetail,

--- a/web-client/integration-tests/admissionsClerkCreatesUserForCase.test.js
+++ b/web-client/integration-tests/admissionsClerkCreatesUserForCase.test.js
@@ -94,8 +94,8 @@ describe('admissions clerk creates user for case', () => {
   it('admissions clerk checks pending email for petitioner on case with unverified email', async () => {
     expect(test.getState('currentPage')).toEqual('CaseDetailInternal');
 
-    expect(test.getState('screenMetadata.pendingEmails')).toEqual([
-      { [petitionerContactId]: validEmail },
-    ]);
+    expect(test.getState('screenMetadata.pendingEmails')).toEqual({
+      [petitionerContactId]: validEmail,
+    });
   });
 });

--- a/web-client/integration-tests/petitionerServiceIndicatorJourney.test.js
+++ b/web-client/integration-tests/petitionerServiceIndicatorJourney.test.js
@@ -1,3 +1,4 @@
+import { SERVICE_INDICATOR_TYPES } from '../../shared/src/business/entities/EntityConstants';
 import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import {
   contactPrimaryFromState,
@@ -255,7 +256,7 @@ describe('Petitioner Service Indicator Journey', () => {
   });
 
   loginAs(test, 'docketclerk@example.com');
-  it('Removes private practitioner from case and check service indicator is switched back to paper', async () => {
+  it('Removes private practitioner from case and check service indicator is electronic when contact has an email', async () => {
     await test.runSequence('gotoCaseDetailSequence', {
       docketNumber: test.docketNumber,
     });
@@ -273,11 +274,14 @@ describe('Petitioner Service Indicator Journey', () => {
     expect(test.getState('currentPage')).toEqual('CaseDetailInternal');
 
     const contactPrimary = contactPrimaryFromState(test);
-    expect(contactPrimary.serviceIndicator).toEqual('Paper');
+    expect(contactPrimary.serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
+    expect(contactPrimary.email).toBeDefined();
   });
 
   loginAs(test, 'irsPractitioner@example.com');
-  it('IRS Practitioner verifies service indicator for contact is paper, with sealed address', async () => {
+  it('IRS Practitioner verifies service indicator for contact is electronic, with sealed address', async () => {
     await test.runSequence('gotoCaseDetailSequence', {
       docketNumber: test.docketNumber,
     });
@@ -285,6 +289,8 @@ describe('Petitioner Service Indicator Journey', () => {
     expect(test.getState('currentPage')).toEqual('CaseDetail');
 
     const contactPrimary = contactPrimaryFromState(test);
-    expect(contactPrimary.serviceIndicator).toEqual('Paper');
+    expect(contactPrimary.serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
   });
 });

--- a/web-client/src/presenter/actions/getPendingEmailsForPetitionersOnCaseAction.js
+++ b/web-client/src/presenter/actions/getPendingEmailsForPetitionersOnCaseAction.js
@@ -11,7 +11,7 @@ export const getPendingEmailsForPetitionersOnCaseAction = async ({
   applicationContext,
   get,
 }) => {
-  let pendingEmails = [];
+  let pendingEmails = {};
 
   const { petitioners } = get(state.caseDetail);
 
@@ -22,7 +22,7 @@ export const getPendingEmailsForPetitionersOnCaseAction = async ({
         applicationContext,
         userId: petitioner.contactId,
       });
-    pendingEmails.push({ [petitioner.contactId]: pendingEmail });
+    pendingEmails[petitioner.contactId] = pendingEmail;
   }
 
   return { pendingEmails };

--- a/web-client/src/presenter/actions/getPendingEmailsForPetitionersOnCaseAction.test.js
+++ b/web-client/src/presenter/actions/getPendingEmailsForPetitionersOnCaseAction.test.js
@@ -62,13 +62,9 @@ describe('getPendingEmailsForPetitionersOnCaseAction', () => {
       },
     );
 
-    expect(output.pendingEmails).toEqual([
-      {
-        [mockUserId]: mockEmail,
-      },
-      {
-        [mockSecondUserId]: mockSecondaryEmail,
-      },
-    ]);
+    expect(output.pendingEmails).toEqual({
+      [mockSecondUserId]: mockSecondaryEmail,
+      [mockUserId]: mockEmail,
+    });
   });
 });


### PR DESCRIPTION
Fixed:
* When removing counsel from a petitioner with email (both primary or secondary), the petitioner’s service indicator changed to Paper and should change to Electronic
* When adding a new (no matching email) to either primary or secondary petitioners, pending email should be displaying on Petitioner card (it does display in the Edit Petitioner form)