### PR TITLE
8508 - check the dlq for any messages and fail deploy

### DIFF
--- a/wait-for-migration-to-finish.sh
+++ b/wait-for-migration-to-finish.sh
@@ -36,7 +36,7 @@ fail_on_dlq () {
 fail_on_segments_error_count () {
   # check the past 5 minutes of cloudwatch metrics for invocation and error count and calculate a percentage
   # anything greater than 50% should probably be considered a failed migration
-  start=$(node -e 'var d = new Date(); d.setTime(d.getTime() - (60 * 5000)); console.log(d.toISOString())')
+  start=$(node -e 'var d = new Date(); d.setTime(d.getTime() - (60 * 15000)); console.log(d.toISOString())')
   end=$(node -e 'var d = new Date(); d.setTime(d.getTime()); console.log(d.toISOString())')
   errorResponse=$(aws cloudwatch get-metric-statistics --metric-name Errors --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text)
   invocationsResponse=$(aws cloudwatch get-metric-statistics --metric-name Invocations --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text)
@@ -56,10 +56,10 @@ fail_on_segments_error_count () {
     done
 
   if [[ "$errorTotal" -gt "0" ]] && [[ "$invocationTotal" -gt "0" ]]; then
-    echo "There were $errorTotal errors in the last 5 minutes"
-    echo "There were $invocationTotal invocations in the last 5 minutes"
+    echo "There were $errorTotal errors in the last 15 minutes"
+    echo "There were $invocationTotal invocations in the last 15 minutes"
     local failurePercentage=$(( $errorTotal * 100 / $invocationTotal ))
-    echo "There were $failurePercentage% errors in the last 5 minutes"
+    echo "There were $failurePercentage% errors in the last 15 minutes"
 
     if [ $failurePercentage -gt 50 ]; then
       exit 1
@@ -78,7 +78,7 @@ do
   then
     sleep 120 # wait two minutes and re-check for consistency
     fail_on_dlq
-  fail_on_segments_error_count
+    fail_on_segments_error_count
     recheck=$(get_total)
     if [ "${recheck}" == 0 ]
     then

--- a/wait-for-migration-to-finish.sh
+++ b/wait-for-migration-to-finish.sh
@@ -38,8 +38,8 @@ fail_on_segments_error_count () {
   # anything greater than 50% should probably be considered a failed migration
   start=$(node -e 'var d = new Date(); d.setTime(d.getTime() - (60 * 15000)); console.log(d.toISOString())')
   end=$(node -e 'var d = new Date(); d.setTime(d.getTime()); console.log(d.toISOString())')
-  errorResponse=$(aws cloudwatch get-metric-statistics --metric-name Errors --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text)
-  invocationsResponse=$(aws cloudwatch get-metric-statistics --metric-name Invocations --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text)
+  errorResponse=$(aws cloudwatch get-metric-statistics --metric-name Errors --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text --region us-east-1 )
+  invocationsResponse=$(aws cloudwatch get-metric-statistics --metric-name Invocations --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text --region us-east-1 )
 
   local errorTotal=0
   for count in $errorResponse

--- a/wait-for-migration-to-finish.sh
+++ b/wait-for-migration-to-finish.sh
@@ -26,7 +26,6 @@ fail_on_dlq () {
     do
       total=$(( $total + $count ))
     done
-  echo "$total"
 
   if [[ "$total" != "0" ]]; then
     echo "There are messages in the migration_segments_dl_queue_${ENV} queue"
@@ -34,16 +33,52 @@ fail_on_dlq () {
   fi
 }
 
+fail_on_segments_error_count () {
+  # check the past 5 minutes of cloudwatch metrics for invocation and error count and calculate a percentage
+  # anything greater than 50% should probably be considered a failed migration
+  start=$(node -e 'var d = new Date(); d.setTime(d.getTime() - (60 * 5000)); console.log(d.toISOString())')
+  end=$(node -e 'var d = new Date(); d.setTime(d.getTime()); console.log(d.toISOString())')
+  errorResponse=$(aws cloudwatch get-metric-statistics --metric-name Errors --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text)
+  invocationsResponse=$(aws cloudwatch get-metric-statistics --metric-name Invocations --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text)
+
+  local errorTotal=0
+  for count in $errorResponse
+    do
+      intCount=$(printf "%.0f\n" $count)
+      errorTotal=$(( $errorTotal + $intCount ))
+    done
+  
+  local invocationTotal=0
+  for count in $invocationsResponse
+    do
+      intCount=$(printf "%.0f\n" $count)
+      invocationTotal=$(( $invocationTotal + $intCount ))
+    done
+
+  if [[ "$errorTotal" -gt "0" ]] && [[ "$invocationTotal" -gt "0" ]]; then
+    echo "There were $errorTotal errors in the last 5 minutes"
+    echo "There were $invocationTotal invocations in the last 5 minutes"
+    local failurePercentage=$(( $errorTotal * 100 / $invocationTotal ))
+    echo "There were $failurePercentage% errors in the last 5 minutes"
+
+    if [ $failurePercentage -gt 50 ]; then
+      exit 1
+    fi
+  fi
+}
+
 sleep 5
 while true
 do
   fail_on_dlq
+  fail_on_segments_error_count
   total=$(get_total)
 
   if [ "${total}" == 0 ]
   then
     sleep 120 # wait two minutes and re-check for consistency
     fail_on_dlq
+  fail_on_segments_error_count
     recheck=$(get_total)
     if [ "${recheck}" == 0 ]
     then

--- a/wait-for-migration-to-finish.sh
+++ b/wait-for-migration-to-finish.sh
@@ -19,15 +19,31 @@ get_total () {
   echo "$total"
 }
 
+fail_on_dlq () {
+  response=$(aws sqs get-queue-attributes --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible ApproximateNumberOfMessagesDelayed --queue-url="https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/migration_segments_dl_queue_${ENV}" --region us-east-1 --query "Attributes" --output=text)
+  local total=0
+  for count in $response
+    do
+      total=$(( $total + $count ))
+    done
+  echo "$total"
+
+  if [[ "$total" != "0" ]]; then
+    echo "There are messages in the migration_segments_dl_queue_${ENV} queue"
+    exit 1
+  fi
+}
+
 sleep 5
 while true
 do
-  
+  fail_on_dlq
   total=$(get_total)
 
   if [ "${total}" == 0 ]
   then
     sleep 120 # wait two minutes and re-check for consistency
+    fail_on_dlq
     recheck=$(get_total)
     if [ "${recheck}" == 0 ]
     then

--- a/wait-for-migration-to-finish.sh
+++ b/wait-for-migration-to-finish.sh
@@ -38,8 +38,8 @@ fail_on_segments_error_count () {
   # anything greater than 50% should probably be considered a failed migration
   start=$(node -e 'var d = new Date(); d.setTime(d.getTime() - (60 * 15000)); console.log(d.toISOString())')
   end=$(node -e 'var d = new Date(); d.setTime(d.getTime()); console.log(d.toISOString())')
-  errorResponse=$(aws cloudwatch get-metric-statistics --metric-name Errors --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text --region us-east-1 )
-  invocationsResponse=$(aws cloudwatch get-metric-statistics --metric-name Invocations --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text --region us-east-1 )
+  errorResponse=$(aws cloudwatch get-metric-statistics --metric-name Errors --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text --region us-east-1)
+  invocationsResponse=$(aws cloudwatch get-metric-statistics --metric-name Invocations --namespace AWS/Lambda --statistics Sum --start-time $start --end-time $end --period 60 --dimensions Name=FunctionName,Value=migration_segments_lambda_${ENV} --query "Datapoints[].Sum" --output=text --region us-east-1)
 
   local errorTotal=0
   for count in $errorResponse

--- a/wait-for-migration-to-finish.sh
+++ b/wait-for-migration-to-finish.sh
@@ -34,7 +34,7 @@ fail_on_dlq () {
 }
 
 fail_on_segments_error_count () {
-  # check the past 5 minutes of cloudwatch metrics for invocation and error count and calculate a percentage
+  # check the past 15 minutes of cloudwatch metrics for invocation and error count and calculate a percentage
   # anything greater than 50% should probably be considered a failed migration
   start=$(node -e 'var d = new Date(); d.setTime(d.getTime() - (60 * 15000)); console.log(d.toISOString())')
   end=$(node -e 'var d = new Date(); d.setTime(d.getTime()); console.log(d.toISOString())')


### PR DESCRIPTION
This PR adds checks to fail the circle deploy if the following is true:
- any messages are put onto the DLQ
- if the error % (failed * 100 / invocations) is greater than 50% within a period of 15 minutes


![Screen Shot 2021-08-13 at 5 32 37 PM](https://user-images.githubusercontent.com/1868782/129420440-cb70b420-b2cc-468a-996f-4e22cef50917.png)

![Screen Shot 2021-08-13 at 9 02 20 PM](https://user-images.githubusercontent.com/1868782/129429937-c64aa200-9032-42db-b975-2376f7ca4772.png)
