### PR TITLE
Smoketest fix - use more specific class when waiting for messages screen to load

### DIFF
--- a/cypress-smoketests/support/pages/case-detail.js
+++ b/cypress-smoketests/support/pages/case-detail.js
@@ -16,7 +16,7 @@ exports.goToCaseOverview = docketNumber => {
   // not see it as a new page visit when routing to the same route again and the page
   // will not reload
   cy.goToRoute('/');
-  cy.get('.ustc-table').should('exist');
+  cy.get('.message-unread-column').should('exist');
   cy.goToRoute(`/case-detail/${docketNumber}`);
   cy.get(`.big-blue-header h1 a:contains("${docketNumber}")`).should('exist');
   cy.get('#tab-case-information').click();


### PR DESCRIPTION
See them pass a few times: 
https://app.circleci.com/pipelines/github/flexion/ef-cms?branch=experimental1