### PR TITLE
979 - Standardize Terraform Deployment From Local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ web-client/terraform/common/cloudfront-edge/header-security-lambda.js.zip
 web-client/terraform/common/cloudfront-edge/strip-basepath-lambda.js.zip
 web-client/tests_output/
 bulk-import-log.txt
+**/.env

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,7 @@
 * [Testing](testing.md)
 * [🆘 Migrations](migrations.md)
 * [Terraform](terraform.md)
+* [Deploying](deploying.md)
 * [Kibana](kibana.md)
 * [🆘 AWS](aws.md)
 * [Additional Resources](additional-resources/README.md)

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,3 @@
+# Deploying The Application
+
+## 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,3 +1,52 @@
 # Deploying The Application
 
-## 
+## During CI/CD
+
+Automated deployments are just one portion of CI/CD. Please see the CircleCI portion of the [CI/CD documentation](/ci-cd).
+
+## During Development
+
+Sometimes during the course of development it is preferable to deploy just one portion of the application to a lower 
+environment without waiting for the entire CI/CD process to complete. This is best accomplished by following the 
+procedures set out in the following sections.
+
+### AWS Account
+
+This deployment sets up Kibana instances for the AWS Account. It can also be used to make changes to the AWS Account. 
+The effects of this deployment apply for all Flexion environments OR for all USTC environments according to which AWS 
+account is being deployed to.
+
+`/iam/terraform/account-specific/bin/deploy-app.sh` may be executed from the project root with this command:
+
+```shell
+npm run deploy:account-specific
+```
+
+### Web API
+
+This deployment sets up the back end of the application.
+
+`/web-api/terraform/bin/deploy-app.sh` may be executed from the project root with this command:
+
+```shell
+npm run deploy:api ${environment}
+```
+
+### Web Client
+
+This deployment publishes the web client to CloudFront.
+
+`/web-client/terraform/bin/deploy-app.sh` may be executed from the project root with this command:
+
+```shell
+npm run deploy:ui ${environment}
+```
+
+## AWS Secrets Manager
+
+To enable painless deployments from a developer's local machine, environment variables used for the various environments 
+are stored in secrets which are retrieved during the deployment script. The secret name is something like `${env}_deploy` 
+and the value of `${env}` is what must be passed as an argument to the deployment script. The only exception to this is 
+the account specific deployment which takes no argument and makes use of a secret called `account_deploy`.
+
+Secrets can be managed via the [AWS console](https://console.aws.amazon.com/secretsmanager/home?region=us-east-1#!/listSecrets/).

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -22,10 +22,9 @@ This document covers the initial setup needed to get EF-CMS continuous integrati
 
 - Clone this repository.
 
-- Set the `EFCMS_DOMAIN` environment variable to the domain you’ll be hosting EF-CMS at. You may want to set this in your `~/.zshrc` file for ease of use:
-  ```bash
-  export EFCMS_DOMAIN="example.com"
-  ```
+- Ensure that AWS Secrets Manager has a secret for the domain you’ll be hosting EF-CMS at. 
+  - These can be found at [AWS Secrets Manager > Secrets](https://console.aws.amazon.com/secretsmanager/home?region=us-east-1#!/listSecrets/) for the Flexion environments.
+    - Examples include exp1_deploy, 
 
 ### 3. Configure the AWS account for hosting EF-CMS.
 
@@ -61,29 +60,28 @@ A prerequisite for a successful build within CircleCI is [access to CircleCI’s
 
   | Environment variable | Description |
   |----------------------|-------------|
-  | `AWS_ACCOUNT_ID` | AWS account ID without hyphens |
-  | `AWS_ACCESS_KEY_ID` | AWS access key for the AWS CircleCI user |
-  | `AWS_SECRET_ACCESS_KEY` | AWS secret access key for the AWS CircleCI user |
-  | `DYNAMSOFT_PRODUCT_KEYS_STG` | Dynamsoft Web TWAIN product key used for STG |
-  | `DYNAMSOFT_PRODUCT_KEYS_TEST` | Dynamsoft Web TWAIN product key used for TEST |
-  | `DYNAMSOFT_PRODUCT_KEYS_PROD` | Dynamsoft Web TWAIN product key used for PROD |
-  | `DYNAMSOFT_S3_ZIP_PATH` | Dynamsoft Web TWAIN full S3 path ZIP configured above, e.g. `s3://bucketname/Dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz` |
-  | `EFCMS_DOMAIN` | Domain name chosen above |
-  | `COGNITO_SUFFIX` | Suffix of your choice for the Cognito URL |
-  | `USTC_ADMIN_USER` | Username of your choice used by the Cognito admin user |
-  | `USTC_ADMIN_PASS` | Password of your choice used by the Cognito admin user |
-  | `EMAIL_DMARC_POLICY` | DMARC policy in the format of `v=DMARC1; p=none; rua=mailto:postmaster@example.com;` |
-  | `IRS_SUPERUSER_EMAIL_STG` | Email address used to serve all new petitions to the IRS for STG |
-  | `IRS_SUPERUSER_EMAIL_TEST` | Email address used to serve all new petitions to the IRS for TEST |
-  | `IRS_SUPERUSER_EMAIL_PROD` | Email address used to serve all new petitions to the IRS for PROD |
-  | `DEFAULT_ACCOUNT_PASS` | Default password for all test accounts and some password resets |
-  | `STATUSPAGE_DNS_RECORD` | DNS record for Statuspage of CNAME `status.${EFCMS_DOMAIN}` (optional) |
-  | `SESSION_MODAL_TIMEOUT` | Time in ms to wait before logging the user out after the idle timeout modal displays (optional, default: `300000` / 5 mins) |
-  | `SESSION_TIMEOUT` | Time in ms to wait displaying the idle timeout modal (optional, default: `3300000` / 55 mins) |
-  | `CLIENT_STAGE` | The `process.env.STAGE` for the React application |
-  | `BOUNCED_EMAIL_RECIPIENT` | An email to which email bounced should be sent (defaults to noreply@`EFCMS_DOMAIN`) |
-  | `PROD_ENV_ACCOUNT_ID` | The account ID of the AWS account with Production Data |
-  | `LOWER_ENV_ACCOUNT_ID` | The account ID of the AWS account where copies of Production Data might live |
+  | `AWS_ACCOUNT_ID`            | AWS account ID without hyphens |
+  | `AWS_ACCESS_KEY_ID`         | AWS access key for the AWS CircleCI user |
+  | `AWS_SECRET_ACCESS_KEY`     | AWS secret access key for the AWS CircleCI user |
+  | `DYNAMSOFT_PRODUCT_KEYS`*   | Dynamsoft Web TWAIN product key used |
+  | `DYNAMSOFT_S3_ZIP_PATH`*    | Dynamsoft Web TWAIN full S3 path ZIP configured above, e.g. `s3://bucketname/Dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz` |
+  | `EFCMS_DOMAIN`*             | Domain name chosen above |
+  | `COGNITO_SUFFIX`*           | Suffix of your choice for the Cognito URL |
+  | `USTC_ADMIN_USER`           | Username of your choice used by the Cognito admin user |
+  | `USTC_ADMIN_PASS`           | Password of your choice used by the Cognito admin user |
+  | `EMAIL_DMARC_POLICY`*       | DMARC policy in the format of `v=DMARC1; p=none; rua=mailto:postmaster@example.com;` |
+  | `IRS_SUPERUSER_EMAIL`*      | Email address used to serve all new petitions to the IRS |
+  | `DEFAULT_ACCOUNT_PASS`      | Default password for all test accounts and some password resets |
+  | `STATUSPAGE_DNS_RECORD`     | DNS record for Statuspage of CNAME `status.${EFCMS_DOMAIN}` (optional) |
+  | `SESSION_MODAL_TIMEOUT`     | Time in ms to wait before logging the user out after the idle timeout modal displays (optional, default: `300000` / 5 mins) |
+  | `SESSION_TIMEOUT`           | Time in ms to wait displaying the idle timeout modal (optional, default: `3300000` / 55 mins) |
+  | `CLIENT_STAGE`              | The `process.env.STAGE` for the React application |
+  | `BOUNCED_EMAIL_RECIPIENT`*  | An email to which email bounced should be sent (defaults to noreply@`EFCMS_DOMAIN`) |
+  | `PROD_ENV_ACCOUNT_ID`       | The account ID of the AWS account with Production Data |
+  | `LOWER_ENV_ACCOUNT_ID`      | The account ID of the AWS account where copies of Production Data might live |
+
+  > **Note:**\
+  `*` - These environment variables are now stored in AWS Secrets Manager and retrieved as part of the deployment 
 
 - Run a build in CircleCI.
   - The build may fail the first time, as provisioning new security certificates can take some time (and cause a timeout). See [the troubleshooting guide](/additional-resources/troubleshooting) for solutions to common problems.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -60,25 +60,25 @@ A prerequisite for a successful build within CircleCI is [access to CircleCI’s
 
   | Environment variable | Description |
   |----------------------|-------------|
-  | `AWS_ACCOUNT_ID`            | AWS account ID without hyphens |
-  | `AWS_ACCESS_KEY_ID`         | AWS access key for the AWS CircleCI user |
-  | `AWS_SECRET_ACCESS_KEY`     | AWS secret access key for the AWS CircleCI user |
-  | `DYNAMSOFT_PRODUCT_KEYS`*   | Dynamsoft Web TWAIN product key used |
-  | `DYNAMSOFT_S3_ZIP_PATH`*    | Dynamsoft Web TWAIN full S3 path ZIP configured above, e.g. `s3://bucketname/Dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz` |
-  | `EFCMS_DOMAIN`*             | Domain name chosen above |
-  | `COGNITO_SUFFIX`*           | Suffix of your choice for the Cognito URL |
-  | `USTC_ADMIN_USER`           | Username of your choice used by the Cognito admin user |
-  | `USTC_ADMIN_PASS`           | Password of your choice used by the Cognito admin user |
-  | `EMAIL_DMARC_POLICY`*       | DMARC policy in the format of `v=DMARC1; p=none; rua=mailto:postmaster@example.com;` |
-  | `IRS_SUPERUSER_EMAIL`*      | Email address used to serve all new petitions to the IRS |
-  | `DEFAULT_ACCOUNT_PASS`      | Default password for all test accounts and some password resets |
-  | `STATUSPAGE_DNS_RECORD`     | DNS record for Statuspage of CNAME `status.${EFCMS_DOMAIN}` (optional) |
-  | `SESSION_MODAL_TIMEOUT`     | Time in ms to wait before logging the user out after the idle timeout modal displays (optional, default: `300000` / 5 mins) |
-  | `SESSION_TIMEOUT`           | Time in ms to wait displaying the idle timeout modal (optional, default: `3300000` / 55 mins) |
-  | `CLIENT_STAGE`              | The `process.env.STAGE` for the React application |
-  | `BOUNCED_EMAIL_RECIPIENT`*  | An email to which email bounced should be sent (defaults to noreply@`EFCMS_DOMAIN`) |
-  | `PROD_ENV_ACCOUNT_ID`       | The account ID of the AWS account with Production Data |
-  | `LOWER_ENV_ACCOUNT_ID`      | The account ID of the AWS account where copies of Production Data might live |
+  | `AWS_ACCOUNT_ID` | AWS account ID without hyphens |
+  | `AWS_ACCESS_KEY_ID` | AWS access key for the AWS CircleCI user |
+  | `AWS_SECRET_ACCESS_KEY` | AWS secret access key for the AWS CircleCI user |
+  | `DYNAMSOFT_PRODUCT_KEYS`* | Dynamsoft Web TWAIN product key used |
+  | `DYNAMSOFT_S3_ZIP_PATH`* | Dynamsoft Web TWAIN full S3 path ZIP configured above, e.g. `s3://bucketname/Dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz` |
+  | `EFCMS_DOMAIN`* | Domain name chosen above |
+  | `COGNITO_SUFFIX`* | Suffix of your choice for the Cognito URL |
+  | `USTC_ADMIN_USER` | Username of your choice used by the Cognito admin user |
+  | `USTC_ADMIN_PASS` | Password of your choice used by the Cognito admin user |
+  | `EMAIL_DMARC_POLICY`* | DMARC policy in the format of `v=DMARC1; p=none; rua=mailto:postmaster@example.com;` |
+  | `IRS_SUPERUSER_EMAIL`* | Email address used to serve all new petitions to the IRS |
+  | `DEFAULT_ACCOUNT_PASS` | Default password for all test accounts and some password resets |
+  | `STATUSPAGE_DNS_RECORD` | DNS record for Statuspage of CNAME `status.${EFCMS_DOMAIN}` (optional) |
+  | `SESSION_MODAL_TIMEOUT` | Time in ms to wait before logging the user out after the idle timeout modal displays (optional, default: `300000` / 5 mins) |
+  | `SESSION_TIMEOUT` | Time in ms to wait displaying the idle timeout modal (optional, default: `3300000` / 55 mins) |
+  | `CLIENT_STAGE` | The `process.env.STAGE` for the React application |
+  | `BOUNCED_EMAIL_RECIPIENT`* | An email to which email bounced should be sent (defaults to noreply@`EFCMS_DOMAIN`) |
+  | `PROD_ENV_ACCOUNT_ID` | The account ID of the AWS account with Production Data |
+  | `LOWER_ENV_ACCOUNT_ID` | The account ID of the AWS account where copies of Production Data might live |
 
   > **Note:**\
   `*` - These environment variables are now stored in AWS Secrets Manager and retrieved as part of the deployment 

--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+REGION=us-east-1
+content=$(aws secretsmanager get-secret-value --region ${REGION} --secret-id "account_deploy" --query "SecretString" --output text)
+echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
+set -o allexport
+source .env
+set +o allexport
+
 if [ -z "$ZONE_NAME" ]; then
   echo "Please export the ZONE_NAME variable in your shell"
   exit 1

--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -158,7 +158,12 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "s3:*",
         "cloudformation:*",
         "cloudwatch:*",
-        "lambda:*"
+        "lambda:*",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:GetResourcePolicy",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetRandomPassword",
+        "secretsmanager:ListSecretVersionIds"
       ],
       "Resource": "*"
     },

--- a/web-api/runtimes/puppeteer/build-local.sh
+++ b/web-api/runtimes/puppeteer/build-local.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker build -t puppeteer -f Dockerfile .
+docker run --name puppeteer puppeteer
+docker cp puppeteer:/home/build/puppeteer_lambda_layer.zip .
+docker rm puppeteer

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -5,11 +5,14 @@ ENVIRONMENT=$1
 export DEPLOYING_COLOR=(sh ./scripts/get-deploying-color.sh ${ENVIRONMENT})
 export MIGRATE_FLAG=(sh ./scripts/get-migrate-flag.sh ${ENVIRONMENT})
 
+set -o allexport
 REGION=us-east-1
 content=$(aws secretsmanager get-secret-value --secret-id "${ENVIRONMENT}_deploy" --query "SecretString" --output text)
 echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
-set -o allexport
 source .env
+BUCKET="${ZONE_NAME}.terraform.deploys"
+KEY="documents-${ENVIRONMENT}.tfstate"
+LOCK_TABLE=efcms-terraform-lock
 set +o allexport
 
 [ -z "${COGNITO_SUFFIX}" ] && echo "You must have COGNITO_SUFFIX set in your environment" && exit 1
@@ -42,10 +45,6 @@ echo "  - PROD_ENV_ACCOUNT_ID=${PROD_ENV_ACCOUNT_ID}"
 echo "  - ZONE_NAME=${ZONE_NAME}"
 
 ../../../scripts/verify-terraform-version.sh
-
-BUCKET="${ZONE_NAME}.terraform.deploys"
-KEY="documents-${ENVIRONMENT}.tfstate"
-LOCK_TABLE=efcms-terraform-lock
 
 rm -rf .terraform
 

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -5,14 +5,11 @@ ENVIRONMENT=$1
 export DEPLOYING_COLOR=(sh ./scripts/get-deploying-color.sh ${ENVIRONMENT})
 export MIGRATE_FLAG=(sh ./scripts/get-migrate-flag.sh ${ENVIRONMENT})
 
-set -o allexport
-REGION=us-east-1
+AWS_DEFAULT_REGION=us-east-1
 content=$(aws secretsmanager get-secret-value --secret-id "${ENVIRONMENT}_deploy" --query "SecretString" --output text)
 echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
+set -o allexport
 source .env
-BUCKET="${ZONE_NAME}.terraform.deploys"
-KEY="documents-${ENVIRONMENT}.tfstate"
-LOCK_TABLE=efcms-terraform-lock
 set +o allexport
 
 [ -z "${COGNITO_SUFFIX}" ] && echo "You must have COGNITO_SUFFIX set in your environment" && exit 1
@@ -45,6 +42,11 @@ echo "  - PROD_ENV_ACCOUNT_ID=${PROD_ENV_ACCOUNT_ID}"
 echo "  - ZONE_NAME=${ZONE_NAME}"
 
 ../../../scripts/verify-terraform-version.sh
+
+BUCKET="${ZONE_NAME}.terraform.deploys"
+KEY="documents-${ENVIRONMENT}.tfstate"
+LOCK_TABLE=efcms-terraform-lock
+REGION=us-east-1
 
 rm -rf .terraform
 

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -45,7 +45,7 @@ echo "  - ZONE_NAME=${ZONE_NAME}"
 BUCKET="${ZONE_NAME}.terraform.deploys"
 KEY="documents-${ENVIRONMENT}.tfstate"
 LOCK_TABLE=efcms-terraform-lock
-REGION=us-east-1
+export REGION=us-east-1
 
 rm -rf .terraform
 

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -5,8 +5,8 @@ ENVIRONMENT=$1
 export DEPLOYING_COLOR=(sh ./scripts/get-deploying-color.sh ${ENVIRONMENT})
 export MIGRATE_FLAG=(sh ./scripts/get-migrate-flag.sh ${ENVIRONMENT})
 
-AWS_DEFAULT_REGION=us-east-1
-content=$(aws secretsmanager get-secret-value --secret-id "${ENVIRONMENT}_deploy" --query "SecretString" --output text)
+REGION=us-east-1
+content=$(aws secretsmanager get-secret-value --region ${REGION} --secret-id "${ENVIRONMENT}_deploy" --query "SecretString" --output text)
 echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
 set -o allexport
 source .env
@@ -46,7 +46,6 @@ echo "  - ZONE_NAME=${ZONE_NAME}"
 BUCKET="${ZONE_NAME}.terraform.deploys"
 KEY="documents-${ENVIRONMENT}.tfstate"
 LOCK_TABLE=efcms-terraform-lock
-REGION=us-east-1
 
 rm -rf .terraform
 

--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -11,7 +11,6 @@ set -o allexport
 source .env
 set +o allexport
 
-#[ -z "${CIRCLE_BRANCH}" ] && echo "You must have CIRCLE_BRANCH set in your environment" && exit 1
 [ -z "${COGNITO_SUFFIX}" ] && echo "You must have COGNITO_SUFFIX set in your environment" && exit 1
 [ -z "${DEPLOYING_COLOR}" ] && echo "You must have DEPLOYING_COLOR set in your environment" && exit 1
 [ -z "${DISABLE_EMAILS}" ] && echo "You must have DISABLE_EMAILS set in your environment" && exit 1

--- a/web-client/terraform/bin/deploy-app.sh
+++ b/web-client/terraform/bin/deploy-app.sh
@@ -2,10 +2,32 @@
 
 ENVIRONMENT=$1
 
+content=$(aws secretsmanager get-secret-value --secret-id "exp2_deploy" --query "SecretString" --output text)
+echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
+set -o allexport
+source .env
+set +o allexport
+
+[ -z "${DYNAMSOFT_PRODUCT_KEYS}" ] && echo "You must have DYNAMSOFT_PRODUCT_KEYS set in your environment" && exit 1
+[ -z "${DYNAMSOFT_S3_ZIP_PATH}" ] && echo "You must have DYNAMSOFT_S3_ZIP_PATH set in your environment" && exit 1
+[ -z "${DYNAMSOFT_URL}" ] && echo "You must have DYNAMSOFT_URL set in your environment" && exit 1
+[ -z "${DYNAMSOFT_URL}" ] && echo "You must have DYNAMSOFT_URL set in your environment" && exit 1
+[ -z "${ENABLE_HEALTH_CHECKS}" ] && echo "You must have ENABLE_HEALTH_CHECKS set in your environment" && exit 1
 [ -z "${ENVIRONMENT}" ] && echo "You must have ENVIRONMENT set in your environment" && exit 1
+[ -z "${EFCMS_DOMAIN}" ] && echo "You must have EFCMS_DOMAIN set in your environment" && exit 1
+[ -z "${IS_DYNAMSOFT_ENABLED}" ] && echo "You must have IS_DYNAMSOFT_ENABLED set in your environment" && exit 1
+[ -z "${ZONE_NAME}" ] && echo "You must have ZONE_NAME set in your environment" && exit 1
 
 echo "Running terraform with the following environment configs:"
+echo "  - DYNAMSOFT_PRODUCT_KEYS=${DYNAMSOFT_PRODUCT_KEYS}"
+echo "  - DYNAMSOFT_S3_ZIP_PATH=${DYNAMSOFT_S3_ZIP_PATH}"
+echo "  - DYNAMSOFT_URL=${DYNAMSOFT_URL}"
+echo "  - DYNAMSOFT_URL=${DYNAMSOFT_URL}"
+echo "  - ENABLE_HEALTH_CHECKS=${ENABLE_HEALTH_CHECKS}"
 echo "  - ENVIRONMENT=${ENVIRONMENT}"
+echo "  - EFCMS_DOMAIN=${EFCMS_DOMAIN}"
+echo "  - IS_DYNAMSOFT_ENABLED=${IS_DYNAMSOFT_ENABLED}"
+echo "  - ZONE_NAME=${ZONE_NAME}"
 
 ../../../scripts/verify-terraform-version.sh
 

--- a/web-client/terraform/bin/deploy-app.sh
+++ b/web-client/terraform/bin/deploy-app.sh
@@ -3,7 +3,7 @@
 ENVIRONMENT=$1
 
 REGION=us-east-1
-content=$(aws secretsmanager get-secret-value --region ${REGION} --secret-id "exp2_deploy" --query "SecretString" --output text)
+content=$(aws secretsmanager get-secret-value --region ${REGION} --secret-id "${ENVIRONMENT}_deploy" --query "SecretString" --output text)
 echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
 set -o allexport
 source .env

--- a/web-client/terraform/bin/deploy-app.sh
+++ b/web-client/terraform/bin/deploy-app.sh
@@ -11,7 +11,6 @@ set +o allexport
 [ -z "${DYNAMSOFT_PRODUCT_KEYS}" ] && echo "You must have DYNAMSOFT_PRODUCT_KEYS set in your environment" && exit 1
 [ -z "${DYNAMSOFT_S3_ZIP_PATH}" ] && echo "You must have DYNAMSOFT_S3_ZIP_PATH set in your environment" && exit 1
 [ -z "${DYNAMSOFT_URL}" ] && echo "You must have DYNAMSOFT_URL set in your environment" && exit 1
-[ -z "${DYNAMSOFT_URL}" ] && echo "You must have DYNAMSOFT_URL set in your environment" && exit 1
 [ -z "${ENABLE_HEALTH_CHECKS}" ] && echo "You must have ENABLE_HEALTH_CHECKS set in your environment" && exit 1
 [ -z "${ENVIRONMENT}" ] && echo "You must have ENVIRONMENT set in your environment" && exit 1
 [ -z "${EFCMS_DOMAIN}" ] && echo "You must have EFCMS_DOMAIN set in your environment" && exit 1
@@ -21,7 +20,6 @@ set +o allexport
 echo "Running terraform with the following environment configs:"
 echo "  - DYNAMSOFT_PRODUCT_KEYS=${DYNAMSOFT_PRODUCT_KEYS}"
 echo "  - DYNAMSOFT_S3_ZIP_PATH=${DYNAMSOFT_S3_ZIP_PATH}"
-echo "  - DYNAMSOFT_URL=${DYNAMSOFT_URL}"
 echo "  - DYNAMSOFT_URL=${DYNAMSOFT_URL}"
 echo "  - ENABLE_HEALTH_CHECKS=${ENABLE_HEALTH_CHECKS}"
 echo "  - ENVIRONMENT=${ENVIRONMENT}"

--- a/web-client/terraform/bin/deploy-app.sh
+++ b/web-client/terraform/bin/deploy-app.sh
@@ -2,7 +2,8 @@
 
 ENVIRONMENT=$1
 
-content=$(aws secretsmanager get-secret-value --secret-id "exp2_deploy" --query "SecretString" --output text)
+REGION=us-east-1
+content=$(aws secretsmanager get-secret-value --region ${REGION} --secret-id "exp2_deploy" --query "SecretString" --output text)
 echo ${content} | jq -r 'to_entries|map("\(.key)=\"\(.value)\"")|.[]' > .env
 set -o allexport
 source .env
@@ -32,7 +33,6 @@ echo "  - ZONE_NAME=${ZONE_NAME}"
 BUCKET="${ZONE_NAME}.terraform.deploys"
 KEY="ui-${ENVIRONMENT}.tfstate"
 LOCK_TABLE=efcms-terraform-lock
-REGION=us-east-1
 
 rm -rf .terraform
 


### PR DESCRIPTION
Grabs deployment-related environment variables from AWS Secrets Manager during `deploy-app.sh` for web-api, web-client, and environment-specific deployments. This makes it easy to deploy a portion of the app from the local machine without the risk of accidentally provisioning too many resources, for example two or more ES instances for environments where more than one is not needed. Examples shown below, but may be accessed [via AWS console](https://console.aws.amazon.com/secretsmanager/home?region=us-east-1#!/listSecrets/).

**exp2_deploy:**
```json
{
  "EFCMS_DOMAIN": "exp2.ustc-case-mgmt.flexion.us",
  "ZONE_NAME": "ustc-case-mgmt.flexion.us",
  "ENVIRONMENT": "exp2",
  "DYNAMSOFT_PRODUCT_KEYS": "noop",
  "DYNAMSOFT_S3_ZIP_PATH": "s3://ustc-case-mgmt.flexion.us-dynamsoft/dynamic-web-twain-sdk-14.3.1.tar.gz",
  "DYNAMSOFT_URL": "https://dynamsoft-lib-dev.ustc-case-mgmt.flexion.us",
  "IS_DYNAMSOFT_ENABLED": 0,
  "ENABLE_HEALTH_CHECKS": 0,
  "BOUNCED_EMAIL_RECIPIENT": "",
  "COGNITO_SUFFIX": "flexion-efcms",
  "DISABLE_EMAILS": true,
  "EMAIL_DMARC_POLICY": "v=DMARC1; p=none; rua=mailto:flexionustc@gmail.com;",
  "ES_INSTANCE_COUNT": 1,
  "ES_INSTANCE_TYPE": "t2.small.elasticsearch",
  "ES_VOLUME_SIZE": 10,
  "IRS_SUPERUSER_EMAIL": "flexionustc+irsSuperUser@gmail.com"
}
```

**account_deploy:**
```json
{
  "ZONE_NAME": "ustc-case-mgmt.flexion.us",
  "ES_LOGS_INSTANCE_COUNT": 1,
  "ES_LOGS_INSTANCE_TYPE": "t2.medium.elasticsearch",
  "ES_LOGS_EBS_VOLUME_SIZE_GB": 20,
  "COGNITO_SUFFIX": "flexion-efcms"
}
```

**When this goes to the court environments, secrets will need to have been created, and the IAM roles updated to grant CircleCI access to the secrets.**