### PR TITLE
fixing issue with switch colors getting stuck due to pager output

### DIFF
--- a/web-client/switch-colors.sh
+++ b/web-client/switch-colors.sh
@@ -12,6 +12,8 @@ MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)
 
 # disabling aws pager https://github.com/aws/aws-cli/pull/4702#issue-344978525
 AWS_PAGER=""
+# disable pager to newer cli version
+PAGER=""
 
 # exit on any failure
 set -eo pipefail


### PR DESCRIPTION
if commands output text that is too long, aws pipes it to some type of `vi` like process where a user has to interactive with the pager to continue the script