### PR TITLE
7643 - fixing service indicator ordering to fix emails

### DIFF
--- a/shared/src/business/useCases/users/verifyUserPendingEmailInteractor.js
+++ b/shared/src/business/useCases/users/verifyUserPendingEmailInteractor.js
@@ -40,8 +40,6 @@ const updateCaseEntityAndGenerateChange = async ({
   const oldData = { email: oldEmail };
   petitionerObject.email = user.email;
 
-  const servedParties = aggregatePartiesForService(caseEntity);
-
   if (
     !caseEntity.isUserIdRepresentedByPrivatePractitioner(
       petitionerObject.contactId,
@@ -50,6 +48,7 @@ const updateCaseEntityAndGenerateChange = async ({
     petitionerObject.serviceIndicator = SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
   }
 
+  const servedParties = aggregatePartiesForService(caseEntity);
   const documentType = applicationContext
     .getUtilities()
     .getDocumentTypeForAddressChange({ newData, oldData });


### PR DESCRIPTION
This is a bug fix:

Bug: when a admissionclerk ads a new unverified email to a party, the service indicator was not set correctly before figuring out who needs service on the case; therefore, no service email was sent out to the new user when the NOCE was generated.