### PR TITLE
7095 routing fixes

### DIFF
--- a/web-client/src/app.jsx
+++ b/web-client/src/app.jsx
@@ -274,8 +274,8 @@ const app = {
 
     const cerebralApp = App(presenter, debugTools);
 
-    router.initialize(cerebralApp, route);
     initializeSocketProvider(cerebralApp, applicationContext);
+    router.initialize(cerebralApp, route);
 
     ReactDOM.render(
       <Container app={cerebralApp}>

--- a/web-client/src/presenter/actions/setMaintenanceModeAction.js
+++ b/web-client/src/presenter/actions/setMaintenanceModeAction.js
@@ -1,0 +1,21 @@
+import { state } from 'cerebral';
+
+/**
+ * sets the maintenance mode value
+ *
+ * @param {object} applicationContext object that contains all the context specific methods
+ * @param {object} props the cerebral props object
+ * @param {object} store the cerebral store
+ */
+export const setMaintenanceModeAction = async ({
+  applicationContext,
+  props,
+  store,
+}) => {
+  store.set(state.maintenanceMode, props.maintenanceMode);
+
+  await applicationContext.getUseCases().setItemInteractor(applicationContext, {
+    key: 'maintenanceMode',
+    value: props.maintenanceMode,
+  });
+};

--- a/web-client/src/presenter/actions/setMaintenanceModeAction.test.js
+++ b/web-client/src/presenter/actions/setMaintenanceModeAction.test.js
@@ -18,4 +18,18 @@ describe('setMaintenanceModeAction', () => {
     });
     expect(state.maintenanceMode).toBe(true);
   });
+
+  it('should call setItemInteractor', async () => {
+    await runAction(setMaintenanceModeAction, {
+      modules: { presenter },
+      props: {
+        maintenanceMode: true,
+      },
+      state: {},
+    });
+
+    expect(
+      applicationContext.getUseCases().setItemInteractor,
+    ).toHaveBeenCalled();
+  });
 });

--- a/web-client/src/presenter/actions/setMaintenanceModeAction.test.js
+++ b/web-client/src/presenter/actions/setMaintenanceModeAction.test.js
@@ -1,0 +1,21 @@
+import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
+import { presenter } from '../presenter-mock';
+import { runAction } from 'cerebral/test';
+import { setMaintenanceModeAction } from './setMaintenanceModeAction';
+
+describe('setMaintenanceModeAction', () => {
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
+  it('should set state.maintenanceMode to the value passed in from props', async () => {
+    const { state } = await runAction(setMaintenanceModeAction, {
+      modules: { presenter },
+      props: {
+        maintenanceMode: true,
+      },
+      state: {},
+    });
+    expect(state.maintenanceMode).toBe(true);
+  });
+});

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -85,6 +85,7 @@ import { deleteTrialSessionSequence } from './sequences/deleteTrialSessionSequen
 import { deleteUploadedPdfSequence } from './sequences/deleteUploadedPdfSequence';
 import { deleteUserCaseNoteFromWorkingCopySequence } from './sequences/deleteUserCaseNoteFromWorkingCopySequence';
 import { deleteWorkingCopySessionNoteSequence } from './sequences/deleteWorkingCopySessionNoteSequence';
+import { disengageAppMaintenanceSequence } from './sequences/disengageAppMaintenanceSequence';
 import { dismissAlertSequence } from './sequences/dismissAlertSequence';
 import { dismissCreateMessageModalSequence } from './sequences/dismissCreateMessageModalSequence';
 import { dismissModalSequence } from './sequences/dismissModalSequence';
@@ -567,6 +568,7 @@ export const presenter = {
     deleteUploadedPdfSequence,
     deleteUserCaseNoteFromWorkingCopySequence,
     deleteWorkingCopySessionNoteSequence,
+    disengageAppMaintenanceSequence,
     dismissAlertSequence,
     dismissCreateMessageModalSequence,
     dismissModalSequence,

--- a/web-client/src/presenter/sequences/disengageAppMaintenanceSequence.js
+++ b/web-client/src/presenter/sequences/disengageAppMaintenanceSequence.js
@@ -1,0 +1,17 @@
+import { clearModalSequence } from './clearModalSequence';
+import { isLoggedInAction } from '../actions/isLoggedInAction';
+import { navigateToPathAction } from '../actions/navigateToPathAction';
+import { navigateToPathSequence } from './navigateToPathSequence';
+import { setMaintenanceModeAction } from '../actions/setMaintenanceModeAction';
+
+export const disengageAppMaintenanceSequence = [
+  isLoggedInAction,
+  {
+    isLoggedIn: [
+      clearModalSequence,
+      setMaintenanceModeAction,
+      navigateToPathSequence,
+    ],
+    unauthorized: [navigateToPathAction],
+  },
+];

--- a/web-client/src/presenter/sequences/gotoMaintenanceSequence.js
+++ b/web-client/src/presenter/sequences/gotoMaintenanceSequence.js
@@ -1,9 +1,11 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
+import { startWebSocketConnectionSequenceDecorator } from '../utilities/startWebSocketConnectionSequenceDecorator';
 
-export const gotoMaintenanceSequence = [
-  clearAlertsAction,
-  clearScreenMetadataAction,
-  setCurrentPageAction('AppMaintenance'),
-];
+export const gotoMaintenanceSequence =
+  startWebSocketConnectionSequenceDecorator([
+    clearAlertsAction,
+    clearScreenMetadataAction,
+    setCurrentPageAction('AppMaintenance'),
+  ]);

--- a/web-client/src/presenter/sequences/openAppMaintenanceModalSequence.js
+++ b/web-client/src/presenter/sequences/openAppMaintenanceModalSequence.js
@@ -1,11 +1,15 @@
 import { isLoggedInAction } from '../actions/isLoggedInAction';
 import { navigateToPathAction } from '../actions/navigateToPathAction';
+import { setMaintenanceModeAction } from '../actions/setMaintenanceModeAction';
 import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction';
 
 export const openAppMaintenanceModalSequence = [
   isLoggedInAction,
   {
-    isLoggedIn: [setShowModalFactoryAction('AppMaintenanceModal')],
+    isLoggedIn: [
+      setMaintenanceModeAction,
+      setShowModalFactoryAction('AppMaintenanceModal'),
+    ],
     unauthorized: [navigateToPathAction],
   },
 ];

--- a/web-client/src/providers/socketRouter.js
+++ b/web-client/src/providers/socketRouter.js
@@ -67,6 +67,7 @@ export const socketRouter = (app, onMessageCallbackFn) => {
       case 'maintenance_mode_engaged':
         await app.getSequence('openAppMaintenanceModalSequence')({
           ...message,
+          maintenanceMode: true,
           path: '/maintenance',
         });
         break;

--- a/web-client/src/providers/socketRouter.js
+++ b/web-client/src/providers/socketRouter.js
@@ -72,11 +72,9 @@ export const socketRouter = (app, onMessageCallbackFn) => {
         });
         break;
       case 'maintenance_mode_disengaged':
-        await app.getSequence('clearModalSequence')({
+        await app.getSequence('disengageAppMaintenanceSequence')({
           ...message,
-        });
-        await app.getSequence('navigateToPathSequence')({
-          ...message,
+          maintenanceMode: false,
         });
         break;
     }

--- a/web-client/src/providers/socketRouter.test.js
+++ b/web-client/src/providers/socketRouter.test.js
@@ -100,7 +100,7 @@ describe('socketRouter', () => {
     });
   });
 
-  it('should call disengageAppMaintenanceSequenceif action is maintenance_mode_disengaged', async () => {
+  it('should call disengageAppMaintenanceSequence if action is maintenance_mode_disengaged', async () => {
     await socketRouter(mockApp)({
       data: '{ "action": "maintenance_mode_disengaged" }',
     });

--- a/web-client/src/providers/socketRouter.test.js
+++ b/web-client/src/providers/socketRouter.test.js
@@ -95,13 +95,19 @@ describe('socketRouter', () => {
       data: '{ "action": "maintenance_mode_engaged" }',
     });
     expect(mockSequence.mock.calls.length).toBe(1);
+    expect(mockSequence.mock.calls[0][0]).toMatchObject({
+      maintenanceMode: true,
+    });
   });
 
-  it('should call clearModalSequence and navigateToPathSequence if action is maintenance_mode_disengaged', async () => {
+  it('should call disengageAppMaintenanceSequenceif action is maintenance_mode_disengaged', async () => {
     await socketRouter(mockApp)({
       data: '{ "action": "maintenance_mode_disengaged" }',
     });
-    expect(mockSequence.mock.calls.length).toBe(2);
+    expect(mockSequence.mock.calls.length).toBe(1);
+    expect(mockSequence.mock.calls[0][0]).toMatchObject({
+      maintenanceMode: false,
+    });
   });
 
   it('should not call a sequence if action is an unknown action', async () => {


### PR DESCRIPTION
- Fix for routing to maintenance page on reloading while maintenanceMode is engaged 
- Disengage maintenanceMode routes to dashboard
- Fixed order of websocket and router initialization