### PR TITLE
Increase eslint maxlines rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,7 +115,7 @@ module.exports = {
     ],
     'max-lines': [
       'error',
-      { max: 800, skipBlankLines: true, skipComments: true }, // TODO - devex 864 - max 500 lines
+      { max: 850, skipBlankLines: true, skipComments: true }, // TODO - devex 864 - max 500 lines
     ],
     'no-irregular-whitespace': ['error', { skipStrings: false }],
     'no-prototype-builtins': 'off',


### PR DESCRIPTION
When merging migration into develop to make the migration PR, the combined code results in a test with more lines than the rule allows.