### PR TITLE
8949 - the progress bar is timing out fixing it by checking progress indicators

### DIFF
--- a/cypress-smoketests/support/pages/my-account.js
+++ b/cypress-smoketests/support/pages/my-account.js
@@ -17,7 +17,13 @@ exports.updateAddress1 = () => {
 
 exports.saveContactInformation = () => {
   cy.get('button.usa-button').contains('Save').click();
-
+  // the progress bar will take a while to finish when practitioner has too many open cases, so
+  // we check these intervals to prevent the cy.get('.progress-indicator').should('not.exist'); from timing out.
+  [25, 50, 75].forEach(expectedValue => {
+    cy.get('.progress-text').should(div => {
+      expect(parseInt(div.get(0).innerText.split('%')[0])).to.gt(expectedValue);
+    });
+  });
   cy.get('.progress-indicator').should('not.exist');
   cy.get('.progress-user-contact-edit').should('not.exist');
   cy.get('.usa-alert--success').should('exist');


### PR DESCRIPTION
If the private practitioner has too many open cases, the smoke tests will start failing due to the progress bar expecting to disappear, but it still remains.  We are making a change to instead check for progress values > 25%, 50%, and 75% to prevent this timeout.