### PR TITLE
8131 - hiding the edit button for non primary / secondary

### DIFF
--- a/web-client/src/presenter/computeds/partiesInformationHelper.js
+++ b/web-client/src/presenter/computeds/partiesInformationHelper.js
@@ -103,12 +103,14 @@ export const partiesInformationHelper = (get, applicationContext) => {
     }
 
     const editPetitionerLink = isExternalUser
-      ? `/case-detail/${caseDetail.docketNumber}/contacts/${externalType}/edit`
+      ? externalType
+        ? `/case-detail/${caseDetail.docketNumber}/contacts/${externalType}/edit`
+        : null
       : `/case-detail/${caseDetail.docketNumber}/edit-petitioner-information/${petitioner.contactId}`;
 
     return {
       ...petitioner,
-      canEditPetitioner,
+      canEditPetitioner: canEditPetitioner && !!editPetitionerLink,
       editPetitionerLink,
       hasCounsel: representingPractitioners.length > 0,
       representingPractitioners,

--- a/web-client/src/presenter/computeds/partiesInformationHelper.test.js
+++ b/web-client/src/presenter/computeds/partiesInformationHelper.test.js
@@ -643,6 +643,35 @@ describe('partiesInformationHelper', () => {
       expect(result.formattedPetitioners[0].canEditPetitioner).toBe(true);
     });
 
+    it('is returns false when the petitioner is otherPetitioner and we are logged in as an external user', () => {
+      const result = runCompute(partiesInformationHelper, {
+        state: {
+          ...getBaseState(mockDocketClerk),
+          caseDetail: {
+            docketEntries: [
+              {
+                documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+                servedAt: '2020-08-01',
+              },
+            ],
+            irsPractitioners: [],
+            petitioners: [
+              {
+                contactType: CONTACT_TYPES.otherPetitioner,
+              },
+            ],
+            privatePractitioners: [],
+          },
+          permissions: { EDIT_PETITIONER_INFO: false },
+          screenMetadata: {
+            pendingEmails: {},
+          },
+        },
+      });
+
+      expect(result.formattedPetitioners[0].canEditPetitioner).toBe(false);
+    });
+
     it('is false when the user is an internal user without permission to edit petitioner info', () => {
       const result = runCompute(partiesInformationHelper, {
         state: {
@@ -738,6 +767,41 @@ describe('partiesInformationHelper', () => {
             ],
             irsPractitioners: [],
             petitioners: [mockPetitioner],
+            privatePractitioners: [
+              {
+                ...mockPrivatePractitioner,
+                representing: [mockPetitioner.contactId],
+              },
+            ],
+          },
+          permissions: {},
+          screenMetadata: {
+            pendingEmails: {},
+          },
+        },
+      });
+
+      expect(result.formattedPetitioners[0].canEditPetitioner).toBeTruthy();
+    });
+
+    it('is false when the current user is a private practitioner associated with the case and the petition has been served BUT the petitioner is an otherPetitioner', () => {
+      const result = runCompute(partiesInformationHelper, {
+        state: {
+          caseDetail: {
+            ...getBaseState(mockPrivatePractitioner),
+            docketEntries: [
+              {
+                documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+                servedAt: '2020-08-01',
+              },
+            ],
+            irsPractitioners: [],
+            petitioners: [
+              {
+                ...mockPetitioner,
+                contactType: CONTACT_TYPES.primary,
+              },
+            ],
             privatePractitioners: [
               {
                 ...mockPrivatePractitioner,


### PR DESCRIPTION
The edit button for non-primary / non-secondary will be hidden UNLESS you are an internal user

![Screen Shot 2021-05-19 at 4 41 50 PM](https://user-images.githubusercontent.com/1868782/118881467-1d9d9e80-b8c1-11eb-9e61-d90c75f9051c.png)
