### PR TITLE
8506 - refresh migrate flag after running setup blue green if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ jobs:
           name: Setup Migrate Flag
           command: echo "export MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)" >> $BASH_ENV
       - run:
-          name: Setup Destination Table
+          name: Setup Destination Table Var
           command: echo "export DESTINATION_TABLE=$(./scripts/get-destination-table.sh $ENV)" >> $BASH_ENV
       - run:
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,6 +379,9 @@ jobs:
               -e "ENV=${ENV}" \
               --rm efcms /bin/sh -c "./setup-for-blue-green-migration.sh"
       - run:
+          name: Setup Migrate Flag
+          command: echo "export MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)" >> $BASH_ENV
+      - run:
           no_output_timeout: 20m
           name: 'Deploy - Web API - Terraform'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,6 +382,9 @@ jobs:
           name: Setup Migrate Flag
           command: echo "export MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)" >> $BASH_ENV
       - run:
+          name: Setup Destination Table
+          command: echo "export DESTINATION_TABLE=$(./scripts/get-destination-table.sh $ENV)" >> $BASH_ENV
+      - run:
           no_output_timeout: 20m
           name: 'Deploy - Web API - Terraform'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,9 +342,7 @@ jobs:
             echo "export ZONE_NAME=$(./scripts/get-zone-name.sh $CIRCLE_BRANCH)" >> $BASH_ENV
             echo "export IRS_SUPERUSER_EMAIL=$(./scripts/get-irs-superuser-email.sh $CIRCLE_BRANCH)" >> $BASH_ENV
             echo "export DEPLOYING_COLOR=$(./scripts/get-deploying-color.sh $ENV)" >> $BASH_ENV
-            echo "export DESTINATION_TABLE=$(./scripts/get-destination-table.sh $ENV)" >> $BASH_ENV
             echo "export CURRENT_COLOR=$(./scripts/get-current-color.sh $ENV)" >> $BASH_ENV
-            echo "export MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)" >> $BASH_ENV
             echo "export BOUNCED_EMAIL_RECIPIENT=$(./scripts/get-bounced-email-recipient.sh $CIRCLE_BRANCH)" >> $BASH_ENV
       - run:
           name: Build Docker Image


### PR DESCRIPTION
We added automation to turn on the migrate true flag, but circle was keeping a reference to an old cache value which was causing the terraform API to run thinking the migrate flag was false even though the script prior turned it on.