### PR TITLE
7370: loosen validation of search results

### DIFF
--- a/shared/src/business/entities/documents/InternalDocumentSearchResult.js
+++ b/shared/src/business/entities/documents/InternalDocumentSearchResult.js
@@ -56,10 +56,10 @@ InternalDocumentSearchResult.schema = joi.object().keys({
   eventCode: JoiValidationConstants.STRING,
   isSealed: joi.boolean(),
   isStricken: joi.boolean(),
-  judge: JoiValidationConstants.STRING.optional(),
+  judge: JoiValidationConstants.STRING.optional().allow(null),
   numberOfPages: joi.number().integer().optional().allow(null),
   sealedDate: JoiValidationConstants.ISO_DATE,
-  signedJudgeName: JoiValidationConstants.STRING.optional(),
+  signedJudgeName: JoiValidationConstants.STRING.optional().allow(null),
 });
 
 joiValidationDecorator(

--- a/shared/src/business/entities/documents/InternalDocumentSearchResult.test.js
+++ b/shared/src/business/entities/documents/InternalDocumentSearchResult.test.js
@@ -90,7 +90,7 @@ describe('Internal Document Search Result entity', () => {
     expect(validationErrors).toBeNull();
   });
 
-  it('passes validation if numberOfPages is null', () => {
+  it('passes validation if optional numberOfPages, judge, and signedJudgeName are all null', () => {
     const searchResult = new InternalDocumentSearchResult({
       caseCaption: 'This is a case caption',
       docketEntryId: 'c5bee7c0-bd98-4504-890b-b00eb398e547',
@@ -99,7 +99,9 @@ describe('Internal Document Search Result entity', () => {
       documentType: 'Memorandum Opinion',
       eventCode: 'MOP',
       isSealed: true,
+      judge: null,
       numberOfPages: null,
+      signedJudgeName: null,
     });
     const validationErrors = searchResult.getFormattedValidationErrors();
 

--- a/web-api/src/documents/opinionAdvancedSearchLambda.js
+++ b/web-api/src/documents/opinionAdvancedSearchLambda.js
@@ -7,11 +7,11 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.opinionAdvancedSearchLambda = event =>
-  genericHandler(event, async ({ applicationContext }) => {
-    return await applicationContext
+  genericHandler(event, ({ applicationContext }) =>
+    applicationContext
       .getUseCases()
       .opinionAdvancedSearchInteractor(
         applicationContext,
         event.queryStringParameters,
-      );
-  });
+      ),
+  );


### PR DESCRIPTION
also removing unnecessary promise-wrapping.
Data found in court's MIG environment was found to be failing validation when searching for opinions, hence the validation alteration rules that allow optional values to be null -- same as the original Docket Entry Validation rules.
![Screen Shot 2021-09-01 at 5 35 22 PM](https://user-images.githubusercontent.com/2445917/131755648-97b8477e-02d6-4593-b754-4b758cfd2a1f.png)
