### PR TITLE
8640: revert internal filtering

### DIFF
--- a/web-client/src/presenter/computeds/internalTypesHelper.js
+++ b/web-client/src/presenter/computeds/internalTypesHelper.js
@@ -36,29 +36,13 @@ export const getSortFunction = searchText => {
 };
 
 export const internalTypesHelper = (get, applicationContext) => {
-  const {
-    INTERNAL_CATEGORY_MAP,
-    LODGED_EVENT_CODE,
-    NOTICE_OF_CHANGE_CONTACT_INFORMATION_EVENT_CODES,
-  } = applicationContext.getConstants();
+  const { INTERNAL_CATEGORY_MAP, LODGED_EVENT_CODE } =
+    applicationContext.getConstants();
   const searchText = get(state.screenMetadata.searchText) || '';
-
-  // 8640
-  const docketEntries = get(state.caseDetail.docketEntries);
-  const docketEntryId = get(state.form.docketEntryId);
-  const selectedEventCode = docketEntryId
-    ? docketEntries.find(entry => entry.docketEntryId === docketEntryId)
-        .eventCode
-    : undefined;
-
-  const forbiddenDocumentEventCodes =
-    NOTICE_OF_CHANGE_CONTACT_INFORMATION_EVENT_CODES.filter(
-      docTypeCode => selectedEventCode !== docTypeCode,
-    );
 
   const internalDocumentTypesForSelect = getDocumentTypesForSelect(
     INTERNAL_CATEGORY_MAP,
-  ).filter(docType => !forbiddenDocumentEventCodes.includes(docType.eventCode));
+  );
 
   const internalDocumentTypesForSelectSorted = internalDocumentTypesForSelect
     .sort(getSortFunction(searchText))

--- a/web-client/src/presenter/computeds/internalTypesHelper.test.js
+++ b/web-client/src/presenter/computeds/internalTypesHelper.test.js
@@ -40,38 +40,6 @@ describe('internalTypesHelper', () => {
         scenario: 'Nonstandard G',
       },
     ],
-    Notice: [
-      {
-        category: 'Notice',
-        documentTitle: 'Notice of Change of Address',
-        documentType: 'Notice of Change of Address',
-        eventCode: 'NCA',
-        labelFreeText: '',
-        labelPreviousDocument: '',
-        ordinalField: '',
-        scenario: 'Standard',
-      },
-      {
-        category: 'Notice',
-        documentTitle: 'Notice of Change of Address and Telephone Number',
-        documentType: 'Notice of Change of Address and Telephone Number',
-        eventCode: 'NCAP',
-        labelFreeText: '',
-        labelPreviousDocument: '',
-        ordinalField: '',
-        scenario: 'Standard',
-      },
-      {
-        category: 'Notice',
-        documentTitle: 'Notice of Change of Telephone Number',
-        documentType: 'Notice of Change of Telephone Number',
-        eventCode: 'NCP',
-        labelFreeText: '',
-        labelPreviousDocument: '',
-        ordinalField: '',
-        scenario: 'Standard',
-      },
-    ],
     'Seriatim Brief': [
       {
         category: 'Seriatim Brief',
@@ -182,7 +150,7 @@ describe('internalTypesHelper', () => {
   });
 
   describe('produces a list', () => {
-    it('of value/label objects (that does not include NCA, NCP, or NCAP type documents) sorted by their label (default) when no search text is provided', () => {
+    it('of value/label objects sorted by their label (default) when no search text is provided', () => {
       const expected = [
         { label: 'Amended Answer', value: 'AA' },
         { label: 'Amendment to Answer', value: 'ATAN' },
@@ -192,38 +160,6 @@ describe('internalTypesHelper', () => {
 
       const result = runCompute(internalTypesHelper, {
         state: {},
-      });
-
-      expect(result.internalDocumentTypesForSelect).toMatchObject(expected);
-      expect(result.internalDocumentTypesForSelectSorted).toMatchObject(
-        expected,
-      );
-    });
-
-    it('that includes NCA type documents when the currently edited document is NCA type', () => {
-      const docketEntryId = 'ABC123';
-      const expected = [
-        { label: 'Amended Answer', value: 'AA' },
-        { label: 'Amendment to Answer', value: 'ATAN' },
-        { label: 'Answer', value: 'A' },
-        { label: 'Notice of Change of Address', value: 'NCA' },
-        { label: 'Seriatim Answering Memorandum Brief', value: 'SAMB' },
-      ];
-
-      const result = runCompute(internalTypesHelper, {
-        state: {
-          caseDetail: {
-            docketEntries: [
-              {
-                docketEntryId,
-                eventCode: 'NCA',
-              },
-            ],
-          },
-          form: {
-            docketEntryId,
-          },
-        },
       });
 
       expect(result.internalDocumentTypesForSelect).toMatchObject(expected);


### PR DESCRIPTION
AC/User story confusion: This reverts filtering NCA, NCP, and NCAP documents for _internal_ users only.