### PR TITLE
DevEx 979 - Make deployments from local cleaner

### DIFF
--- a/web-api/terraform/main/.env
+++ b/web-api/terraform/main/.env
@@ -1,0 +1,21 @@
+# common variables
+EFCMS_DOMAIN=exp1.ustc-case-mgmt.flexion.us
+ZONE_NAME=ustc-case-mgmt.flexion.us
+ENVIRONMENT=exp1
+
+# web-client
+DYNAMSOFT_PRODUCT_KEYS=noop
+DYNAMSOFT_S3_ZIP_PATH=s3://ustc-case-mgmt.flexion.us-dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz
+DYNAMSOFT_URL=https://dynamsoft-lib-dev.ustc-case-mgmt.flexion.us
+IS_DYNAMSOFT_ENABLED=0
+ENABLE_HEALTH_CHECKS=0
+
+# web-api
+BOUNCED_EMAIL_RECIPIENT=
+COGNITO_SUFFIX=flexion-efcms
+DISABLE_EMAILS=true
+EMAIL_DMARC_POLICY=v=DMARC1; p=none; rua=mailto:flexionustc@gmail.com;
+ES_INSTANCE_COUNT=3
+ES_INSTANCE_TYPE=t2.small.elasticsearch
+ES_VOLUME_SIZE=10
+IRS_SUPERUSER_EMAIL=flexionustc+irsSuperUser@gmail.com

--- a/web-client/src/appPublic.jsx
+++ b/web-client/src/appPublic.jsx
@@ -45,6 +45,7 @@ import ReactDOM from 'react-dom';
 const appPublic = {
   initialize: (applicationContext, debugTools) => {
     const withAppContextDecorator = (f, context) => {
+      console.log(Date.now());
       return get => f(get, context || applicationContext);
     };
 

--- a/web-client/terraform/main/.env
+++ b/web-client/terraform/main/.env
@@ -1,0 +1,8 @@
+EFCMS_DOMAIN=exp1.ustc-case-mgmt.flexion.us
+DYNAMSOFT_PRODUCT_KEYS=noop
+DYNAMSOFT_S3_ZIP_PATH=s3://ustc-case-mgmt.flexion.us-dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz
+DYNAMSOFT_URL=https://dynamsoft-lib-dev.ustc-case-mgmt.flexion.us
+ENVIRONMENT=exp1
+IS_DYNAMSOFT_ENABLED=0
+ZONE_NAME=ustc-case-mgmt.flexion.us
+ENABLE_HEALTH_CHECKS=0


### PR DESCRIPTION
This draft is just acting as a placeholder and is not ready.

This approach uses an environment-specific .env file uploaded to the `flexion-ef-cms-environments` bucket. So when a developer wants to deploy only a portion of the app to an environment, they can run the appropriate terraform command without setting the environment variables and having them incorrect.