### PR TITLE
Increase deploy timeouts to 20 mins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,6 +362,7 @@ jobs:
           name: Setup ES Volume Size
           command: echo "export ES_VOLUME_SIZE='$(./scripts/get-es-volume-size.sh $CIRCLE_BRANCH)'" >> $BASH_ENV
       - run:
+          no_output_timeout: 20m
           name: 'Deploy - Web API - Terraform'
           command: |
             docker run \
@@ -385,6 +386,7 @@ jobs:
              -e "DYNAMSOFT_URL_OVERRIDE=${DYNAMSOFT_URL_OVERRIDE}" \
              --rm efcms /bin/sh -c "cd web-api/terraform/main && ../bin/deploy-app.sh ${ENV}"
       - run:
+          no_output_timeout: 20m
           name: 'Deploy - Web Client - Terraform'
           command: |
             docker run \


### PR DESCRIPTION
A solution that includes logging would be better, but I'd like to test this simple fix first to verify we are indeed fighting a timeout issue (and hopefully get dev up sooner).

This effectively doubles the no output timeout on the circle job from the default 10 mins.