### PR TITLE
wait for dynamsoft popup with 10 sec timeout

### DIFF
--- a/cypress-smoketests/support/pages/create-paper-case.js
+++ b/cypress-smoketests/support/pages/create-paper-case.js
@@ -26,7 +26,8 @@ exports.closeScannerSetupDialog = () => {
   cy.intercept('dynamsoft.webtwain.install.js?t=*').as('getDynamsoft');
   cy.wait('@getDynamsoft');
   // the dynamsoft popup doesn't show immediately after the last script has been downloaded
-  cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+  cy.get('div.dynamsoft-dialog-close', { timeout: 10000 }).should('be.visible');
+
   cy.get('body').then(body => {
     if (body.find('div.dynamsoft-backdrop').length > 0) {
       cy.get('div.dynamsoft-dialog-close').click();


### PR DESCRIPTION
we are seeing failing smoketests due to the dynamsoft modal taking longer than 2 seconds to appear which causes the test to fail