### PR TITLE
8626 - upgrading to uswds 2.12 causes the checkboxes to no longer work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6155,6 +6155,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.772.tgz",
       "integrity": "sha512-X/6VRCXWALzdX+RjCtBU6cyg8WZgoxm9YA02COmDOiNJEZ59WkQggDbWZ4t/giHi/3GS+cvdrP6gbLISANAGYA=="
     },
+    "elem-dataset": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/elem-dataset/-/elem-dataset-2.0.0.tgz",
+      "integrity": "sha512-e7gieGopWw5dMdEgythH3lUS7nMizutPDTtkzfQW/q2gCvFnACyNnK3ytCncAXKxdBXQWcXeKaYTTODiMnp8mw=="
+    },
     "element-closest": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
@@ -17928,13 +17933,15 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "uswds": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.12.0.tgz",
-      "integrity": "sha512-zunOnGXVOye8CSTjzakHBTdhH+Swi6uJLD5xOcI6xmlZFgNzk5qpLdcsxrjtknELBqRUccMRAp4MIlds9QQUMw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.11.1.tgz",
+      "integrity": "sha512-yhLTik8AuiLdp+e7/v84unn1PF3f+qtYjcdsFRjy8+7TI2mTa4wk8/5oDaMJnk1LMA3tSQNkmxGetmOS1q4zXA==",
       "requires": {
         "classlist-polyfill": "^1.0.3",
         "del": "^6.0.0",
         "domready": "^1.0.8",
+        "elem-dataset": "^2.0.0",
+        "lodash.debounce": "^4.0.7",
         "object-assign": "^4.1.1",
         "receptor": "^1.0.0",
         "resolve-id-refs": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "stylelint-config-standard": "^22.0.0",
     "swagger-cli": "^4.0.4",
     "tmp": "^0.2.1",
-    "uswds": "^2.12.0",
+    "uswds": "2.11.1",
     "util": "^0.12.4",
     "uuid": "^8.3.2",
     "webpack": "^5.44.0",


### PR DESCRIPTION
they are also broken in 2.12.1.


this is probably related to this bug which requires the usa-checkbox__label to be the LAST class imn your class list: https://github.com/uswds/uswds/issues/4251.