### PR TITLE
quiet down devtools messages

### DIFF
--- a/web-client/src/index-public.dev.js
+++ b/web-client/src/index-public.dev.js
@@ -1,17 +1,9 @@
 import { appPublic } from './appPublic';
 import { applicationContextPublic } from './applicationContextPublic';
-import Devtools from 'cerebral/devtools';
 
 /**
  * Initializes the app with dev environment context
  */
-let debugTools = null;
-if (process.env.USTC_DEBUG) {
-  debugTools = {
-    devtools: Devtools({
-      host: 'localhost:8585',
-    }),
-  };
-}
+const options = {};
 
-appPublic.initialize(applicationContextPublic, debugTools);
+appPublic.initialize(applicationContextPublic, options);

--- a/web-client/src/index.dev.js
+++ b/web-client/src/index.dev.js
@@ -1,20 +1,11 @@
-import { Case } from '../../shared/src/business/entities/cases/Case';
-import { User } from '../../shared/src/business/entities/User';
 import { app } from './app';
 import { applicationContext } from './applicationContext';
-import Devtools from 'cerebral/devtools';
 
 /**
  * Initializes the app with dev environment context
  */
-let options = {
+const options = {
   returnSequencePromise: true,
 };
-if (process.env.USTC_DEBUG) {
-  options.devtools = Devtools({
-    allowedTypes: [Blob, User, Case],
-    host: 'localhost:8585',
-  });
-}
 
 app.initialize(applicationContext, options);

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -5,6 +5,7 @@ const HtmlWebpackPugPlugin = require('html-webpack-pug-plugin');
 const webpack = require('webpack');
 
 module.exports = {
+  devtool: false,
   module: {
     rules: [
       {


### PR DESCRIPTION
quiet down the console warnings and noises about sourcemaps when developing locally
remove references to cerebral devtools also.