### PR TITLE
8131: Migration script fix

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migrations/0031-add-filers-to-docket-entry.test.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0031-add-filers-to-docket-entry.test.js
@@ -105,6 +105,21 @@ describe('migrateItems', () => {
     expect(results[0].partySecondary).toBeUndefined();
   });
 
+  it('should not throw an error when partySecondary is true on the docketEntry and the case does NOT have a contactSecondary', async () => {
+    const items = [
+      { ...mockDocketEntry, partyPrimary: true, partySecondary: true },
+    ];
+    mockCaseItem.petitioners = [...MOCK_CASE.petitioners];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results[0].filers.length).toBe(1);
+    expect(results[0].filers[0]).toEqual(
+      getContactPrimary(mockCaseItem).contactId,
+    );
+    expect(results[0].partySecondary).toBeUndefined();
+  });
+
   it('should not add to the filers array if no partyPrimary or partySecondary', async () => {
     const items = [
       { ...mockDocketEntry, partyPrimary: false, partySecondary: false },


### PR DESCRIPTION
Fix bug in filers migration script where partySecondary was set to true on docketEntry but the case no longer had a contactSecondary