### PR TITLE
Issue with the live migrations crashing on REMOVE events

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migration.js
+++ b/web-api/migration-terraform/main/lambdas/migration.js
@@ -32,7 +32,7 @@ const processItems = async ({ documentClient, items, migrateRecords }) => {
 
 const getFilteredGlobalEvents = event => {
   const { Records } = event;
-  return Records.map(item =>
+  return Records.filter(item => item.eventName !== 'REMOVE').map(item =>
     AWS.DynamoDB.Converter.unmarshall(item.dynamodb.NewImage),
   );
 };

--- a/web-api/migration-terraform/main/lambdas/migration.test.js
+++ b/web-api/migration-terraform/main/lambdas/migration.test.js
@@ -29,8 +29,8 @@ describe('migration', () => {
   });
 
   describe('getFilteredGlobalEvents', () => {
-    it('should return everything', async () => {
-      const items = await getFilteredGlobalEvents({
+    it('should return everything', () => {
+      const items = getFilteredGlobalEvents({
         Records: [
           {
             dynamodb: {
@@ -49,6 +49,100 @@ describe('migration', () => {
         ],
       });
       expect(items.length).toBe(1);
+    });
+
+    it('should not attempt to process REMOVE events', () => {
+      const items = getFilteredGlobalEvents({
+        Records: [
+          {
+            awsRegion: 'us-east-1',
+            dynamodb: {
+              Keys: {
+                Id: {
+                  N: '101',
+                },
+              },
+              NewImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'New item!',
+                },
+              },
+              SequenceNumber: '111',
+              SizeBytes: 26,
+              StreamViewType: 'NEW_AND_OLD_IMAGES',
+            },
+            eventID: '1',
+            eventName: 'INSERT',
+            eventSource: 'aws:dynamodb',
+            eventSourceARN: 'stream-ARN',
+            eventVersion: '1.0',
+          },
+          {
+            awsRegion: 'us-east-1',
+            dynamodb: {
+              Keys: {
+                Id: {
+                  N: '101',
+                },
+              },
+              NewImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'This item has changed',
+                },
+              },
+              OldImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'New item!',
+                },
+              },
+              SequenceNumber: '222',
+              SizeBytes: 59,
+              StreamViewType: 'NEW_AND_OLD_IMAGES',
+            },
+            eventID: '2',
+            eventName: 'MODIFY',
+            eventSource: 'aws:dynamodb',
+            eventSourceARN: 'stream-ARN',
+            eventVersion: '1.0',
+          },
+          {
+            awsRegion: 'us-east-1',
+            dynamodb: {
+              Keys: {
+                Id: {
+                  N: '101',
+                },
+              },
+              OldImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'This item has changed',
+                },
+              },
+              SequenceNumber: '333',
+              SizeBytes: 38,
+              StreamViewType: 'NEW_AND_OLD_IMAGES',
+            },
+            eventID: '3',
+            eventName: 'REMOVE',
+            eventSource: 'aws:dynamodb',
+            eventSourceARN: 'stream-ARN',
+            eventVersion: '1.0',
+          },
+        ],
+      });
+      expect(items.length).toEqual(2);
     });
   });
 });


### PR DESCRIPTION
We used to do global filtering which ultimately would skip the REMOVE events, but aftaer refactoring to update to 2019 we removed the filter which is trying to pass empty js objects {} to the migration scripts