### PR TITLE
8131 - Removing Petitioner Bug

### DIFF
--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -1183,6 +1183,22 @@ const getPractitionersRepresenting = function (rawCase, petitionerContactId) {
 };
 
 /**
+ * removes the contact from the practitioner they are presenting
+ *
+ * @params {string} petitionerContactId the id of the petitioner
+ */
+Case.prototype.removeRepresentingFromPractitioners = function (
+  petitionerContactId,
+) {
+  this.privatePractitioners.forEach(practitioner =>
+    practitioner.representing.splice(
+      practitioner.representing.indexOf(petitionerContactId),
+      1,
+    ),
+  );
+};
+
+/**
  * returns the practitioner representing a petitioner
  *
  * @params {string} petitionerContactId the id of the petitioner

--- a/shared/src/business/entities/cases/Case.removeRepresentingFromPractitioners.test.js
+++ b/shared/src/business/entities/cases/Case.removeRepresentingFromPractitioners.test.js
@@ -1,0 +1,32 @@
+const {
+  applicationContext,
+} = require('../../test/createTestApplicationContext');
+const { Case } = require('./Case');
+
+describe('removeRepresentingFromPractitioners', () => {
+  it('does not remove a practitioner if not found in the associated case privatePractioners array', () => {
+    const caseToVerify = new Case(
+      {
+        privatePractitioners: [
+          {
+            representing: ['123', 'abc'],
+          },
+          {
+            representing: ['ggg', '123'],
+          },
+        ],
+      },
+      {
+        applicationContext,
+      },
+    );
+
+    caseToVerify.removeRepresentingFromPractitioners('123');
+    expect(caseToVerify.privatePractitioners[0]).toMatchObject({
+      representing: ['abc'],
+    });
+    expect(caseToVerify.privatePractitioners[1]).toMatchObject({
+      representing: ['ggg'],
+    });
+  });
+});

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -59,10 +59,8 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
     petitionerContactId,
   );
   for (const practitioner of practitioners) {
-    if (
-      practitioner.isRepresenting(petitionerContactId) &&
-      practitioner.representing.length === 1
-    ) {
+    if (!practitioner.isRepresenting(petitionerContactId)) continue;
+    if (practitioner.representing.length === 1) {
       caseEntity.removePrivatePractitioner(practitioner);
 
       await applicationContext.getPersistenceGateway().deleteUserFromCase({
@@ -70,6 +68,8 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
         docketNumber,
         userId: practitioner.userId,
       });
+    } else if (practitioner.representing.length > 1) {
+      caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
     }
   }
 

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.test.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.test.js
@@ -187,4 +187,46 @@ describe('removePetitionerAndUpdateCaptionInteractor', () => {
         .caseToUpdate.caseCaption,
     ).toEqual(mockUpdatedCaption);
   });
+
+  it('should remove the petitioner from the representing id of the privatePractitioner', async () => {
+    const otherPetitioner = petitionerToRemove;
+
+    mockCase.privatePractitioners = [
+      {
+        barNumber: 'OK0063',
+        contact: {
+          address1: '5943 Joseph Summit',
+          address2: 'Suite 334',
+          address3: null,
+          city: 'Millermouth',
+          country: 'U.S.A.',
+          countryType: 'domestic',
+          phone: '348-858-8312',
+          postalCode: '99517',
+          state: 'AK',
+        },
+        email: 'thomastorres@example.com',
+        entityName: 'PrivatePractitioner',
+        name: 'Brandon Choi',
+        representing: [
+          getContactPrimary(MOCK_CASE).contactId,
+          otherPetitioner.contactId,
+        ],
+        role: 'privatePractitioner',
+        serviceIndicator: 'Electronic',
+        userId: '3bcd5fb7-434e-4354-aa08-1d10846c1867',
+      },
+    ];
+
+    await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
+      caseCaption: 'hello world',
+      contactId: getContactPrimary(MOCK_CASE).contactId,
+      docketNumber: mockCase.docketNumber,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateCase.mock.calls[0][0]
+        .caseToUpdate.privatePractitioners[0].representing,
+    ).toEqual([otherPetitioner.contactId]);
+  });
 });


### PR DESCRIPTION
Removing a petitioner from a case that had 2 or more petitioners represented by counsel was not updating the representing array on the counsel, so the case thought counsel was still representing a contact that no longer exists