### PR TITLE
985 - upgrade es to 7.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -126,7 +126,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -176,7 +176,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -221,7 +221,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -266,7 +266,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -311,7 +311,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -360,7 +360,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.10.1
+      - image: elastic/elasticsearch:7.10.2
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -126,7 +126,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -176,7 +176,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -221,7 +221,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -266,7 +266,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -311,7 +311,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
@@ -360,7 +360,7 @@ jobs:
         environment:
           discovery.type: single-node
           JAVA_OPTS: '-Xms512m -Xmx512m'
-      - image: elastic/elasticsearch:7.8.1
+      - image: elastic/elasticsearch:7.10.1
         environment:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'

--- a/clear-env.sh
+++ b/clear-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Deletes existing cases from DynamoDB and ElasticSearch
+# clears and reinitializes the current active dynamo and elasticsearch instances
 
 # Usage
 #   ./clear-env.sh $ENV
@@ -11,24 +11,35 @@
   "AWS_SECRET_ACCESS_KEY" \
   "DEFAULT_ACCOUNT_PASS" \
   "ENV" \
-  "DYNAMODB_TABLE_NAME" \
-  "ELASTICSEARCH_ENDPOINT" \
-  "REGION" \
-  "FILE_NAME" \
   "USTC_ADMIN_USER" \
   "DEPLOYING_COLOR"
+
+export REGION=us-east-1
 
 ( ! command -v terraform > /dev/null ) && echo "Terraform was not found on your path. Please install terraform." && exit 1
 ( ! command -v node > /dev/null ) && echo "node was not found on your path. Please install node." && exit 1
 ( ! command -v aws > /dev/null ) && echo "aws was not found on your path. Please install aws." && exit 1
 
+SOURCE_TABLE_VERSION=$(aws dynamodb get-item \
+  --region us-east-1 \
+  --table-name "efcms-deploy-${ENV}" \
+  --key '{"pk":{"S":"source-table-version"},"sk":{"S":"source-table-version"}}' | jq -r ".Item.current.S")
+
+export ELASTICSEARCH_ENDPOINT=$(aws es describe-elasticsearch-domain \
+  --domain-name efcms-search-${ENV}-${SOURCE_TABLE_VERSION} \
+  --region us-east-1 \
+  --query 'DomainStatus.Endpoint' \
+  --output text)
+
+export FILE_NAME=./scripts/data-import/judge/judge_users.csv
+
 echo "clearing elasticsearch"
-./web-api/clear-elasticsearch-index.sh $ENV $ELASTICSEARCH_ENDPOINT
+./web-api/clear-elasticsearch-index.sh "${ENV}" "${ELASTICSEARCH_ENDPOINT}"
 echo "setting up elasticsearch"
-./web-api/setup-elasticsearch-index.sh $ENV
+./web-api/setup-elasticsearch-index.sh "${ENV}"
 
 echo "clearing dynamo"
-node ./web-api/clear-dynamodb-table.js $DYNAMODB_TABLE_NAME
+node ./web-api/clear-dynamodb-table.js "efcms-${ENV}-${SOURCE_TABLE_VERSION}"
 echo "setting up test users"
 node shared/admin-tools/user/setup-test-users.js
 echo "importing judge users"

--- a/shared/admin-tools/elasticsearch/find-cases-linked-to-practitioners.js
+++ b/shared/admin-tools/elasticsearch/find-cases-linked-to-practitioners.js
@@ -25,7 +25,7 @@ const esClient = new elasticsearch.Client({
     credentials: new EnvironmentCredentials('AWS'),
     region: 'us-east-1',
   },
-  apiVersion: '7.10',
+  apiVersion: '7.7',
   awsConfig: new AWS.Config({ region: 'us-east-1' }),
   connectionClass,
   host: esEndpoint,

--- a/shared/admin-tools/elasticsearch/find-cases-linked-to-practitioners.js
+++ b/shared/admin-tools/elasticsearch/find-cases-linked-to-practitioners.js
@@ -25,7 +25,7 @@ const esClient = new elasticsearch.Client({
     credentials: new EnvironmentCredentials('AWS'),
     region: 'us-east-1',
   },
-  apiVersion: '7.4',
+  apiVersion: '7.10',
   awsConfig: new AWS.Config({ region: 'us-east-1' }),
   connectionClass,
   host: esEndpoint,

--- a/shared/admin-tools/elasticsearch/find-petitioners-missing-cases.js
+++ b/shared/admin-tools/elasticsearch/find-petitioners-missing-cases.js
@@ -25,7 +25,7 @@ const esClient = new elasticsearch.Client({
     credentials: new EnvironmentCredentials('AWS'),
     region: 'us-east-1',
   },
-  apiVersion: '7.10',
+  apiVersion: '7.7',
   awsConfig: new AWS.Config({ region: 'us-east-1' }),
   connectionClass,
   host: esEndpoint,

--- a/shared/admin-tools/elasticsearch/find-petitioners-missing-cases.js
+++ b/shared/admin-tools/elasticsearch/find-petitioners-missing-cases.js
@@ -25,7 +25,7 @@ const esClient = new elasticsearch.Client({
     credentials: new EnvironmentCredentials('AWS'),
     region: 'us-east-1',
   },
-  apiVersion: '7.4',
+  apiVersion: '7.10',
   awsConfig: new AWS.Config({ region: 'us-east-1' }),
   connectionClass,
   host: esEndpoint,

--- a/web-api/elasticsearch/elasticsearch-settings.js
+++ b/web-api/elasticsearch/elasticsearch-settings.js
@@ -7,7 +7,7 @@ considerations:
   then search for "deja" to see if the order is returned.
 */
 module.exports = {
-  ELASTICSEARCH_API_VERSION: '7.4', // when this changes, ensure elasticsearch.tf files are also updated
+  ELASTICSEARCH_API_VERSION: '7.10', // when this changes, ensure elasticsearch.tf files are also updated
   settings: {
     index: {
       analysis: {

--- a/web-api/elasticsearch/elasticsearch-settings.js
+++ b/web-api/elasticsearch/elasticsearch-settings.js
@@ -7,7 +7,7 @@ considerations:
   then search for "deja" to see if the order is returned.
 */
 module.exports = {
-  ELASTICSEARCH_API_VERSION: '7.10', // when this changes, ensure elasticsearch.tf files are also updated
+  ELASTICSEARCH_API_VERSION: '7.7', // when this changes, ensure elasticsearch.tf files are also updated
   settings: {
     index: {
       analysis: {

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1819,7 +1819,7 @@ module.exports = (appContextUser, logger = createLogger()) => {
               credentials: new EnvironmentCredentials('AWS'),
               region: environment.region,
             },
-            apiVersion: '7.4',
+            apiVersion: '7.10',
             awsConfig: new AWS.Config({ region: 'us-east-1' }),
             connectionClass,
             host: environment.elasticsearchEndpoint,

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1819,7 +1819,7 @@ module.exports = (appContextUser, logger = createLogger()) => {
               credentials: new EnvironmentCredentials('AWS'),
               region: environment.region,
             },
-            apiVersion: '7.10',
+            apiVersion: '7.7',
             awsConfig: new AWS.Config({ region: 'us-east-1' }),
             connectionClass,
             host: environment.elasticsearchEndpoint,

--- a/web-api/start-elasticsearch.sh
+++ b/web-api/start-elasticsearch.sh
@@ -5,9 +5,9 @@
 
 # download the elasticsearch archive if needed
 if [ -f /.dockerenv ]; then
-  ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.8.1-linux-x86_64.tar.gz"
+  ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.10.2-linux-x86_64.tar.gz"
 else
-  ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.8.1-darwin-x86_64.tar.gz"
+  ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.10.2-darwin-x86_64.tar.gz"
 fi
 
 ES_ARCH_RENAMED="elasticsearch.tar.gz"

--- a/web-api/terraform/template/elasticsearch/elasticsearch.tf
+++ b/web-api/terraform/template/elasticsearch/elasticsearch.tf
@@ -36,7 +36,7 @@ CONFIG
 
 resource "aws_elasticsearch_domain" "efcms-search" {
   domain_name           = var.domain_name
-  elasticsearch_version = "7.4"
+  elasticsearch_version = "7.10"
 
   cluster_config {
     instance_type  = var.es_instance_type


### PR DESCRIPTION
- improving the clear-env.sh script to not required a bunch of additional arguments to run.  Now it will clear the active dynamodb table and ES cluster and re-initialize them for a specified environment
- upgrading ES to 7.10