### PR TITLE
8545 - upgrade es to allow reporting

### DIFF
--- a/iam/terraform/account-specific/main/elasticsearch.tf
+++ b/iam/terraform/account-specific/main/elasticsearch.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_log_group" "elasticsearch_kibana_logs" {
 
 resource "aws_elasticsearch_domain" "efcms-logs" {
   domain_name           = "info"
-  elasticsearch_version = "7.4"
+  elasticsearch_version = "7.10"
 
   cluster_config {
     instance_type  = var.es_logs_instance_type


### PR DESCRIPTION
ES version 7.9 is when reporting (exporting to a CSV) is supported on Kibana, so we need to upgrade.