### PR TITLE
Devex 864: finish splitting Case unit tests into separate files; add eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,6 +113,7 @@ module.exports = {
         },
       },
     ],
+    'max-lines': ['error', { max: 3800, skipBlankLines: true }], // TODO - devex 864 - max 500 lines
     'no-irregular-whitespace': ['error', { skipStrings: false }],
     'no-prototype-builtins': 'off',
     'no-restricted-globals': [

--- a/shared/src/business/entities/cases/Case.getOtherFilers.test.js
+++ b/shared/src/business/entities/cases/Case.getOtherFilers.test.js
@@ -1,0 +1,61 @@
+const {
+  applicationContext,
+} = require('../../test/createTestApplicationContext');
+const {
+  CASE_STATUS_TYPES,
+  CONTACT_TYPES,
+  COUNTRY_TYPES,
+  OTHER_FILER_TYPES,
+  SERVICE_INDICATOR_TYPES,
+  UNIQUE_OTHER_FILER_TYPE,
+} = require('../EntityConstants');
+const { Case, getContactPrimary } = require('./Case');
+const { MOCK_CASE } = require('../../../test/mockCase');
+
+describe('getOtherFilers', () => {
+  it('sets a valid value of otherFilers on the case', () => {
+    const mockOtherFilers = [
+      {
+        address1: '42 Lamb Sauce Blvd',
+        city: 'Nashville',
+        contactType: CONTACT_TYPES.otherFiler,
+        country: 'USA',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        email: 'gordon@example.com',
+        name: 'Gordon Ramsay',
+        otherFilerType: UNIQUE_OTHER_FILER_TYPE,
+        phone: '1234567890',
+        postalCode: '05198',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        state: 'AK',
+      },
+      {
+        address1: '1337 12th Ave',
+        city: 'Flavortown',
+        contactType: CONTACT_TYPES.otherFiler,
+        country: 'USA',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        email: 'mayor@example.com',
+        name: 'Guy Fieri',
+        otherFilerType: OTHER_FILER_TYPES[1],
+        phone: '1234567890',
+        postalCode: '05198',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        state: 'AK',
+      },
+    ];
+
+    const myCase = new Case(
+      {
+        ...MOCK_CASE,
+        petitioners: [getContactPrimary(MOCK_CASE), ...mockOtherFilers],
+        status: CASE_STATUS_TYPES.generalDocket,
+      },
+      {
+        applicationContext,
+      },
+    );
+
+    expect(myCase.getOtherFilers()).toMatchObject(mockOtherFilers);
+  });
+});

--- a/shared/src/business/entities/cases/Case.getOtherPetitioners.test.js
+++ b/shared/src/business/entities/cases/Case.getOtherPetitioners.test.js
@@ -1,0 +1,59 @@
+const {
+  applicationContext,
+} = require('../../test/createTestApplicationContext');
+const {
+  CASE_STATUS_TYPES,
+  CONTACT_TYPES,
+  COUNTRY_TYPES,
+  SERVICE_INDICATOR_TYPES,
+} = require('../EntityConstants');
+const { Case } = require('./Case');
+const { MOCK_CASE } = require('../../../test/mockCase');
+
+describe('getOtherPetitioners', () => {
+  it('sets the value of otherPetitioners on the case', () => {
+    const mockOtherPetitioners = [
+      {
+        additionalName: 'First Other Petitioner',
+        address1: '876 12th Ave',
+        city: 'Nashville',
+        contactType: CONTACT_TYPES.otherPetitioner,
+        country: 'USA',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        email: 'someone@example.com',
+        name: 'Jimmy Dean',
+        phone: '1234567890',
+        postalCode: '05198',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        state: 'AK',
+      },
+      {
+        additionalName: 'First Other Petitioner',
+        address1: '876 12th Ave',
+        city: 'Nashville',
+        contactType: CONTACT_TYPES.otherPetitioner,
+        country: 'USA',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        email: 'someone@example.com',
+        name: 'Jimmy Dean',
+        phone: '1234567890',
+        postalCode: '05198',
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+        state: 'AK',
+      },
+    ];
+
+    const myCase = new Case(
+      {
+        ...MOCK_CASE,
+        petitioners: [...MOCK_CASE.petitioners, ...mockOtherPetitioners],
+        status: CASE_STATUS_TYPES.generalDocket,
+      },
+      {
+        applicationContext,
+      },
+    );
+
+    expect(myCase.getOtherPetitioners()).toMatchObject(mockOtherPetitioners);
+  });
+});

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -43,6 +43,36 @@ describe('Case entity', () => {
     });
   });
 
+  it('sets the expected order booleans', () => {
+    const myCase = new Case(
+      {
+        ...MOCK_CASE,
+        noticeOfAttachments: true,
+        orderDesignatingPlaceOfTrial: true,
+        orderForAmendedPetition: false,
+        orderForAmendedPetitionAndFilingFee: false,
+        orderForFilingFee: true,
+        orderForOds: false,
+        orderForRatification: false,
+        orderToShowCause: true,
+      },
+      {
+        applicationContext,
+      },
+    );
+
+    expect(myCase).toMatchObject({
+      noticeOfAttachments: true,
+      orderDesignatingPlaceOfTrial: true,
+      orderForAmendedPetition: false,
+      orderForAmendedPetitionAndFilingFee: false,
+      orderForFilingFee: true,
+      orderForOds: false,
+      orderForRatification: false,
+      orderToShowCause: true,
+    });
+  });
+
   it('sorts correspondence array according to `filingDate`', () => {
     const myCase = new Case(
       {
@@ -204,132 +234,6 @@ describe('Case entity', () => {
       );
 
       expect(newCase.hearings).toEqual([]);
-    });
-  });
-
-  describe('adding and removing practitioners', () => {
-    let myCase;
-
-    beforeEach(() => {
-      myCase = new Case(
-        {
-          ...MOCK_CASE,
-          irsPractitioners: [{ name: 'Christopher Walken', userId: '123' }],
-          privatePractitioners: [{ name: 'Slim Shady', userId: '567' }],
-        },
-        { applicationContext },
-      );
-    });
-
-    describe('who are from IRS', () => {
-      it('updates a matching IRS practitioner found on the case', () => {
-        expect(myCase.irsPractitioners.length).toEqual(1);
-
-        myCase.updateIrsPractitioner({
-          name: 'Christopher Running',
-          userId: '123',
-        });
-
-        expect(myCase.irsPractitioners.length).toEqual(1);
-        expect(myCase.irsPractitioners[0]).toMatchObject({
-          name: 'Christopher Running',
-        });
-      });
-      it('updates nothing when provided object does not match', () => {
-        myCase.updateIrsPractitioner({
-          name: 'Slow Jog',
-          userId: '000-111-222',
-        });
-
-        expect(myCase.irsPractitioners.length).toEqual(1);
-        expect(myCase.irsPractitioners[0]).toMatchObject({
-          name: 'Christopher Walken',
-        });
-      });
-    });
-
-    describe('who are private', () => {
-      it('updates a matching private practitioner found on the case', () => {
-        expect(myCase.privatePractitioners.length).toEqual(1);
-
-        myCase.updatePrivatePractitioner({
-          name: 'Stout Sunny',
-          userId: '567',
-        });
-
-        expect(myCase.privatePractitioners.length).toEqual(1);
-        expect(myCase.privatePractitioners[0]).toMatchObject({
-          name: 'Stout Sunny',
-        });
-      });
-      it('updates nothing when provided object does not match', () => {
-        myCase.updatePrivatePractitioner({
-          name: 'Slow Jog',
-          userId: '000-111-222',
-        });
-
-        expect(myCase.privatePractitioners.length).toEqual(1);
-        expect(myCase.privatePractitioners[0]).toMatchObject({
-          name: 'Slim Shady',
-        });
-      });
-    });
-  });
-
-  it('sets the expected order booleans', () => {
-    const myCase = new Case(
-      {
-        ...MOCK_CASE,
-        noticeOfAttachments: true,
-        orderDesignatingPlaceOfTrial: true,
-        orderForAmendedPetition: false,
-        orderForAmendedPetitionAndFilingFee: false,
-        orderForFilingFee: true,
-        orderForOds: false,
-        orderForRatification: false,
-        orderToShowCause: true,
-      },
-      {
-        applicationContext,
-      },
-    );
-
-    expect(myCase).toMatchObject({
-      noticeOfAttachments: true,
-      orderDesignatingPlaceOfTrial: true,
-      orderForAmendedPetition: false,
-      orderForAmendedPetitionAndFilingFee: false,
-      orderForFilingFee: true,
-      orderForOds: false,
-      orderForRatification: false,
-      orderToShowCause: true,
-    });
-  });
-
-  describe('toRawObject', () => {
-    beforeEach(() => {
-      jest.spyOn(Case.prototype, 'doesHavePendingItems');
-    });
-
-    afterEach(() => {
-      Case.prototype.doesHavePendingItems.mockRestore();
-    });
-
-    it('calls own function to update values after decorated toRawObject', () => {
-      const myCase = new Case({}, { applicationContext });
-
-      const result = myCase.toRawObject();
-
-      expect(Case.prototype.doesHavePendingItems).toHaveBeenCalled();
-      expect(result.hasPendingItems).toBeFalsy();
-    });
-
-    it('does not call own function to update values if flag is set to false after decorated toRawObject', () => {
-      const myCase = new Case({}, { applicationContext });
-      const result = myCase.toRawObject(false);
-
-      expect(Case.prototype.doesHavePendingItems).not.toHaveBeenCalled();
-      expect(result.hasPendingItems).toBeFalsy();
     });
   });
 
@@ -517,101 +421,7 @@ describe('Case entity', () => {
     });
   });
 
-  describe('Other Petitioners', () => {
-    it('sets the value of otherPetitioners on the case', () => {
-      const mockOtherPetitioners = [
-        {
-          additionalName: 'First Other Petitioner',
-          address1: '876 12th Ave',
-          city: 'Nashville',
-          contactType: CONTACT_TYPES.otherPetitioner,
-          country: 'USA',
-          countryType: COUNTRY_TYPES.DOMESTIC,
-          email: 'someone@example.com',
-          name: 'Jimmy Dean',
-          phone: '1234567890',
-          postalCode: '05198',
-          serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-          state: 'AK',
-        },
-        {
-          additionalName: 'First Other Petitioner',
-          address1: '876 12th Ave',
-          city: 'Nashville',
-          contactType: CONTACT_TYPES.otherPetitioner,
-          country: 'USA',
-          countryType: COUNTRY_TYPES.DOMESTIC,
-          email: 'someone@example.com',
-          name: 'Jimmy Dean',
-          phone: '1234567890',
-          postalCode: '05198',
-          serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-          state: 'AK',
-        },
-      ];
-
-      const myCase = new Case(
-        {
-          ...MOCK_CASE,
-          petitioners: [...MOCK_CASE.petitioners, ...mockOtherPetitioners],
-          status: CASE_STATUS_TYPES.generalDocket,
-        },
-        {
-          applicationContext,
-        },
-      );
-
-      expect(myCase.getOtherPetitioners()).toMatchObject(mockOtherPetitioners);
-    });
-  });
-
   describe('Other Filers', () => {
-    it('sets a valid value of otherFilers on the case', () => {
-      const mockOtherFilers = [
-        {
-          address1: '42 Lamb Sauce Blvd',
-          city: 'Nashville',
-          contactType: CONTACT_TYPES.otherFiler,
-          country: 'USA',
-          countryType: COUNTRY_TYPES.DOMESTIC,
-          email: 'gordon@example.com',
-          name: 'Gordon Ramsay',
-          otherFilerType: UNIQUE_OTHER_FILER_TYPE,
-          phone: '1234567890',
-          postalCode: '05198',
-          serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-          state: 'AK',
-        },
-        {
-          address1: '1337 12th Ave',
-          city: 'Flavortown',
-          contactType: CONTACT_TYPES.otherFiler,
-          country: 'USA',
-          countryType: COUNTRY_TYPES.DOMESTIC,
-          email: 'mayor@example.com',
-          name: 'Guy Fieri',
-          otherFilerType: OTHER_FILER_TYPES[1],
-          phone: '1234567890',
-          postalCode: '05198',
-          serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-          state: 'AK',
-        },
-      ];
-
-      const myCase = new Case(
-        {
-          ...MOCK_CASE,
-          petitioners: [getContactPrimary(MOCK_CASE), ...mockOtherFilers],
-          status: CASE_STATUS_TYPES.generalDocket,
-        },
-        {
-          applicationContext,
-        },
-      );
-
-      expect(myCase.getOtherFilers()).toMatchObject(mockOtherFilers);
-    });
-
     it('fails validation with more than one unique filer type', () => {
       const mockOtherFilers = [
         {

--- a/shared/src/business/entities/cases/Case.toRawObject.test.js
+++ b/shared/src/business/entities/cases/Case.toRawObject.test.js
@@ -1,0 +1,31 @@
+const {
+  applicationContext,
+} = require('../../test/createTestApplicationContext');
+const { Case } = require('./Case');
+
+describe('toRawObject', () => {
+  beforeEach(() => {
+    jest.spyOn(Case.prototype, 'doesHavePendingItems');
+  });
+
+  afterEach(() => {
+    Case.prototype.doesHavePendingItems.mockRestore();
+  });
+
+  it('calls own function to update values after decorated toRawObject', () => {
+    const myCase = new Case({}, { applicationContext });
+
+    const result = myCase.toRawObject();
+
+    expect(Case.prototype.doesHavePendingItems).toHaveBeenCalled();
+    expect(result.hasPendingItems).toBeFalsy();
+  });
+
+  it('does not call own function to update values if flag is set to false after decorated toRawObject', () => {
+    const myCase = new Case({}, { applicationContext });
+    const result = myCase.toRawObject(false);
+
+    expect(Case.prototype.doesHavePendingItems).not.toHaveBeenCalled();
+    expect(result.hasPendingItems).toBeFalsy();
+  });
+});

--- a/shared/src/business/entities/cases/Case.updateIrsPractitioner.test.js
+++ b/shared/src/business/entities/cases/Case.updateIrsPractitioner.test.js
@@ -3,8 +3,22 @@ const {
 } = require('../../test/createTestApplicationContext');
 const { Case } = require('./Case');
 const { IrsPractitioner } = require('../IrsPractitioner');
+const { MOCK_CASE } = require('../../../test/mockCase');
 
 describe('updateIrsPractitioner', () => {
+  let myCase;
+
+  beforeEach(() => {
+    myCase = new Case(
+      {
+        ...MOCK_CASE,
+        irsPractitioners: [{ name: 'Christopher Walken', userId: '123' }],
+        privatePractitioners: [{ name: 'Slim Shady', userId: '567' }],
+      },
+      { applicationContext },
+    );
+  });
+
   it('updates the given irsPractitioner on the case', () => {
     const caseToVerify = new Case(
       {
@@ -32,5 +46,30 @@ describe('updateIrsPractitioner', () => {
     expect(caseToVerify.irsPractitioners[0].email).toEqual(
       'irsPractitioner@example.com',
     );
+  });
+
+  it('updates a matching IRS practitioner found on the case', () => {
+    expect(myCase.irsPractitioners.length).toEqual(1);
+
+    myCase.updateIrsPractitioner({
+      name: 'Christopher Running',
+      userId: '123',
+    });
+
+    expect(myCase.irsPractitioners.length).toEqual(1);
+    expect(myCase.irsPractitioners[0]).toMatchObject({
+      name: 'Christopher Running',
+    });
+  });
+  it('updates nothing when provided object does not match', () => {
+    myCase.updateIrsPractitioner({
+      name: 'Slow Jog',
+      userId: '000-111-222',
+    });
+
+    expect(myCase.irsPractitioners.length).toEqual(1);
+    expect(myCase.irsPractitioners[0]).toMatchObject({
+      name: 'Christopher Walken',
+    });
   });
 });

--- a/shared/src/business/entities/cases/Case.updatePrivatePractitioner.test.js
+++ b/shared/src/business/entities/cases/Case.updatePrivatePractitioner.test.js
@@ -2,9 +2,23 @@ const {
   applicationContext,
 } = require('../../test/createTestApplicationContext');
 const { Case } = require('./Case');
+const { MOCK_CASE } = require('../../../test/mockCase');
 const { PrivatePractitioner } = require('../PrivatePractitioner');
 
 describe('updatePrivatePractitioner', () => {
+  let myCase;
+
+  beforeEach(() => {
+    myCase = new Case(
+      {
+        ...MOCK_CASE,
+        irsPractitioners: [{ name: 'Christopher Walken', userId: '123' }],
+        privatePractitioners: [{ name: 'Slim Shady', userId: '567' }],
+      },
+      { applicationContext },
+    );
+  });
+
   it('updates the given practitioner on the case', () => {
     const caseToVerify = new Case(
       {
@@ -30,5 +44,30 @@ describe('updatePrivatePractitioner', () => {
       userId: 'privatePractitioner',
     });
     expect(caseToVerify.privatePractitioners[0].representing).toEqual([]);
+  });
+
+  it('updates a matching private practitioner found on the case', () => {
+    expect(myCase.privatePractitioners.length).toEqual(1);
+
+    myCase.updatePrivatePractitioner({
+      name: 'Stout Sunny',
+      userId: '567',
+    });
+
+    expect(myCase.privatePractitioners.length).toEqual(1);
+    expect(myCase.privatePractitioners[0]).toMatchObject({
+      name: 'Stout Sunny',
+    });
+  });
+  it('updates nothing when provided object does not match', () => {
+    myCase.updatePrivatePractitioner({
+      name: 'Slow Jog',
+      userId: '000-111-222',
+    });
+
+    expect(myCase.privatePractitioners.length).toEqual(1);
+    expect(myCase.privatePractitioners[0]).toMatchObject({
+      name: 'Slim Shady',
+    });
   });
 });


### PR DESCRIPTION
The intention of adding the eslint rule now with the limit set high is to not let the problem get any worse while we continue to split the files. 3800 lines is our largest unit test file right now. I also included `skipBlankLines: true` so we don't encourage reducing whitespace (and readability) to reduce filesize. 