### PR TITLE
revert change that fails when database is empty

### DIFF
--- a/cypress-smoketests/support/pages/my-account.js
+++ b/cypress-smoketests/support/pages/my-account.js
@@ -17,13 +17,6 @@ exports.updateAddress1 = () => {
 
 exports.saveContactInformation = () => {
   cy.get('button.usa-button').contains('Save').click();
-  // the progress bar will take a while to finish when practitioner has too many open cases, so
-  // we check these intervals to prevent the cy.get('.progress-indicator').should('not.exist'); from timing out.
-  [25, 50, 75].forEach(expectedValue => {
-    cy.get('.progress-text').should(div => {
-      expect(parseInt(div.get(0).innerText.split('%')[0])).to.gt(expectedValue);
-    });
-  });
   cy.get('.progress-indicator').should('not.exist');
   cy.get('.progress-user-contact-edit').should('not.exist');
   cy.get('.usa-alert--success').should('exist');


### PR DESCRIPTION
we added some logic to check increments of the progress bar.  It turns out this fails if the practitioner doesn't have many cases, so I'm going to remove it for now until we can rethink a better solution.