### PR TITLE
992 devex: fix test that was trying to connect to dynamo

### DIFF
--- a/web-api/src/genericHandler.test.js
+++ b/web-api/src/genericHandler.test.js
@@ -70,7 +70,9 @@ describe('genericHandler', () => {
   it('defaults the options param to an empty object if not provided', async () => {
     const callback = () => null;
 
-    await genericHandler({ ...MOCK_EVENT }, callback);
+    await genericHandler({ ...MOCK_EVENT }, callback, {
+      applicationContext,
+    });
 
     expect(applicationContext.logger.error).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Fixes https://trello.com/c/uHOrnbMG/992-generichandler-test-actually-trying-to-connect-to-dynamo which was producing an AWS param validation error