### PR TITLE
8896 Feature Toggle Standalone Remote UI

### DIFF
--- a/shared/src/business/useCases/trialSessions/createTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/createTrialSessionInteractor.test.js
@@ -91,7 +91,8 @@ describe('createTrialSessionInteractor', () => {
     const result = await createTrialSessionInteractor(applicationContext, {
       trialSession: {
         ...MOCK_TRIAL,
-        sessionType: 'Motion/Hearing',
+        sessionScope: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
+        sessionType: 'Something Else',
       },
     });
 

--- a/shared/src/business/utilities/getIsFeatureEnabled.js
+++ b/shared/src/business/utilities/getIsFeatureEnabled.js
@@ -22,6 +22,8 @@ const getIsFeatureEnabled = (featureName, user, env) => {
 
       return !isProduction && isInternalUser;
     })(),
+    // FEATURE FLAG: standalone_remote_session
+    standalone_remote_session: false,
   };
 
   return !!features[featureName];

--- a/web-client/pa11y/pa11y-petitionsclerk.js
+++ b/web-client/pa11y/pa11y-petitionsclerk.js
@@ -415,14 +415,15 @@ module.exports = [
     notes: 'checks a11y of remote trial session add form',
     url: 'http://localhost:1234/mock-login?token=petitionsclerk&path=/add-a-trial-session&info=add-trial-session',
   },
-  {
-    actions: [
-      'wait for #standaloneRemote-session-scope-label to be visible',
-      'click element #standaloneRemote-session-scope-label',
-    ],
-    notes: 'checks a11y of standalone remote trial session add form',
-    url: 'http://localhost:1234/mock-login?token=petitionsclerk&path=/add-a-trial-session&info=add-trial-session',
-  },
+  // FEATURE FLAG: standalone_remote_session
+  // {
+  //   actions: [
+  //     'wait for #standaloneRemote-session-scope-label to be visible',
+  //     'click element #standaloneRemote-session-scope-label',
+  //   ],
+  //   notes: 'checks a11y of standalone remote trial session add form',
+  //   url: 'http://localhost:1234/mock-login?token=petitionsclerk&path=/add-a-trial-session&info=add-trial-session',
+  // },
   {
     actions: [
       'wait for #start-date-date to be visible',

--- a/web-client/src/presenter/computeds/TrialSession/addTrialSessionInformationHelper.js
+++ b/web-client/src/presenter/computeds/TrialSession/addTrialSessionInformationHelper.js
@@ -5,6 +5,10 @@ export const addTrialSessionInformationHelper = (get, applicationContext) => {
 
   const { proceedingType, sessionScope } = get(state.form);
 
+  // FEATURE FLAG: standalone_remote_session
+  const FEATURE_canDisplayStandaloneRemote =
+    applicationContext.isFeatureEnabled('standalone_remote_session');
+
   const isStandaloneSession = applicationContext
     .getUtilities()
     .isStandaloneRemoteSession(sessionScope);
@@ -24,6 +28,7 @@ export const addTrialSessionInformationHelper = (get, applicationContext) => {
   }
 
   return {
+    FEATURE_canDisplayStandaloneRemote,
     displayRemoteProceedingForm,
     isStandaloneSession,
     sessionTypes,

--- a/web-client/src/presenter/computeds/TrialSession/addTrialSessionInformationHelper.test.js
+++ b/web-client/src/presenter/computeds/TrialSession/addTrialSessionInformationHelper.test.js
@@ -140,4 +140,32 @@ describe('addTrialSessionInformationHelper', () => {
       ]);
     });
   });
+
+  describe('FEATURE_canDisplayStandaloneRemote', () => {
+    // FEATURE FLAG: standalone_remote_session
+    it('should return FEATURE_canDisplayStandaloneRemote true if standalone_remote_session feature flag is enabled', () => {
+      applicationContext.isFeatureEnabled.mockReturnValueOnce(true);
+
+      const result = runCompute(addTrialSessionInformationHelper, {
+        state: {
+          form: { sessionScope: TRIAL_SESSION_SCOPE_TYPES.locationBased },
+        },
+      });
+
+      expect(result.FEATURE_canDisplayStandaloneRemote).toEqual(true);
+    });
+
+    // FEATURE FLAG: standalone_remote_session
+    it('should NOT return FEATURE_canDisplayStandaloneRemote false if the standalone_remote_session feature flag is NOT enabled', () => {
+      applicationContext.isFeatureEnabled.mockReturnValueOnce(false);
+
+      const result = runCompute(addTrialSessionInformationHelper, {
+        state: {
+          form: { sessionScope: TRIAL_SESSION_SCOPE_TYPES.locationBased },
+        },
+      });
+
+      expect(result.FEATURE_canDisplayStandaloneRemote).toEqual(false);
+    });
+  });
 });

--- a/web-client/src/views/TrialSessions/SessionInformationForm.jsx
+++ b/web-client/src/views/TrialSessions/SessionInformationForm.jsx
@@ -29,41 +29,43 @@ export const SessionInformationForm = connect(
       <>
         <h2 className="margin-top-0">Session Information</h2>
         <div className="blue-container">
-          <div className="margin-bottom-5">
-            <legend className="usa-legend" id="session-scope-legend">
-              Session scope
-            </legend>
-            {Object.entries(TRIAL_SESSION_SCOPE_TYPES).map(([key, value]) => (
-              <div className="usa-radio usa-radio__inline" key={key}>
-                <input
-                  aria-describedby="session-scope"
-                  checked={form.sessionScope === value}
-                  className="usa-radio__input"
-                  id={`${key}-sessionScope`}
-                  name="sessionScope"
-                  type="radio"
-                  value={value}
-                  onBlur={() => {
-                    validateTrialSessionSequence();
-                  }}
-                  onChange={e => {
-                    updateTrialSessionFormDataSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-                <label
-                  aria-label={value}
-                  className="smaller-padding-right usa-radio__label"
-                  htmlFor={`${key}-sessionScope`}
-                  id={`${key}-session-scope-label`}
-                >
-                  {value}
-                </label>
-              </div>
-            ))}
-          </div>
+          {addTrialSessionInformationHelper.FEATURE_canDisplayStandaloneRemote && (
+            <div className="margin-bottom-5">
+              <legend className="usa-legend" id="session-scope-legend">
+                Session scope
+              </legend>
+              {Object.entries(TRIAL_SESSION_SCOPE_TYPES).map(([key, value]) => (
+                <div className="usa-radio usa-radio__inline" key={key}>
+                  <input
+                    aria-describedby="session-scope"
+                    checked={form.sessionScope === value}
+                    className="usa-radio__input"
+                    id={`${key}-sessionScope`}
+                    name="sessionScope"
+                    type="radio"
+                    value={value}
+                    onBlur={() => {
+                      validateTrialSessionSequence();
+                    }}
+                    onChange={e => {
+                      updateTrialSessionFormDataSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                  <label
+                    aria-label={value}
+                    className="smaller-padding-right usa-radio__label"
+                    htmlFor={`${key}-sessionScope`}
+                    id={`${key}-session-scope-label`}
+                  >
+                    {value}
+                  </label>
+                </div>
+              ))}
+            </div>
+          )}
 
           <DateInput
             errorText={validationErrors.startDate}


### PR DESCRIPTION
This leaves the business logic in place, as none of it is user-impacting unless the user is able to create the session in the first place.

Thanks to fine work by the 8896 team, the abstractions in place prevent much of this feature from leaking into the UI, so it only required one conditional where a standalone remote session would be created to prevent the implementation of standalone remote sessions from being exposed to the user.

One caveat to that could be a case where a session was created by an integration test on a particular environment. Since it already exists, it would be available in the UI. We opted to leave the integration tests enabled, because they can still run and pass (since they are state based and not UI based), and this helps prevent any future development from causing collisions with this feature before it's available to a user in the UI. Additionally, the fewer places we implement a code toggle, the fewer places we need to remove it or even account for it via testing permutations.

To enable the feature, simply change the flag in `getIsFeatureEnabled`
https://github.com/flexion/ef-cms/compare/develop...8896-feature-toggle-standalone-remote#diff-0f3e4c4a7497e326d9c7bedbedec5cdeb686667a52dbc15c949d975ded69d467R26

Long-term, it would be nice to replace this hard-coded value with a flag in dynamodb

Lastly, we commented out a pa11y test, since these are really intended to test accessibility, and this feature should not be accessible in the UI.

Conventions:
- We've used a comment to note anywhere a feature flag is affecting the code so that it's easy to remove later.
- Where we've implemented a feature toggle in the UI, we've used a naming convention that includes `FEATURE_` in front of the variable name, so that it is very clear that it's a feature toggle.

