### PR TITLE
public-smoketest-fix due to case sensitivity

### DIFF
--- a/cypress-readonly/integration/public/advanced-search.spec.js
+++ b/cypress-readonly/integration/public/advanced-search.spec.js
@@ -37,7 +37,9 @@ describe('Case Search Public UI Smoketests', () => {
     searchForCaseByDocketNumber('104-20');
     const docketRecord = docketRecordTable();
     docketRecord.should('exist');
-    const petitionRow = docketRecord.get('tr').contains('Petition');
+    const petitionRow = docketRecord
+      .get('tr')
+      .contains('Petition', { matchCase: false });
     petitionRow.should('exist');
     petitionRow.find('button').should('not.exist');
   });


### PR DESCRIPTION
ensures case insensitivity since taxcourt/migration data is in all caps on advanced-search.spec.js

relevant prs:
- into flexion/stg https://github.com/flexion/ef-cms/pull/9084
- flexion/stg to court/mig https://github.com/ustaxcourt/ef-cms/pull/1759

data on mig for case 104-20 shows "PETITION" vs "Petition" on flexion envs
![image](https://user-images.githubusercontent.com/16403861/138362942-f3136576-39fe-44e4-bbeb-0dcea7e84bc3.png)
