### PR TITLE
8320 - fixing issue with signedAt changing

### DIFF
--- a/shared/src/business/entities/DocketEntry.js
+++ b/shared/src/business/entities/DocketEntry.js
@@ -171,7 +171,7 @@ DocketEntry.prototype.init = function init(
   }
 
   if (DOCUMENT_NOTICE_EVENT_CODES.includes(rawDocketEntry.eventCode)) {
-    this.signedAt = createISODateString();
+    this.signedAt = rawDocketEntry.signedAt || createISODateString();
   }
 
   this.generateFiledBy(petitioners);

--- a/shared/src/business/entities/DocketEntry.test.js
+++ b/shared/src/business/entities/DocketEntry.test.js
@@ -78,6 +78,19 @@ describe('DocketEntry entity', () => {
       expect(myDoc.signedAt).toBeTruthy();
     });
 
+    it('should not change an already signedAt Notice', () => {
+      const myDoc = new DocketEntry(
+        {
+          ...A_VALID_DOCKET_ENTRY,
+          eventCode: 'NOT',
+          signedAt: '2019-08-25T05:00:00.000Z',
+        },
+        { applicationContext, petitioners: MOCK_PETITIONERS },
+      );
+
+      expect(myDoc.signedAt).toEqual('2019-08-25T05:00:00.000Z');
+    });
+
     it('should NOT implicitly set a signedAt for non Notice event codes', () => {
       const myDoc = new DocketEntry(
         {


### PR DESCRIPTION
this is causing the docket entries signedAt property to update every time we persist a case for notice documents