### PR TITLE
DevEx - Gzip API Responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-cerebral": "^1.0.1",
     "babel-plugin-transform-html-import-require-to-string": "^0.0.3",
-    "body-parser": "^1.19.0",
     "broadcast-channel": "^3.5.3",
     "canvas": "^2.7.0",
     "cerebral": "5.2.1-1584683380023",

--- a/web-api/src/app-public.js
+++ b/web-api/src/app-public.js
@@ -1,5 +1,5 @@
 const awsServerlessExpressMiddleware = require('@vendia/serverless-express/middleware');
-const bodyParser = require('body-parser');
+const compression = require('compression');
 const cors = require('cors');
 const express = require('express');
 const logger = require('./logger');
@@ -7,8 +7,9 @@ const { lambdaWrapper } = require('./lambdaWrapper');
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(compression());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use((req, res, next) => {
   if (process.env.NODE_ENV !== 'production') {
     // we added this to suppress error `Missing x-apigateway-event or x-apigateway-context header(s)` locally

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -1,5 +1,5 @@
 const awsServerlessExpressMiddleware = require('@vendia/serverless-express/middleware');
-const bodyParser = require('body-parser');
+const compression = require('compression');
 const cors = require('cors');
 const express = require('express');
 const logger = require('./logger');
@@ -8,8 +8,9 @@ const { lambdaWrapper } = require('./lambdaWrapper');
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.json({ limit: '1200kb' }));
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(compression());
+app.use(express.json({ limit: '1200kb' }));
+app.use(express.urlencoded({ extended: true }));
 app.use((req, res, next) => {
   if (process.env.NODE_ENV !== 'production') {
     // we added this to suppress error `Missing x-apigateway-event or x-apigateway-context header(s)` locally

--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -24,6 +24,7 @@ resource "aws_api_gateway_rest_api" "gateway_for_api_public" {
   name = "gateway_api_public_${var.environment}_${var.current_color}"
 
   minimum_compression_size = "1"
+  binary_media_types = ["*/*"]
 
   endpoint_configuration {
     types = ["REGIONAL"]

--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -91,6 +91,12 @@ resource "aws_api_gateway_deployment" "api_public_deployment" {
   ]
   rest_api_id       = aws_api_gateway_rest_api.gateway_for_api_public.id
 
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_rest_api.gateway_for_api_public,
+    ]))
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -23,7 +23,6 @@ resource "aws_lambda_function" "api_public_lambda" {
 resource "aws_api_gateway_rest_api" "gateway_for_api_public" {
   name = "gateway_api_public_${var.environment}_${var.current_color}"
 
-  minimum_compression_size = "1"
   binary_media_types = ["*/*"]
 
   endpoint_configuration {

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -24,6 +24,7 @@ resource "aws_api_gateway_rest_api" "gateway_for_api" {
   name = "gateway_api_${var.environment}_${var.current_color}"
 
   minimum_compression_size = "1"
+  binary_media_types = ["*/*"]
 
   endpoint_configuration {
     types = ["REGIONAL"]

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -23,7 +23,6 @@ resource "aws_lambda_function" "api_lambda" {
 resource "aws_api_gateway_rest_api" "gateway_for_api" {
   name = "gateway_api_${var.environment}_${var.current_color}"
 
-  minimum_compression_size = "1"
   binary_media_types = ["*/*"]
 
   endpoint_configuration {

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -204,6 +204,12 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
   rest_api_id = aws_api_gateway_rest_api.gateway_for_api.id
 
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_rest_api.gateway_for_api,
+    ]))
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/web-api/terraform/template/lambdas/api-public.js
+++ b/web-api/terraform/template/lambdas/api-public.js
@@ -1,6 +1,8 @@
 const awsServerlessExpress = require('@vendia/serverless-express');
 const { app } = require('../../../src/app-public');
-const server = awsServerlessExpress.createServer(app);
+const server = awsServerlessExpress.createServer(app, undefined, [
+  'application/json',
+]);
 
 exports.handler = (event, context) => {
   awsServerlessExpress.proxy(server, event, context);

--- a/web-api/terraform/template/lambdas/api.js
+++ b/web-api/terraform/template/lambdas/api.js
@@ -1,6 +1,8 @@
 const awsServerlessExpress = require('@vendia/serverless-express');
 const { app } = require('../../../src/app');
-const server = awsServerlessExpress.createServer(app);
+const server = awsServerlessExpress.createServer(app, undefined, [
+  'application/json',
+]);
 
 exports.handler = (event, context) => {
   event.body =


### PR DESCRIPTION
- bring in the compression middleware for expres
- setup aws-serverless-express to treat application/json as binary
- setup api-gateway in terraform to treat */* as potentially binary
- removing bodyParser since it is depreciated