### PR TITLE
8955 - authorizer crashing on async endpoints

### DIFF
--- a/web-api/src/lambdaWrapper.js
+++ b/web-api/src/lambdaWrapper.js
@@ -1,9 +1,11 @@
+const { get } = require('lodash');
+
 export const lambdaWrapper = lambda => {
   return async (req, res) => {
     // If you'd like to test the terminal user functionality locally, make this boolean true
     let isTerminalUser =
-      req.apiGateway.event &&
-      req.apiGateway.event.requestContext.authorizer.isTerminalUser === 'true';
+      get(req, 'apiGateway.event.requestContext.authorizer.isTerminalUser') ===
+      'true';
 
     const event = {
       headers: req.headers,

--- a/web-api/src/lambdaWrapper.test.js
+++ b/web-api/src/lambdaWrapper.test.js
@@ -43,7 +43,7 @@ describe('lambdaWrapper', () => {
       Pragma: 'no-cache',
       Vary: 'Authorization',
       'X-Content-Type-Options': 'nosniff',
-      'X-Terminal-User': undefined,
+      'X-Terminal-User': false,
     });
   });
 


### PR DESCRIPTION
- using lodash get to verify stuff does not crash when requestContext is undefined or unexpected