### PR TITLE
8919 feedback

### DIFF
--- a/web-client/src/presenter/computeds/addToTrialSessionModalHelper.js
+++ b/web-client/src/presenter/computeds/addToTrialSessionModalHelper.js
@@ -1,9 +1,8 @@
-import { isEmpty, isEqual, sortBy } from 'lodash';
+import { getTrialSessionStatus } from '../../../../shared/src/business/utilities/getFormattedTrialSessionDetails';
+import { sortBy } from 'lodash';
 import { state } from 'cerebral';
 
 const formatTrialSessionsForHelper = (trialSessions, applicationContext) => {
-  const { SESSION_STATUS_GROUPS } = applicationContext.getConstants();
-
   return trialSessions.map(trialSession => {
     trialSession.startDateFormatted = applicationContext
       .getUtilities()
@@ -23,18 +22,10 @@ const formatTrialSessionsForHelper = (trialSessions, applicationContext) => {
     }
     trialSession.optionText = `${trialSession.trialLocation} ${trialSession.startDateFormatted} (${trialSession.sessionTypeFormatted})`;
 
-    const allCases = trialSession.caseOrder || [];
-    const inactiveCases = allCases.filter(
-      sessionCase => sessionCase.removedFromTrial === true,
-    );
-
-    if (!isEmpty(allCases) && isEqual(allCases, inactiveCases)) {
-      trialSession.computedStatus = SESSION_STATUS_GROUPS.closed;
-    } else if (trialSession.isCalendared) {
-      trialSession.computedStatus = SESSION_STATUS_GROUPS.open;
-    } else {
-      trialSession.computedStatus = SESSION_STATUS_GROUPS.new;
-    }
+    trialSession.computedStatus = getTrialSessionStatus({
+      applicationContext,
+      session: trialSession,
+    });
 
     return trialSession;
   });

--- a/web-client/src/presenter/computeds/addToTrialSessionModalHelper.js
+++ b/web-client/src/presenter/computeds/addToTrialSessionModalHelper.js
@@ -1,4 +1,3 @@
-import { getTrialSessionStatus } from '../../../../shared/src/business/utilities/getFormattedTrialSessionDetails';
 import { sortBy } from 'lodash';
 import { state } from 'cerebral';
 
@@ -22,10 +21,12 @@ const formatTrialSessionsForHelper = (trialSessions, applicationContext) => {
     }
     trialSession.optionText = `${trialSession.trialLocation} ${trialSession.startDateFormatted} (${trialSession.sessionTypeFormatted})`;
 
-    trialSession.computedStatus = getTrialSessionStatus({
-      applicationContext,
-      session: trialSession,
-    });
+    trialSession.computedStatus = applicationContext
+      .getUtilities()
+      .getTrialSessionStatus({
+        applicationContext,
+        session: trialSession,
+      });
 
     return trialSession;
   });

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
@@ -74,7 +74,7 @@ export const TrialSessionDetail = connect(
                 {formattedTrialSessionDetails.canClose && (
                   <Button
                     link
-                    className="ustc-ui-tabs ustc-ui-tabs--right-link-button margin-right-0 red-warning"
+                    className="ustc-ui-tabs ustc-ui-tabs--right-link-button margin-right-0 red-warning ustc-button--mobile-inline"
                     id="close-session-button"
                     onClick={() => openConfirmModalSequence()}
                   >

--- a/web-client/src/views/TrialSessions/AddTrialSession.jsx
+++ b/web-client/src/views/TrialSessions/AddTrialSession.jsx
@@ -45,7 +45,7 @@ export const AddTrialSession = connect(
               All fields required unless otherwise noted
             </p>
 
-            <SessionInformationForm />
+            <SessionInformationForm addingTrialSession={true} />
             <LocationInformationForm />
             <SessionAssignmentsForm />
 

--- a/web-client/src/views/TrialSessions/SessionInformationForm.jsx
+++ b/web-client/src/views/TrialSessions/SessionInformationForm.jsx
@@ -17,6 +17,7 @@ export const SessionInformationForm = connect(
     validationErrors: state.validationErrors,
   },
   function SessionInformationForm({
+    addingTrialSession,
     addTrialSessionInformationHelper,
     form,
     formattedTrialSessions,
@@ -29,43 +30,46 @@ export const SessionInformationForm = connect(
       <>
         <h2 className="margin-top-0">Session Information</h2>
         <div className="blue-container">
-          {addTrialSessionInformationHelper.FEATURE_canDisplayStandaloneRemote && (
-            <div className="margin-bottom-5">
-              <legend className="usa-legend" id="session-scope-legend">
-                Session scope
-              </legend>
-              {Object.entries(TRIAL_SESSION_SCOPE_TYPES).map(([key, value]) => (
-                <div className="usa-radio usa-radio__inline" key={key}>
-                  <input
-                    aria-describedby="session-scope"
-                    checked={form.sessionScope === value}
-                    className="usa-radio__input"
-                    id={`${key}-sessionScope`}
-                    name="sessionScope"
-                    type="radio"
-                    value={value}
-                    onBlur={() => {
-                      validateTrialSessionSequence();
-                    }}
-                    onChange={e => {
-                      updateTrialSessionFormDataSequence({
-                        key: e.target.name,
-                        value: e.target.value,
-                      });
-                    }}
-                  />
-                  <label
-                    aria-label={value}
-                    className="smaller-padding-right usa-radio__label"
-                    htmlFor={`${key}-sessionScope`}
-                    id={`${key}-session-scope-label`}
-                  >
-                    {value}
-                  </label>
-                </div>
-              ))}
-            </div>
-          )}
+          {addingTrialSession &&
+            addTrialSessionInformationHelper.FEATURE_canDisplayStandaloneRemote && (
+              <div className="margin-bottom-5">
+                <legend className="usa-legend" id="session-scope-legend">
+                  Session scope
+                </legend>
+                {Object.entries(TRIAL_SESSION_SCOPE_TYPES).map(
+                  ([key, value]) => (
+                    <div className="usa-radio usa-radio__inline" key={key}>
+                      <input
+                        aria-describedby="session-scope"
+                        checked={form.sessionScope === value}
+                        className="usa-radio__input"
+                        id={`${key}-sessionScope`}
+                        name="sessionScope"
+                        type="radio"
+                        value={value}
+                        onBlur={() => {
+                          validateTrialSessionSequence();
+                        }}
+                        onChange={e => {
+                          updateTrialSessionFormDataSequence({
+                            key: e.target.name,
+                            value: e.target.value,
+                          });
+                        }}
+                      />
+                      <label
+                        aria-label={value}
+                        className="smaller-padding-right usa-radio__label"
+                        htmlFor={`${key}-sessionScope`}
+                        id={`${key}-session-scope-label`}
+                      >
+                        {value}
+                      </label>
+                    </div>
+                  ),
+                )}
+              </div>
+            )}
 
           <DateInput
             errorText={validationErrors.startDate}


### PR DESCRIPTION
- addresses showing "Session scope" only when creating a trial session
- improves mobile display of "Close session" button
- using `getTrialSessionStatus` to set computed status in `addToTrialSessionModalHelper.js`