### PR TITLE
8652 - Updated Notice of Receipt

### DIFF
--- a/shared/src/business/utilities/documentGenerators/addressLabelCoverSheet.test.js
+++ b/shared/src/business/utilities/documentGenerators/addressLabelCoverSheet.test.js
@@ -7,6 +7,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { addressLabelCoverSheet } = require('./addressLabelCoverSheet');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/caseInventoryReport.test.js
+++ b/shared/src/business/utilities/documentGenerators/caseInventoryReport.test.js
@@ -11,6 +11,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { caseInventoryReport } = require('./caseInventoryReport');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -28,6 +29,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/changeOfAddress.test.js
+++ b/shared/src/business/utilities/documentGenerators/changeOfAddress.test.js
@@ -7,6 +7,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { changeOfAddress } = require('./changeOfAddress');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/coverSheet.test.js
+++ b/shared/src/business/utilities/documentGenerators/coverSheet.test.js
@@ -7,6 +7,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { coverSheet } = require('./coverSheet');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { PARTY_TYPES } = require('../../entities/EntityConstants');
 
 describe('documentGenerators', () => {
@@ -25,6 +26,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/docketRecord.test.js
+++ b/shared/src/business/utilities/documentGenerators/docketRecord.test.js
@@ -11,6 +11,7 @@ const {
   SERVED_PARTIES_CODES,
 } = require('../../entities/EntityConstants');
 const { docketRecord } = require('./docketRecord');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -28,6 +29,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/feature_8652_noticeOfReceiptOfPetition.js
+++ b/shared/src/business/utilities/documentGenerators/feature_8652_noticeOfReceiptOfPetition.js
@@ -1,0 +1,45 @@
+const {
+  reactTemplateGenerator,
+} = require('../generateHTMLTemplateForPDF/reactTemplateGenerator');
+const { generateHTMLTemplateForPDF } = require('../generateHTMLTemplateForPDF');
+
+const feature_8652_noticeOfReceiptOfPetition = async ({
+  applicationContext,
+  data,
+}) => {
+  const reactNoticeReceiptPetitionTemplate = reactTemplateGenerator({
+    componentName: 'Feature_8652_NoticeOfReceiptOfPetition',
+    data,
+  });
+
+  const pdfContentHtml = await generateHTMLTemplateForPDF({
+    applicationContext,
+    content: reactNoticeReceiptPetitionTemplate,
+    options: {
+      overwriteMain: true,
+      title: 'Notice of Receipt of Petition',
+    },
+  });
+
+  const headerHtml = reactTemplateGenerator({
+    componentName: 'PageMetaHeaderDocket',
+    data: {
+      docketNumber: data.docketNumberWithSuffix,
+    },
+  });
+
+  const pdf = await applicationContext
+    .getUseCases()
+    .generatePdfFromHtmlInteractor(applicationContext, {
+      contentHtml: pdfContentHtml,
+      displayHeaderFooter: true,
+      docketNumber: data.docketNumberWithSuffix,
+      headerHtml,
+    });
+
+  return pdf;
+};
+
+module.exports = {
+  feature_8652_noticeOfReceiptOfPetition,
+};

--- a/shared/src/business/utilities/documentGenerators/feature_8652_noticeOfReceiptOfPetition.test.js
+++ b/shared/src/business/utilities/documentGenerators/feature_8652_noticeOfReceiptOfPetition.test.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  applicationContext,
+} = require('../../test/createTestApplicationContext');
+const {
+  feature_8652_noticeOfReceiptOfPetition,
+} = require('./feature_8652_noticeOfReceiptOfPetition');
+const {
+  generatePdfFromHtmlInteractor,
+} = require('../../useCases/generatePdfFromHtmlInteractor');
+
+describe('documentGenerators', () => {
+  const testOutputPath = path.resolve(
+    __dirname,
+    '../../../../test-output/document-generation',
+  );
+
+  const writePdfFile = (name, data) => {
+    const pdfPath = `${testOutputPath}/${name}.pdf`;
+    fs.writeFileSync(pdfPath, data);
+  };
+
+  beforeAll(() => {
+    if (process.env.PDF_OUTPUT) {
+      fs.mkdirSync(testOutputPath, { recursive: true }, err => {
+        if (err) throw err;
+      });
+
+      applicationContext
+        .getUseCases()
+        .generatePdfFromHtmlInteractor.mockImplementation(
+          generatePdfFromHtmlInteractor,
+        );
+    }
+  });
+
+  describe('feature_8652_noticeOfReceiptOfPetition', () => {
+    it('generates a Notice of Receipt of Petition document', async () => {
+      const pdf = await feature_8652_noticeOfReceiptOfPetition({
+        applicationContext,
+        data: {
+          address: {
+            address1: '123 Some St.',
+            city: 'Somecity',
+            countryName: '',
+            name: 'Test Petitioner',
+            postalCode: '80008',
+            state: 'ZZ',
+          },
+          caseCaptionExtension: 'Petitioner(s)',
+          caseTitle: 'Test Petitioner',
+          docketNumberWithSuffix: '123-45S',
+          preferredTrialCity: 'Birmingham, Alabama',
+          receivedAtFormatted: 'December 1, 2019',
+          servedDate: 'June 3, 2020',
+        },
+      });
+
+      // Do not write PDF when running on CircleCI
+      if (process.env.PDF_OUTPUT) {
+        writePdfFile('Feature_8652_Notice_Receipt_Petition', pdf);
+        expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
+      }
+
+      expect(
+        applicationContext.getUseCases().generatePdfFromHtmlInteractor,
+      ).toHaveBeenCalled();
+      expect(applicationContext.getNodeSass).toHaveBeenCalled();
+      expect(applicationContext.getPug).toHaveBeenCalled();
+    });
+  });
+});

--- a/shared/src/business/utilities/documentGenerators/feature_8652_noticeOfReceiptOfPetition.test.js
+++ b/shared/src/business/utilities/documentGenerators/feature_8652_noticeOfReceiptOfPetition.test.js
@@ -9,6 +9,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -26,6 +27,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/noticeOfDocketChange.test.js
+++ b/shared/src/business/utilities/documentGenerators/noticeOfDocketChange.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { noticeOfDocketChange } = require('./noticeOfDocketChange');
 
 describe('documentGenerators', () => {
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/noticeOfReceiptOfPetition.test.js
+++ b/shared/src/business/utilities/documentGenerators/noticeOfReceiptOfPetition.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { noticeOfReceiptOfPetition } = require('./noticeOfReceiptOfPetition');
 
 describe('documentGenerators', () => {
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/noticeOfTrialIssued.test.js
+++ b/shared/src/business/utilities/documentGenerators/noticeOfTrialIssued.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { noticeOfTrialIssued } = require('./noticeOfTrialIssued');
 
 describe('documentGenerators', () => {
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/noticeOfTrialIssuedInPerson.test.js
+++ b/shared/src/business/utilities/documentGenerators/noticeOfTrialIssuedInPerson.test.js
@@ -9,6 +9,7 @@ const {
 const {
   noticeOfTrialIssuedInPerson,
 } = require('./noticeOfTrialIssuedInPerson');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -26,6 +27,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()
@@ -60,7 +65,7 @@ describe('documentGenerators', () => {
 
       // Do not write PDF when running on CircleCI
       if (process.env.PDF_OUTPUT) {
-        writePdfFile('Notice_Trial_Issued', pdf);
+        writePdfFile('Notice_Trial_Issued_In_Person', pdf);
         expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
         const { PDFDocument } = await applicationContext.getPdfLib();
         const pdfDoc = await PDFDocument.load(new Uint8Array(pdf));

--- a/shared/src/business/utilities/documentGenerators/order.test.js
+++ b/shared/src/business/utilities/documentGenerators/order.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { order } = require('./order');
 
 describe('documentGenerators', () => {
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/pendingReport.test.js
+++ b/shared/src/business/utilities/documentGenerators/pendingReport.test.js
@@ -7,6 +7,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { CHIEF_JUDGE } = require('../../entities/EntityConstants');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { pendingReport } = require('./pendingReport');
 
 describe('documentGenerators', () => {
@@ -25,6 +26,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/practitionerCaseList.test.js
+++ b/shared/src/business/utilities/documentGenerators/practitionerCaseList.test.js
@@ -7,6 +7,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { CASE_STATUS_TYPES } = require('../../entities/EntityConstants');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { practitionerCaseList } = require('./practitionerCaseList');
 
 describe('documentGenerators', () => {
@@ -25,6 +26,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/receiptOfFiling.test.js
+++ b/shared/src/business/utilities/documentGenerators/receiptOfFiling.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { OBJECTIONS_OPTIONS_MAP } = require('../../entities/EntityConstants');
 const { receiptOfFiling } = require('./receiptOfFiling');
 
@@ -25,6 +26,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/standingPretrialOrder.test.js
+++ b/shared/src/business/utilities/documentGenerators/standingPretrialOrder.test.js
@@ -9,6 +9,7 @@ const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
 const { combineTwoPdfs } = require('./combineTwoPdfs');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { standingPretrialOrder } = require('./standingPretrialOrder');
 
 describe('documentGenerators', () => {
@@ -27,6 +28,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/standingPretrialOrderForSmallCase.test.js
+++ b/shared/src/business/utilities/documentGenerators/standingPretrialOrderForSmallCase.test.js
@@ -12,6 +12,7 @@ const {
   standingPretrialOrderForSmallCase,
 } = require('./standingPretrialOrderForSmallCase');
 const { combineTwoPdfs } = require('./combineTwoPdfs');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -29,6 +30,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/trialCalendar.test.js
+++ b/shared/src/business/utilities/documentGenerators/trialCalendar.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { trialCalendar } = require('./trialCalendar');
 
 describe('documentGenerators', () => {
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/documentGenerators/trialSessionPlanningReport.test.js
+++ b/shared/src/business/utilities/documentGenerators/trialSessionPlanningReport.test.js
@@ -6,6 +6,7 @@ const {
 const {
   generatePdfFromHtmlInteractor,
 } = require('../../useCases/generatePdfFromHtmlInteractor');
+const { getChromiumBrowser } = require('../getChromiumBrowser');
 const { trialSessionPlanningReport } = require('./trialSessionPlanningReport');
 
 describe('documentGenerators', () => {
@@ -24,6 +25,10 @@ describe('documentGenerators', () => {
       fs.mkdirSync(testOutputPath, { recursive: true }, err => {
         if (err) throw err;
       });
+
+      applicationContext.getChromiumBrowser.mockImplementation(
+        getChromiumBrowser,
+      );
 
       applicationContext
         .getUseCases()

--- a/shared/src/business/utilities/generateHTMLTemplateForPDF/reactTemplateGenerator.js
+++ b/shared/src/business/utilities/generateHTMLTemplateForPDF/reactTemplateGenerator.js
@@ -27,6 +27,9 @@ const {
   DocketRecord,
 } = require('../pdfGenerator/documentTemplates/DocketRecord.jsx');
 const {
+  Feature_8652_NoticeOfReceiptOfPetition,
+} = require('../pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.jsx');
+const {
   GettingReadyForTrialChecklist,
 } = require('../pdfGenerator/documentTemplates/GettingReadyForTrialChecklist.jsx');
 const {
@@ -93,6 +96,7 @@ const components = {
   DateServedFooter,
   DocketRecord,
   DocumentService,
+  Feature_8652_NoticeOfReceiptOfPetition,
   GettingReadyForTrialChecklist,
   NoticeOfDocketChange,
   NoticeOfReceiptOfPetition,

--- a/shared/src/business/utilities/htmlGenerator/index.scss
+++ b/shared/src/business/utilities/htmlGenerator/index.scss
@@ -520,6 +520,12 @@ th {
   }
 }
 
+#document-notice-of-receipt {
+  .info-box-content {
+    line-height: 17px;
+  }
+}
+
 .included {
   margin: 2px 0;
 

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.jsx
@@ -1,0 +1,135 @@
+const React = require('react');
+const {
+  CompressedDocketHeader,
+} = require('../components/CompressedDocketHeader.jsx');
+const { AddressLabel } = require('../components/AddressLabel.jsx');
+const { PrimaryHeader } = require('../components/PrimaryHeader.jsx');
+
+export const Feature_8652_NoticeOfReceiptOfPetition = ({
+  address,
+  caseCaptionExtension,
+  caseTitle,
+  docketNumberWithSuffix,
+  preferredTrialCity,
+  receivedAtFormatted,
+  servedDate,
+}) => {
+  return (
+    <>
+      <PrimaryHeader />
+      <CompressedDocketHeader
+        caseCaptionExtension={caseCaptionExtension}
+        caseTitle={caseTitle}
+        docketNumberWithSuffix={docketNumberWithSuffix}
+        h3="Notice of Receipt of Petition"
+      />
+      <div>
+        The Court received and filed your petition on {receivedAtFormatted}, and
+        served it on respondent on {servedDate}.
+      </div>
+
+      {preferredTrialCity && (
+        <div className="margin-top-5 margin-bottom-20">
+          (X) Request for Place of Trial at {preferredTrialCity}.
+        </div>
+      )}
+
+      <div className="info-box margin-bottom-0">
+        <div className="info-box-header">
+          Your Docket Number: {docketNumberWithSuffix}
+        </div>
+        <div className="info-box-content">
+          Please use this docket number on all papers and correspondence that
+          you send to the Tax Court. Do not include your Social Security or
+          Taxpayer Identification numbers on any documents you file with the
+          Court. See Rule 27(a), Tax Court Rules of Practice and Procedure
+          (available at{' '}
+          <strong>
+            <a href="https://www.ustaxcourt.gov">www.ustaxcourt.gov</a>
+          </strong>
+          ).
+        </div>
+      </div>
+
+      <div className="info-box margin-bottom-0">
+        <div className="info-box-header">Electronic Access to Your Case:</div>
+        <div className="info-box-content">
+          The Court encourages registration for DAWSON, the Court&apos;s
+          electronic filing and case management system, so that you can
+          electronically file and view documents in your case. To register for
+          DAWSON, email{' '}
+          <strong>
+            <a href="mailto:dawson.support@ustaxcourt.gov">
+              dawson.support@ustaxcourt.gov
+            </a>
+          </strong>
+          . If you do not register for eFiling, you must send the opposing party
+          a copy of any document you file with the Court. To obtain further
+          information about Tax Court proceedings, visit{' '}
+          <strong>
+            <a href="https://www.ustaxcourt.gov">www.ustaxcourt.gov</a>
+          </strong>{' '}
+          and select &quot;Guidance for Petitioners.&quot;
+        </div>
+      </div>
+
+      <div className="info-box">
+        <div className="info-box-header">Change of Address:</div>
+        <div className="info-box-content">
+          You must notify the Clerk of the Court if you change your address. See
+          Rule 22(b)(4). If you filed your petition in paper, see Tax Court Form
+          10, Notice of Change of Address, under “Forms” on the Tax Court’s
+          Website at{' '}
+          <strong>
+            <a href="https://www.ustaxcourt.gov">www.ustaxcourt.gov</a>
+          </strong>
+          . If you filed your petition electronically, you may update your
+          address under the “Case Information” tab in your case online. Failure
+          to notify the Clerk of the Court of a change of your address can mean
+          you do not receive notices and documents essential to your case and
+          can lead to dismissal of your case.
+        </div>
+      </div>
+
+      <div className="info-box">
+        <div className="info-box-header">Request for Remote Proceeding:</div>
+        <div className="info-box-content">
+          You may request a remote (virtual) trial instead of an in-person
+          trial. To do so, you must submit a Motion to Proceed Remotely. A form
+          motion is available at{' '}
+          <strong>
+            <a href="https://www.ustaxcourt.gov/case_related_forms.html">
+              www.ustaxcourt.gov/case_related_forms.html
+            </a>
+          </strong>
+          . If the Court grants your request, you will be provided with detailed
+          instructions, including the date, time, and Zoomgov information for
+          the remote proceeding.
+        </div>
+      </div>
+
+      <p className="float-right width-third">
+        Stephanie A. Servoss
+        <br />
+        Clerk of the Court
+      </p>
+
+      <div id="address-label-cover-sheet">
+        <AddressLabel
+          additionalName={address.additionalName}
+          address1={address.address1}
+          address2={address.address2}
+          address3={address.address3}
+          city={address.city}
+          countryName={address.country}
+          inCareOf={address.inCareOf}
+          name={address.name}
+          postalCode={address.postalCode}
+          secondaryName={address.secondaryName}
+          state={address.state}
+          title={address.title}
+        />
+      </div>
+    </>
+  );
+};

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.jsx
@@ -15,7 +15,7 @@ export const Feature_8652_NoticeOfReceiptOfPetition = ({
   servedDate,
 }) => {
   return (
-    <>
+    <div id="document-notice-of-receipt">
       <PrimaryHeader />
       <CompressedDocketHeader
         caseCaptionExtension={caseCaptionExtension}
@@ -73,7 +73,7 @@ export const Feature_8652_NoticeOfReceiptOfPetition = ({
         </div>
       </div>
 
-      <div className="info-box">
+      <div className="info-box margin-bottom-0">
         <div className="info-box-header">Change of Address:</div>
         <div className="info-box-content">
           You must notify the Clerk of the Court if you change your address. See
@@ -130,6 +130,6 @@ export const Feature_8652_NoticeOfReceiptOfPetition = ({
           title={address.title}
         />
       </div>
-    </>
+    </div>
   );
 };

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/Feature_8652_NoticeOfReceiptOfPetition.test.js
@@ -1,0 +1,99 @@
+const React = require('react');
+const {
+  Feature_8652_NoticeOfReceiptOfPetition,
+} = require('./Feature_8652_NoticeOfReceiptOfPetition.jsx');
+const { mount, shallow } = require('enzyme');
+
+describe('Feature_8652_NoticeOfReceiptOfPetition', () => {
+  const caseCaptionExtension = 'Petitioner(s)';
+  const caseTitle = 'Test Petitioner';
+  const docketNumberWithSuffix = '123-19S';
+  const address = {
+    address1: '123 Some St.',
+    city: 'Somecity',
+    countryName: '',
+    inCareOf: 'Who',
+    name: 'Test Petitioner',
+    postalCode: '80008',
+    secondaryName: 'What',
+    state: 'ZZ',
+    title: 'When',
+  };
+
+  it('renders a document header with case information', () => {
+    const wrapper = mount(
+      <Feature_8652_NoticeOfReceiptOfPetition
+        address={address}
+        caseCaptionExtension={caseCaptionExtension}
+        caseTitle={caseTitle}
+        docketNumberWithSuffix={docketNumberWithSuffix}
+      />,
+    );
+
+    expect(wrapper.find('#caption').text()).toContain(caseTitle);
+    expect(wrapper.find('#caption').text()).toContain(caseCaptionExtension);
+    expect(wrapper.find('#docket-number').text()).toEqual(
+      `Docket No. ${docketNumberWithSuffix}`,
+    );
+    expect(wrapper.find('h3').at(0).text()).toEqual(
+      'Notice of Receipt of Petition',
+    );
+  });
+
+  it('renders the case information', () => {
+    const wrapper = shallow(
+      <Feature_8652_NoticeOfReceiptOfPetition
+        address={address}
+        caseCaptionExtension={caseCaptionExtension}
+        caseTitle={caseTitle}
+        docketNumberWithSuffix={docketNumberWithSuffix}
+        preferredTrialCity="Birmingham, AL"
+        receivedAtFormatted="December 1, 2019"
+        servedDate="June 3, 2020"
+      />,
+    );
+    const textContent = wrapper.text();
+    expect(textContent).toContain(docketNumberWithSuffix);
+    expect(textContent).toContain('Birmingham, AL');
+    expect(textContent).toContain('December 1, 2019');
+    expect(textContent).toContain('June 3, 2020');
+  });
+
+  it('does not render Request for Place of Trial section if preferredTrialCity is not present', () => {
+    const wrapper = shallow(
+      <Feature_8652_NoticeOfReceiptOfPetition
+        address={address}
+        caseCaptionExtension={caseCaptionExtension}
+        caseTitle={caseTitle}
+        docketNumberWithSuffix={docketNumberWithSuffix}
+        receivedAtFormatted="December 1, 2019"
+        servedDate="June 3, 2020"
+      />,
+    );
+    const textContent = wrapper.text();
+    expect(textContent).not.toContain('Request for Place of Trial');
+  });
+
+  it('renders the the petitioner mailing address', () => {
+    const wrapper = mount(
+      <Feature_8652_NoticeOfReceiptOfPetition
+        address={address}
+        caseCaptionExtension={caseCaptionExtension}
+        caseTitle={caseTitle}
+        docketNumberWithSuffix={docketNumberWithSuffix}
+        preferredTrialCity="Birmingham, AL"
+        receivedAtFormatted="December 1, 2019"
+        servedDate="June 3, 2020"
+      />,
+    );
+    const textContent = wrapper.text();
+    expect(textContent).toContain(address.name);
+    expect(textContent).toContain(address.address1);
+    expect(textContent).toContain(address.city);
+    expect(textContent).toContain(address.state);
+    expect(textContent).toContain(address.postalCode);
+    expect(textContent).toContain(address.inCareOf);
+    expect(textContent).toContain(address.secondaryName);
+    expect(textContent).toContain(address.title);
+  });
+});


### PR DESCRIPTION
This creates a second Notice of Receipt of Petition template with the given changes specified in the story. This isn't to be released / used yet, so it's labeled with `feature_8652_` where appropriate. When we are ready to replace the old one, we can rename these references and delete the old template.

This PR also restores the chromium references that were removed in another PR that allow for the `test:pdf-output` script to write documents to the `test-output` folder. We can discuss alternatives to that if these references need to remain gone.

[Feature_8652_Notice_Receipt_Petition.pdf](https://github.com/flexion/ef-cms/files/6910195/Feature_8652_Notice_Receipt_Petition.pdf)
