### PR TITLE
8516 - Fixing issue with restoring date fields

### DIFF
--- a/web-client/integration-tests/docketClerkOpinionAdvancedSearch.test.js
+++ b/web-client/integration-tests/docketClerkOpinionAdvancedSearch.test.js
@@ -57,6 +57,7 @@ describe('Docket clerk opinion advanced search', () => {
     });
 
     expect(cerebralTest.getState('advancedSearchForm.opinionSearch')).toEqual({
+      dateRange: 'allDates',
       keyword: '',
       opinionTypes: {
         [ADVANCED_SEARCH_OPINION_TYPES.Memorandum]: true,

--- a/web-client/integration-tests/docketClerkOrderAdvancedSearch.test.js
+++ b/web-client/integration-tests/docketClerkOrderAdvancedSearch.test.js
@@ -141,6 +141,7 @@ describe('Docket clerk advanced order search', () => {
     });
 
     expect(cerebralTest.getState('advancedSearchForm.orderSearch')).toEqual({
+      dateRange: 'allDates',
       keyword: '',
     });
   });

--- a/web-client/src/presenter/actions/AdvancedSearch/clearAdvancedSearchFormAction.js
+++ b/web-client/src/presenter/actions/AdvancedSearch/clearAdvancedSearchFormAction.js
@@ -13,24 +13,28 @@ export const clearAdvancedSearchFormAction = ({
   props,
   store,
 }) => {
-  const { ADVANCED_SEARCH_OPINION_TYPES, COUNTRY_TYPES } =
-    applicationContext.getConstants();
+  const {
+    ADVANCED_SEARCH_OPINION_TYPES,
+    COUNTRY_TYPES,
+    DATE_RANGE_SEARCH_OPTIONS,
+  } = applicationContext.getConstants();
 
   const { formType } = props;
-  const emptyForm = {};
+  const defaultForm = {};
   if (formType === 'caseSearchByName') {
-    emptyForm.countryType = COUNTRY_TYPES.DOMESTIC;
+    defaultForm.countryType = COUNTRY_TYPES.DOMESTIC;
   }
   if (formType === 'orderSearch' || formType === 'opinionSearch') {
-    emptyForm.keyword = '';
+    defaultForm.keyword = '';
+    defaultForm.dateRange = DATE_RANGE_SEARCH_OPTIONS.ALL_DATES;
   }
   if (formType === 'opinionSearch') {
-    emptyForm.opinionTypes = {
+    defaultForm.opinionTypes = {
       [ADVANCED_SEARCH_OPINION_TYPES.Memorandum]: true,
       [ADVANCED_SEARCH_OPINION_TYPES.Summary]: true,
       [ADVANCED_SEARCH_OPINION_TYPES.Bench]: true,
       [ADVANCED_SEARCH_OPINION_TYPES['T.C.']]: true,
     };
   }
-  store.set(state.advancedSearchForm[formType], emptyForm);
+  store.set(state.advancedSearchForm[formType], defaultForm);
 };

--- a/web-client/src/presenter/actions/AdvancedSearch/clearAdvancedSearchFormAction.test.js
+++ b/web-client/src/presenter/actions/AdvancedSearch/clearAdvancedSearchFormAction.test.js
@@ -91,7 +91,7 @@ describe('clearAdvancedSearchFormAction', () => {
     });
 
     expect(result.state.advancedSearchForm).toEqual({
-      orderSearch: { keyword: '' },
+      orderSearch: { dateRange: 'allDates', keyword: '' },
     });
   });
 
@@ -108,6 +108,7 @@ describe('clearAdvancedSearchFormAction', () => {
 
     expect(result.state.advancedSearchForm).toEqual({
       opinionSearch: {
+        dateRange: 'allDates',
         keyword: '',
         opinionTypes: {
           [ADVANCED_SEARCH_OPINION_TYPES.Memorandum]: true,

--- a/web-client/src/views/AdvancedSearch/SearchDateRangePickerComponent.jsx
+++ b/web-client/src/views/AdvancedSearch/SearchDateRangePickerComponent.jsx
@@ -37,6 +37,12 @@ export const SearchDateRangePickerComponent = connect(
       const startHiddenInput = window.document.querySelector(
         'input[name="startDate-date-start"]',
       );
+
+      if (advancedSearchForm[formType].startDate && startInput) {
+        startInput.value = advancedSearchForm[formType].startDate;
+        startHiddenInput.value = advancedSearchForm[formType].startDate;
+      }
+
       if (!advancedSearchForm[formType].startDate && startInput) {
         startInput.value = '';
         startHiddenInput.value = '';
@@ -55,6 +61,12 @@ export const SearchDateRangePickerComponent = connect(
       const endHiddenInput = window.document.querySelector(
         'input[name="endDate-date-end"]',
       );
+
+      if (advancedSearchForm[formType].endDate && endInput) {
+        endInput.value = advancedSearchForm[formType].endDate;
+        endHiddenInput.value = advancedSearchForm[formType].endDate;
+      }
+
       if (!advancedSearchForm[formType].endDate && endInput) {
         endInput.value = '';
         endHiddenInput.value = '';


### PR DESCRIPTION
- the react component related to the date range fields was not initializing to the provided cerebral state values if they were defined; this adds additional logic to initialize them
- the clear form buttons were not reseting the date dropdown to the correct default