### PR TITLE
OpEx - Speed Up Circle Jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
     resource_class: xlarge
     steps:
       - git-shallow-clone/checkout
-      # - npm-install
+      - npm-install
       - run:
           name: Create Pa11y Artifacts Directory
           command: mkdir /tmp/pa11y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ jobs:
     resource_class: xlarge
     steps:
       - git-shallow-clone/checkout
-      # - checkout-and-cache-source-code
       - npm-install
       - run:
           name: Create Pa11y Artifacts Directory
@@ -192,7 +191,6 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      # - checkout-and-cache-source-code
       - git-shallow-clone/checkout
       - npm-install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.0
 commands:
   checkout-and-cache-source-code:
     steps:
@@ -96,7 +98,8 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      - checkout-and-cache-source-code
+      - git-shallow-clone/checkout
+      # - checkout-and-cache-source-code
       - npm-install
       - run:
           name: Create Pa11y Artifacts Directory
@@ -144,8 +147,8 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      - checkout-and-cache-source-code
-      - npm-install
+      - git-shallow-clone/checkout
+      # - npm-install
       - run:
           name: Create Pa11y Artifacts Directory
           command: mkdir /tmp/pa11y
@@ -189,7 +192,8 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      - checkout-and-cache-source-code
+      # - checkout-and-cache-source-code
+      - git-shallow-clone/checkout
       - npm-install
       - run:
           name: Create Pa11y Artifacts Directory
@@ -234,7 +238,7 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      - checkout-and-cache-source-code
+      - git-shallow-clone/checkout
       - npm-install
       - run:
           name: Create Cypress Artifacts Directory
@@ -283,7 +287,7 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      - checkout-and-cache-source-code
+      - git-shallow-clone/checkout
       - npm-install
       - run:
           name: Create Cypress Artifacts Directory
@@ -332,7 +336,7 @@ jobs:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: xlarge
     steps:
-      - checkout-and-cache-source-code
+      - git-shallow-clone/checkout
       - npm-install
       - run:
           name: Create Cypress Artifacts Directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,6 @@ jobs:
             AWS_ACCESS_KEY_ID: S3RVER
             AWS_SECRET_ACCESS_KEY: S3RVER
           command: |
-            npm run build:all
             npx --no-install run-p start:api:ci start:client:ci >> /tmp/pa11y/pa11y-server.txt &
             URL=http://localhost:4000/api/swagger ./wait-until.sh
             URL=http://localhost:1234 ./wait-until.sh
@@ -163,7 +162,6 @@ jobs:
             AWS_ACCESS_KEY_ID: S3RVER
             AWS_SECRET_ACCESS_KEY: S3RVER
           command: |
-            npm run build:all
             npx --no-install run-p start:api:ci start:public:ci >> /tmp/pa11y/pa11y-server.txt &
             ./wait-until-services.sh
             URL=http://localhost:5000/ CHECK_CODE=404 ./wait-until.sh
@@ -209,7 +207,6 @@ jobs:
             AWS_ACCESS_KEY_ID: S3RVER
             AWS_SECRET_ACCESS_KEY: S3RVER
           command: |
-            npm run build:all
             npx --no-install run-p start:api:ci start:public:ci >> /tmp/pa11y/pa11y-server.txt &
             ./wait-until-services.sh
             URL=http://localhost:5000/ CHECK_CODE=404 ./wait-until.sh
@@ -255,7 +252,6 @@ jobs:
             AWS_ACCESS_KEY_ID: S3RVER
             AWS_SECRET_ACCESS_KEY: S3RVER
           command: |
-            npm run build:all &&
             CYPRESS_VERSION=`./node_modules/.bin/cypress --version | awk -F' ' '{print $4; exit}'`
             if [ ! -e "/root/.cache/Cypress/${CYPRESS_VERSION}/Cypress/Cypress" ]; then
               ./node_modules/.bin/cypress install
@@ -305,7 +301,6 @@ jobs:
             AWS_ACCESS_KEY_ID: S3RVER
             AWS_SECRET_ACCESS_KEY: S3RVER
           command: |
-            npm run build:all &&
             CYPRESS_VERSION=`./node_modules/.bin/cypress --version | awk -F' ' '{print $4; exit}'`
             if [ ! -e "/root/.cache/Cypress/${CYPRESS_VERSION}/Cypress/Cypress" ]; then
               ./node_modules/.bin/cypress install
@@ -355,7 +350,6 @@ jobs:
             AWS_ACCESS_KEY_ID: S3RVER
             AWS_SECRET_ACCESS_KEY: S3RVER
           command: |
-            npm run build:all &&
             CYPRESS_VERSION=`./node_modules/.bin/cypress --version | awk -F' ' '{print $4; exit}'`
             if [ ! -e "/root/.cache/Cypress/${CYPRESS_VERSION}/Cypress/Cypress" ]; then
               ./node_modules/.bin/cypress install


### PR DESCRIPTION
For some reason we were running build:all in a lot of our circle steps.  We don't seem to be using the bundled distribution at this point for our testing, so we are just wasting time running webpack to create a dist directory we never use.  So I'm removing that build:all call.  

Also, I'm bringing in a orb which allows us to do a shallow clone of the repo which should speed up how long it takes to download the repo.  Also, this might help with disk usage costs since we download the entire repo on each step basically.

Job Speeds After:
<img width="1080" alt="Screen Shot 2021-12-14 at 12 58 27 PM" src="https://user-images.githubusercontent.com/1868782/146054278-526a5711-48c3-465f-89e8-bdbd9e38dd07.png">

Job Speeds Before:
<img width="1106" alt="Screen Shot 2021-12-14 at 1 02 24 PM" src="https://user-images.githubusercontent.com/1868782/146054393-93db25f0-abe5-4dbf-9909-dd3b1eac9632.png">

so it shaved off a couple of minutes for each build step it seems.