### PR TITLE
Fixing issue with migrate step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,9 +581,7 @@ jobs:
       - run:
           name: Build Docker Image
           command: |
-            if [ "$MIGRATE_FLAG" == "true" ]; then
-              docker build -t efcms -f Dockerfile .
-            fi
+            docker build -t efcms -f Dockerfile .
       - run:
           name: Deploy Migration Cron Lambda
           command: |


### PR DESCRIPTION
The "Enable Check Reindex Status Cron" step requires this docker image to be built.  There was a conditional statement added to help speed up the migrate step, but this conditional causes the migrate step to fail since Check reindex status requires the image to exist.  