### PR TITLE
8134: advanced search refactoring

### DIFF
--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
@@ -67,7 +67,7 @@ const RenderPractitioner = ({ countryTypes, practitioner }) => {
           <strong>Representing</strong>
           <br />
           {practitioner.representingFormatted.map(p => (
-            <div key={p.contactId}>{p.name}</div>
+            <div key={p.name}>{p.name}</div>
           ))}
         </div>
       )}

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
@@ -67,7 +67,7 @@ const RenderPractitioner = ({ countryTypes, practitioner }) => {
           <strong>Representing</strong>
           <br />
           {practitioner.representingFormatted.map(p => (
-            <div key={p.name}>{p.name}</div>
+            <div key={p.contactId}>{p.name}</div>
           ))}
         </div>
       )}

--- a/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.js
+++ b/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.js
@@ -10,17 +10,12 @@ export const formatSearchResultRecord = (result, { applicationContext }) => {
   result.caseTitle = applicationContext.getCaseTitle(result.caseCaption || '');
 
   if (result.petitioners) {
-    result.fullStateNamePrimary =
-      US_STATES[result.petitioners[0].state] || result.petitioners[0].state;
-
-    if (
-      result.petitioners[1] &&
-      result.petitioners[1].state &&
-      result.petitioners[0].state !== result.petitioners[1].state
-    ) {
-      result.fullStateNameSecondary =
-        US_STATES[result.petitioners[1].state] || result.petitioners[1].state;
-    }
+    result.petitionerFullStateNames = result.petitioners.map(petitioner => {
+      return {
+        contactId: petitioner.contactId,
+        state: US_STATES[petitioner.state] || petitioner.state,
+      };
+    });
   }
 
   return result;

--- a/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.test.js
+++ b/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.test.js
@@ -158,12 +158,7 @@ describe('advancedSearchHelper', () => {
           case: [
             {
               docketNumber: '101-19',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TN',
-                },
-              ],
+              petitioners: [mockPetitionerOne],
             },
           ],
         },
@@ -190,11 +185,7 @@ describe('advancedSearchHelper', () => {
               caseCaption: 'Test Petitioner, Petitioner',
               docketNumber: '101-19',
               docketNumberWithSuffix: '101-19',
-              petitioners: [
-                {
-                  ...mockPetitionerOne,
-                },
-              ],
+              petitioners: [mockPetitionerOne],
               receivedAt: '2019-03-01T05:00:00.000Z',
             },
             {
@@ -250,12 +241,7 @@ describe('advancedSearchHelper', () => {
               caseCaption: 'Test Petitioner, Petitioner',
               docketNumber: '101-19',
               docketNumberWithSuffix: '101-19',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TN',
-                },
-              ],
+              petitioners: [mockPetitionerOne],
               receivedAt: '2019-03-01T05:00:00.000Z',
             },
             {
@@ -264,28 +250,14 @@ describe('advancedSearchHelper', () => {
               docketNumber: '102-18',
               docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
               docketNumberWithSuffix: '102-18W',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TX',
-                },
-                {
-                  name: 'Another Person',
-                  state: 'TX',
-                },
-              ],
+              petitioners: [mockPetitionerOne, mockPetitionerTwo],
               receivedAt: '2019-05-01T05:00:00.000Z',
             },
             {
               caseCaption: 'Test Petitioner, Petitioner',
               docketNumber: '103-19',
               docketNumberWithSuffix: '103-19',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TN',
-                },
-              ],
+              petitioners: [mockPetitionerOne],
               receivedAt: '2019-03-01T05:00:00.000Z',
             },
             {
@@ -294,16 +266,7 @@ describe('advancedSearchHelper', () => {
               docketNumber: '104-18',
               docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
               docketNumberWithSuffix: '104-18W',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TX',
-                },
-                {
-                  name: 'Another Person',
-                  state: 'TX',
-                },
-              ],
+              petitioners: [mockPetitionerOne, mockPetitionerTwo],
               receivedAt: '2019-05-01T05:00:00.000Z',
             },
           ],

--- a/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.test.js
+++ b/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.test.js
@@ -40,6 +40,17 @@ describe('advancedSearchHelper', () => {
     },
   );
 
+  const mockPetitionerOne = {
+    contactId: '4572d453-fae3-44c8-a298-254cc0eb43cd',
+    name: 'Daenerys Stormborn',
+    state: 'TN',
+  };
+  const mockPetitionerTwo = {
+    contactId: '52f678c6-ba27-4c64-9479-10604684dc7a',
+    name: 'Another Person',
+    state: 'TX',
+  };
+
   beforeEach(() => {
     globalUser = {
       role: USER_ROLES.docketClerk,
@@ -181,8 +192,7 @@ describe('advancedSearchHelper', () => {
               docketNumberWithSuffix: '101-19',
               petitioners: [
                 {
-                  name: 'Daenerys Stormborn',
-                  state: 'TN',
+                  ...mockPetitionerOne,
                 },
               ],
               receivedAt: '2019-03-01T05:00:00.000Z',
@@ -193,16 +203,7 @@ describe('advancedSearchHelper', () => {
               docketNumber: '102-18',
               docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
               docketNumberWithSuffix: '102-18W',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TX',
-                },
-                {
-                  name: 'Another Person',
-                  state: 'TX',
-                },
-              ],
+              petitioners: [mockPetitionerOne, mockPetitionerTwo],
               receivedAt: '2019-05-01T05:00:00.000Z',
             },
           ],
@@ -215,13 +216,24 @@ describe('advancedSearchHelper', () => {
         caseTitle: 'Test Petitioner',
         docketNumberWithSuffix: '101-19',
         formattedFiledDate: '03/01/19',
-        fullStateNamePrimary: US_STATES.TN,
+        petitionerFullStateNames: [
+          { contactId: mockPetitionerOne.contactId, state: US_STATES.TN },
+        ],
       },
       {
         caseTitle: 'Test Petitioner & Another Petitioner',
         docketNumberWithSuffix: '102-18W',
         formattedFiledDate: '05/01/19',
-        fullStateNamePrimary: US_STATES.TX,
+        petitionerFullStateNames: [
+          {
+            contactId: mockPetitionerOne.contactId,
+            state: US_STATES.TN,
+          },
+          {
+            contactId: mockPetitionerTwo.contactId,
+            state: US_STATES.TX,
+          },
+        ],
       },
     ]);
   });
@@ -315,12 +327,7 @@ describe('advancedSearchHelper', () => {
               caseCaption: 'Test Petitioner, Petitioner',
               docketNumber: '101-19',
               docketNumberWithSuffix: '101-19',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TN',
-                },
-              ],
+              petitioners: [mockPetitionerOne],
               receivedAt: '2019-03-01T05:00:00.000Z',
             },
             {
@@ -328,16 +335,7 @@ describe('advancedSearchHelper', () => {
                 'Test Petitioner & Another Petitioner, Petitioner(s)',
               docketNumber: '102-18',
               docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TX',
-                },
-                {
-                  name: 'Another Person',
-                  state: 'TX',
-                },
-              ],
+              petitioners: [mockPetitionerOne, mockPetitionerTwo],
               receivedAt: '2018-05-01T05:00:00.000Z',
             },
           ],
@@ -365,12 +363,7 @@ describe('advancedSearchHelper', () => {
               caseCaption: 'Test Petitioner, Petitioner',
               docketNumber: '101-19',
               docketNumberWithSuffix: '101-19',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TN',
-                },
-              ],
+              petitioners: [mockPetitionerOne],
               receivedAt: '2019-03-01T05:00:00.000Z',
             },
             {
@@ -379,16 +372,7 @@ describe('advancedSearchHelper', () => {
               docketNumber: '102-18',
               docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
               docketNumberWithSuffix: '102-18W',
-              petitioners: [
-                {
-                  name: 'Daenerys Stormborn',
-                  state: 'TX',
-                },
-                {
-                  name: 'Another Person',
-                  state: 'TX',
-                },
-              ],
+              petitioners: [mockPetitionerOne, mockPetitionerTwo],
               receivedAt: '2018-05-01T05:00:00.000Z',
             },
             {
@@ -399,11 +383,11 @@ describe('advancedSearchHelper', () => {
               docketNumberWithSuffix: '101-18W',
               petitioners: [
                 {
-                  name: 'Test Petitioner',
+                  ...mockPetitionerOne,
                   state: 'CA',
                 },
                 {
-                  name: 'Another Petitioner',
+                  ...mockPetitionerTwo,
                   state: 'TN',
                 },
               ],
@@ -415,7 +399,7 @@ describe('advancedSearchHelper', () => {
               docketNumberWithSuffix: '102-18W',
               petitioners: [
                 {
-                  name: 'Another Person',
+                  ...mockPetitionerOne,
                   state: 'AX',
                 },
               ],
@@ -432,26 +416,35 @@ describe('advancedSearchHelper', () => {
         caseTitle: 'Test Petitioner',
         docketNumberWithSuffix: '101-19',
         formattedFiledDate: '03/01/19',
-        fullStateNamePrimary: US_STATES.TN,
+        petitionerFullStateNames: [
+          { contactId: mockPetitionerOne.contactId, state: US_STATES.TN },
+        ],
       },
       {
         caseTitle: 'Test Petitioner & Another Petitioner',
         docketNumberWithSuffix: '102-18W',
         formattedFiledDate: '05/01/18',
-        fullStateNamePrimary: US_STATES.TX,
+        petitionerFullStateNames: [
+          { contactId: mockPetitionerOne.contactId, state: US_STATES.TN },
+          { contactId: mockPetitionerTwo.contactId, state: US_STATES.TX },
+        ],
       },
       {
         caseTitle: 'Test Petitioner & Another Petitioner',
         docketNumberWithSuffix: '101-18W',
         formattedFiledDate: '04/01/18',
-        fullStateNamePrimary: US_STATES.CA,
-        fullStateNameSecondary: US_STATES.TN,
+        petitionerFullStateNames: [
+          { contactId: mockPetitionerOne.contactId, state: US_STATES.CA },
+          { contactId: mockPetitionerTwo.contactId, state: US_STATES.TN },
+        ],
       },
       {
         caseTitle: '',
         docketNumberWithSuffix: '102-18W',
         formattedFiledDate: '05/01/18',
-        fullStateNamePrimary: 'AX',
+        petitionerFullStateNames: [
+          { contactId: mockPetitionerOne.contactId, state: 'AX' },
+        ],
       },
     ]);
   });

--- a/web-client/src/views/AdvancedSearch/SearchResults.jsx
+++ b/web-client/src/views/AdvancedSearch/SearchResults.jsx
@@ -69,14 +69,9 @@ export const SearchResults = connect(
                       <td className="center-column">{idx + 1}</td>
                       <NonMobile>
                         <td>
-                          {/* todo: get UX design for this (show all petitioners?) and update advancedSearchHelper */}
-                          {result.petitioners[0].name}
-                          {result.petitioners[1] && (
-                            <>
-                              <br />
-                              {result.petitioners[1].name}
-                            </>
-                          )}
+                          {result.petitioners.map(p => (
+                            <div key={p.name}>{p.name}</div>
+                          ))}
                         </td>
                       </NonMobile>
                       <td>
@@ -86,13 +81,9 @@ export const SearchResults = connect(
                         <td>{result.formattedFiledDate}</td>
                         <td>{result.caseTitle}</td>
                         <td>
-                          {result.fullStateNamePrimary}
-                          {result.fullStateNameSecondary && (
-                            <>
-                              <br />
-                              {result.fullStateNameSecondary}
-                            </>
-                          )}
+                          {result.petitionerFullStateNames.map(p => (
+                            <div key={p.contactId}>{p.state}</div>
+                          ))}
                         </td>
                       </NonMobile>
                       <Mobile>

--- a/web-client/src/views/AdvancedSearch/SearchResults.jsx
+++ b/web-client/src/views/AdvancedSearch/SearchResults.jsx
@@ -70,7 +70,7 @@ export const SearchResults = connect(
                       <NonMobile>
                         <td>
                           {result.petitioners.map(p => (
-                            <div key={p.name}>{p.name}</div>
+                            <div key={p.contactId}>{p.name}</div>
                           ))}
                         </td>
                       </NonMobile>


### PR DESCRIPTION
Advanced search now displays all petitioners on a case, as well as their full state names (including duplicates)
![Screen Shot 2021-05-28 at 3 01 57 PM](https://user-images.githubusercontent.com/66225176/120036403-b620d680-bfc5-11eb-915a-2087d387e137.png)

