### PR TITLE
DevEx 994 - cleaning up old connections when people close their browser tabs

### DIFF
--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -446,6 +446,7 @@ const createTestApplicationContext = ({ user } = {}) => {
     deleteSectionOutboxRecord: jest
       .fn()
       .mockImplementation(deleteSectionOutboxRecord),
+    deleteUserConnection: jest.fn(),
     deleteUserOutboxRecord: jest
       .fn()
       .mockImplementation(deleteUserOutboxRecord),

--- a/shared/src/notifications/retrySendNotificationToConnections.test.js
+++ b/shared/src/notifications/retrySendNotificationToConnections.test.js
@@ -62,9 +62,9 @@ describe('retrySendNotificationToConnections', () => {
       messageStringified: mockMessageStringified,
     });
 
-    expect(applicationContext.getDocumentClient().delete).toHaveBeenCalledTimes(
-      mockConnections.length,
-    );
+    expect(
+      applicationContext.getPersistenceGateway().deleteUserConnection,
+    ).toHaveBeenCalledTimes(mockConnections.length);
   });
 
   it('does not call client.delete if deleteGoneConnections is false', async () => {

--- a/shared/src/persistence/dynamo/notifications/deleteUserConnection.test.js
+++ b/shared/src/persistence/dynamo/notifications/deleteUserConnection.test.js
@@ -5,16 +5,30 @@ const { deleteUserConnection } = require('./deleteUserConnection');
 
 describe('deleteUserConnection', () => {
   it('attempts to to delete the user connection', async () => {
-    applicationContext.getDocumentClient().query.mockReturnValue({
+    applicationContext.getDocumentClient().get.mockReturnValueOnce({
       promise: () =>
         Promise.resolve({
-          Items: [{ pk: 'connections-123', sk: 'abc' }],
+          Item: {
+            connectionId: '123',
+            pk: 'connection|123',
+            sk: 'connection|123',
+            userId: 'abc',
+          },
+        }),
+    });
+    applicationContext.getDocumentClient().get.mockReturnValueOnce({
+      promise: () =>
+        Promise.resolve({
+          Item: {
+            pk: 'user|abc',
+            sk: 'connection|123',
+          },
         }),
     });
 
     await deleteUserConnection({
       applicationContext,
-      connectionId: 'abc',
+      connectionId: '123',
     });
 
     expect(
@@ -25,8 +39,16 @@ describe('deleteUserConnection', () => {
           {
             DeleteRequest: {
               Key: {
-                pk: 'connections-123',
-                sk: 'abc',
+                pk: 'user|abc',
+                sk: 'connection|123',
+              },
+            },
+          },
+          {
+            DeleteRequest: {
+              Key: {
+                pk: 'connection|123',
+                sk: 'connection|123',
               },
             },
           },

--- a/shared/src/persistence/dynamo/notifications/saveUserConnection.js
+++ b/shared/src/persistence/dynamo/notifications/saveUserConnection.js
@@ -12,20 +12,34 @@ const TIME_TO_EXIST = 60 * 60 * 24;
  * @param {string} providers.userId the user id
  * @returns {Promise} the promise of the call to persistence
  */
-exports.saveUserConnection = ({
+exports.saveUserConnection = async ({
   applicationContext,
   connectionId,
   endpoint,
   userId,
 }) =>
-  put({
-    Item: {
-      connectionId,
-      endpoint,
-      gsi1pk: 'connection',
-      pk: `user|${userId}`,
-      sk: `connection|${connectionId}`,
-      ttl: Math.floor(Date.now() / 1000) + TIME_TO_EXIST,
-    },
-    applicationContext,
-  });
+  Promise.all([
+    put({
+      Item: {
+        connectionId,
+        endpoint,
+        gsi1pk: 'connection',
+        pk: `user|${userId}`,
+        sk: `connection|${connectionId}`,
+        ttl: Math.floor(Date.now() / 1000) + TIME_TO_EXIST,
+        userId,
+      },
+      applicationContext,
+    }),
+    put({
+      Item: {
+        connectionId,
+        endpoint,
+        pk: `connection|${connectionId}`,
+        sk: `connection|${connectionId}`,
+        ttl: Math.floor(Date.now() / 1000) + TIME_TO_EXIST,
+        userId,
+      },
+      applicationContext,
+    }),
+  ]);

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1679,7 +1679,7 @@ module.exports = (appContextUser, logger = createLogger()) => {
       return sass;
     },
     getNotificationClient: ({ endpoint }) => {
-      if (endpoint.indexOf('localhost') !== -1) {
+      if (endpoint.includes('localhost')) {
         endpoint = 'http://localhost:3011';
       }
       return new AWS.ApiGatewayManagementApi({

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -276,6 +276,31 @@ export const getCaseMessagesForCase = async cerebralTest => {
 
 const client = require('../../shared/src/persistence/dynamodbClientService');
 
+export const getConnectionsByUserId = userId => {
+  return client.query({
+    ExpressionAttributeNames: {
+      '#pk': 'pk',
+      '#sk': 'sk',
+    },
+    ExpressionAttributeValues: {
+      ':pk': `user|${userId}`,
+      ':prefix': 'connection',
+    },
+    KeyConditionExpression: '#pk = :pk and begins_with(#sk, :prefix)',
+    applicationContext,
+  });
+};
+
+export const getConnection = connectionId => {
+  return client.get({
+    Key: {
+      pk: `connection|${connectionId}`,
+      sk: `connection|${connectionId}`,
+    },
+    applicationContext,
+  });
+};
+
 export const getUserRecordById = userId => {
   return client.get({
     Key: {

--- a/web-client/integration-tests/websocketConnectionDisconnection.test.js
+++ b/web-client/integration-tests/websocketConnectionDisconnection.test.js
@@ -1,0 +1,37 @@
+import {
+  getConnection,
+  getConnectionsByUserId,
+  loginAs,
+  setupTest,
+  wait,
+} from './helpers';
+const cerebralTest = setupTest();
+
+describe('websocket connections are cleaned up when disconnecting', () => {
+  beforeAll(() => {
+    jest.setTimeout(50000);
+  });
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
+
+  loginAs(cerebralTest, 'petitionsclerk1@example.com');
+
+  it('should clean up the connection records in dynamo when the user disconnect', async () => {
+    const petitionsClerk1UserId = '4805d1ab-18d0-43ec-bafb-654e83405416';
+    const connectionsBeforeSignOut = await getConnectionsByUserId(
+      petitionsClerk1UserId,
+    );
+    expect(connectionsBeforeSignOut.length).toEqual(1);
+    await cerebralTest.runSequence('signOutSequence');
+    await wait(2000);
+    const connectionsAfterSignOut = await getConnectionsByUserId(
+      petitionsClerk1UserId,
+    );
+    expect(connectionsAfterSignOut).toEqual([]);
+    const connection = connectionsBeforeSignOut[0];
+    const connectionInDynamo = await getConnection(connection.connectionId);
+    expect(connectionInDynamo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This fixes a bug where connections on dynamo were not being deleted when people closed their browser.  This was original caused by a change in what we store in the gs1pk which used to be used for getting the connection based on the connection id.  This solution creates a separate record which maps the connectionId to the userId so that both items can be cleaned from dynamodb when a user closes their browser