### PR TITLE
Resolve chrome-aws-lambda import issue for migration infrastructure

### DIFF
--- a/webpack.config.lambda.migration.js
+++ b/webpack.config.lambda.migration.js
@@ -7,6 +7,7 @@ module.exports = {
     'migration-segments':
       './web-api/migration-terraform/main/lambdas/migration-segments.js',
   },
+  externals: ['aws-sdk'],
   output: {
     clean: true,
     libraryTarget: 'umd',


### PR DESCRIPTION
It's not needed for migrations so remove it from webpack config