### PR TITLE
Update docker containers using webpack from large => xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
-    resource_class: large
+    resource_class: xlarge
     steps:
       - restore_cache:
           name: Source - Restoring Cache
@@ -399,7 +399,7 @@ jobs:
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
-    resource_class: large
+    resource_class: xlarge
     steps:
       - restore_cache:
           name: Source - Restoring Cache


### PR DESCRIPTION
This is to help avoid crashes due to the container being out of memory since webpack uses a lot of memory. Thanks @codyseibert for pointing out the cause of this!

Example where a build fails due to this:
https://app.circleci.com/pipelines/github/flexion/ef-cms/32040/workflows/2a402e18-7d02-4d17-ae02-b4c6a23c8ec7/jobs/198294