### PR TITLE
devex - renaming the react-select import so it does not collide with <Select>

### DIFF
--- a/web-client/src/ustc-ui/Select/SelectSearch.jsx
+++ b/web-client/src/ustc-ui/Select/SelectSearch.jsx
@@ -1,6 +1,6 @@
 import { getSortedOptions } from '../../ustc-ui/Utils/selectSearchHelper';
 import React from 'react';
-import Select from 'react-select';
+import ReactSelect from 'react-select';
 import classNames from 'classnames';
 
 export class SelectSearch extends React.Component {
@@ -42,7 +42,7 @@ export class SelectSearch extends React.Component {
     };
 
     return (
-      <Select
+      <ReactSelect
         {...aria}
         className={classNames('select-react-element', className)}
         classNamePrefix="select-react-element"


### PR DESCRIPTION
I thought react-select was used in more places, but it only seems to be used in one file, so this just renames the import to ReactSelect so that it doesn't collide with our custom <Select> component we use everywhere else to avoid confusion.