### PR TITLE
8949 - Verify that the refreshToken is defined

### DIFF
--- a/shared/src/business/useCases/auth/refreshAuthTokenInteractor.js
+++ b/shared/src/business/useCases/auth/refreshAuthTokenInteractor.js
@@ -10,6 +10,9 @@ exports.refreshAuthTokenInteractor = async (
   applicationContext,
   { refreshToken },
 ) => {
+  if (!refreshToken) {
+    throw new Error('refreshToken is required');
+  }
   const { token } = await applicationContext
     .getPersistenceGateway()
     .refreshToken(applicationContext, { refreshToken });

--- a/shared/src/business/useCases/auth/refreshAuthTokenInteractor.test.js
+++ b/shared/src/business/useCases/auth/refreshAuthTokenInteractor.test.js
@@ -22,4 +22,12 @@ describe('refreshAuthTokenInteractor', () => {
       token: 'abc',
     });
   });
+
+  it('throws an exception if not refresh token is passed in', async () => {
+    await expect(
+      refreshAuthTokenInteractor(applicationContext, {
+        refreshToken: undefined,
+      }),
+    ).rejects.toThrow('refreshToken is required');
+  });
 });


### PR DESCRIPTION
throw an error if the refreshToken is undefined which was causing issues for us when trying to run locally with multiple cookie headers set