### PR TITLE
Upgrade Terraform from 0.15.3 to 1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build-client-integration:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -69,7 +69,7 @@ jobs:
 
   e2e-pa11y:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -131,7 +131,7 @@ jobs:
 
   e2e-pa11y-public:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -191,7 +191,7 @@ jobs:
 
   e2e-cypress:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -259,7 +259,7 @@ jobs:
 
   e2e-cypress-public:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -596,7 +596,7 @@ jobs:
 
   smoketests:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -632,7 +632,7 @@ jobs:
 
   switch-colors:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build-client-integration:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -69,7 +69,7 @@ jobs:
 
   e2e-pa11y:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -131,7 +131,7 @@ jobs:
 
   e2e-pa11y-public:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -191,7 +191,7 @@ jobs:
 
   e2e-cypress:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -259,7 +259,7 @@ jobs:
 
   e2e-cypress-public:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -596,7 +596,7 @@ jobs:
 
   smoketests:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -632,7 +632,7 @@ jobs:
 
   switch-colors:
     docker:
-      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:experimental3
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN rm awscliv2.zip
 
 RUN pip install --upgrade pip
 
-RUN wget -q -O terraform_0.15.3_linux_amd64.zip https://releases.hashicorp.com/terraform/0.15.3/terraform_0.15.3_linux_amd64.zip && \
-  unzip -o terraform_0.15.3_linux_amd64.zip terraform && \
+RUN wget -q -O terraform_1.0.0_linux_amd64.zip https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_linux_amd64.zip && \
+  unzip -o terraform_1.0.0_linux_amd64.zip terraform && \
   cp terraform /usr/local/bin/ && \
   curl -OL 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip' && \
   mkdir sonar_scanner && \

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -18,8 +18,8 @@ RUN rm awscliv2.zip
 
 RUN pip install --upgrade pip
 
-RUN wget -q -O terraform_0.15.3_linux_amd64.zip https://releases.hashicorp.com/terraform/0.15.3/terraform_0.15.3_linux_amd64.zip && \
-  unzip -o terraform_0.15.3_linux_amd64.zip terraform && \
+RUN wget -q -O terraform_1.0.0_linux_amd64.zip https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_linux_amd64.zip && \
+  unzip -o terraform_1.0.0_linux_amd64.zip terraform && \
   cp terraform /usr/local/bin/ && \
   curl -OL 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip' && \
   mkdir sonar_scanner && \

--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -27,8 +27,8 @@ fi
 
 tf_version=$(terraform --version)
 
-if [[ ${tf_version} != *"0.15.3"* ]]; then
-  echo "Please set your terraform version to 0.15.3 before deploying."
+if [[ ${tf_version} != *"1.0.0"* ]]; then
+  echo "Please set your terraform version to 1.0.0 before deploying."
   exit 1
 fi
 

--- a/iam/terraform/environment-specific/bin/deploy-app.sh
+++ b/iam/terraform/environment-specific/bin/deploy-app.sh
@@ -7,8 +7,8 @@ ENVIRONMENT=$1
 [ -z "${ZONE_NAME}" ] && echo "You must have ZONE_NAME set in your environment" && exit 1
 
 tf_version=$(terraform --version)
-if [[ ${tf_version} != *"0.15.3"* ]]; then
-  echo "Please set your terraform version to 0.15.3 before deploying."
+if [[ ${tf_version} != *"1.0.0"* ]]; then
+  echo "Please set your terraform version to 1.0.0 before deploying."
   exit 1
 fi
 

--- a/web-api/migration-terraform/bin/deploy-app.sh
+++ b/web-api/migration-terraform/bin/deploy-app.sh
@@ -13,8 +13,8 @@ REGION=us-east-1
 
 tf_version=$(terraform --version)
 
-if [[ ${tf_version} != *"0.15.3"* ]]; then
-  echo "Please set your terraform version to 0.15.3 before deploying."
+if [[ ${tf_version} != *"1.0.0"* ]]; then
+  echo "Please set your terraform version to 1.0.0 before deploying."
   exit 1
 fi
 

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -33,8 +33,8 @@ echo "  - BOUNCED_EMAIL_RECIPIENT=${BOUNCED_EMAIL_RECIPIENT}"
 
 tf_version=$(terraform --version)
 
-if [[ ${tf_version} != *"0.15.3"* ]]; then
-  echo "Please set your terraform version to 0.15.3 before deploying."
+if [[ ${tf_version} != *"1.0.0"* ]]; then
+  echo "Please set your terraform version to 1.0.0 before deploying."
   exit 1
 fi
 

--- a/web-api/terraform/bin/import-api-public-stages.sh
+++ b/web-api/terraform/bin/import-api-public-stages.sh
@@ -8,8 +8,8 @@ ENV=$1
 
 tf_version=$(terraform --version)
 
-if [[ ${tf_version} != *"0.15.3"* ]]; then
-  echo "Please set your terraform version to 0.15.3 before deploying."
+if [[ ${tf_version} != *"1.0.0"* ]]; then
+  echo "Please set your terraform version to 1.0.0 before deploying."
   exit 1
 fi
 

--- a/web-client/terraform/bin/deploy-app.sh
+++ b/web-client/terraform/bin/deploy-app.sh
@@ -9,8 +9,8 @@ REGION=us-east-1
 
 tf_version=$(terraform --version)
 
-if [[ ${tf_version} != *"0.15.3"* ]]; then
-  echo "Please set your terraform version to 0.15.3 before deploying."
+if [[ ${tf_version} != *"1.0.0"* ]]; then
+  echo "Please set your terraform version to 1.0.0 before deploying."
   exit 1
 fi
 


### PR DESCRIPTION
>Terraform v1.0.0 intentionally has no significant changes compared to Terraform v0.15.5. You can consider the v1.0 series as a direct continuation of the v0.15 series.

https://www.terraform.io/upgrade-guides/1-0.html

### TODO
- [ ] Deploy image to ECR with latest tag.