### PR TITLE
6282: fix policy for new s3 buckets

### DIFF
--- a/iam/terraform/environment-specific/main/lambda.tf
+++ b/iam/terraform/environment-specific/main/lambda.tf
@@ -84,7 +84,7 @@ resource "aws_iam_role_policy" "lambda_policy" {
             ],
             "Resource": [
                 "arn:aws:s3:::${var.dns_domain}-documents-*",
-                "arn:aws:s3:::${var.dns_domain}-temp-documents-*"
+                "arn:aws:s3:::${var.dns_domain}-temp-documents-*",
                 "arn:aws:s3:::${var.dns_domain}-quarantine-*"
             ],
             "Effect": "Allow"


### PR DESCRIPTION
This changes the lambda policy and the environment-specific deploy will need to be run for all environments. I'll take care of that for Flexion environments after this is merged.