### PR TITLE
9119 - trying to fix these random OOM errors on the pa11y step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
-    resource_class: large
+    resource_class: xlarge
     steps:
       - restore_cache:
           name: Source - Restoring Cache

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -12,6 +12,7 @@ module.exports = {
         test: /\.(js|jsx)$/,
         use: ['babel-loader'],
       },
+
       {
         test: /\.(png|svg|jpg|jpeg|gif|pdf|woff|woff2|ttf)$/i,
         type: 'asset',
@@ -30,7 +31,6 @@ module.exports = {
       },
     ],
   },
-  parallelism: 66,
   plugins: [
     new HtmlWebpackPugPlugin(),
     new webpack.ProvidePlugin({

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -30,6 +30,7 @@ module.exports = {
       },
     ],
   },
+  parallelism: 66,
   plugins: [
     new HtmlWebpackPugPlugin(),
     new webpack.ProvidePlugin({


### PR DESCRIPTION
I am pretty sure webpack is eating up all the memory on the container and I can't find a way to prevent that.  I'm just going to bump the resource_class to xlarge for this pa11y build step.