### PR TITLE
devex 935 - fixing migration terraform error

### DIFF
--- a/web-api/migration-terraform/bin/policy.json
+++ b/web-api/migration-terraform/bin/policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "RESOURCE",
+      "Principal": {
+        "AWS": "ARN"
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "RESOURCE/KEY",
+      "Principal": {
+        "AWS": "ARN"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
this file was missing so the deploy-app.sh script was printing an error