### PR TITLE
public-smoketests fix for ustc/mig

### DIFF
--- a/cypress-readonly/integration/public/advanced-search.spec.js
+++ b/cypress-readonly/integration/public/advanced-search.spec.js
@@ -37,7 +37,9 @@ describe('Case Search Public UI Smoketests', () => {
     searchForCaseByDocketNumber('104-20');
     const docketRecord = docketRecordTable();
     docketRecord.should('exist');
-    const petitionRow = docketRecord.get('tr').contains('Petition');
+    const petitionRow = docketRecord
+      .get('tr')
+      .contains('Petition', { matchCase: false });
     petitionRow.should('exist');
     petitionRow.find('button').should('not.exist');
   });


### PR DESCRIPTION
ensures case insensitivity since ustaxcourt/migration data is in all caps when checking for "PETITION" vs "Petition" in flexion envs