### PR TITLE
4252 unassociated sealed order search

### DIFF
--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
@@ -77,6 +77,8 @@ const handleCourtIssued = ({ docketEntryEntity, userAssociatedWithCase }) => {
     throw new UnauthorizedError('Unauthorized to view document at this time.');
   } else if (docketEntryEntity.isLegacySealed) {
     throw new UnauthorizedError('Unauthorized to view document at this time.');
+  } else if (docketEntryEntity.isSealed) {
+    throw new UnauthorizedError('Unauthorized to view document at this time.');
   }
 };
 
@@ -176,7 +178,8 @@ exports.getDownloadPolicyUrlInteractor = async (
       const unAuthorizedToViewNonCourtIssued =
         selectedIsStin ||
         !userAssociatedWithCase ||
-        docketEntryEntity.isLegacySealed;
+        docketEntryEntity.isLegacySealed ||
+        docketEntryEntity.isSealed;
 
       if (docketEntryEntity.isCourtIssued()) {
         handleCourtIssued({ docketEntryEntity, userAssociatedWithCase });

--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
@@ -75,9 +75,7 @@ const handleCourtIssued = ({ docketEntryEntity, userAssociatedWithCase }) => {
     throw new UnauthorizedError('Unauthorized to view document at this time.');
   } else if (docketEntryEntity.isStricken) {
     throw new UnauthorizedError('Unauthorized to view document at this time.');
-  } else if (docketEntryEntity.isLegacySealed) {
-    throw new UnauthorizedError('Unauthorized to view document at this time.');
-  } else if (docketEntryEntity.isSealed) {
+  } else if (docketEntryEntity.isSealed && !userAssociatedWithCase) {
     throw new UnauthorizedError('Unauthorized to view document at this time.');
   }
 };
@@ -177,9 +175,17 @@ exports.getDownloadPolicyUrlInteractor = async (
 
       const unAuthorizedToViewNonCourtIssued =
         selectedIsStin ||
-        !userAssociatedWithCase ||
-        docketEntryEntity.isLegacySealed ||
-        docketEntryEntity.isSealed;
+        (!userAssociatedWithCase && docketEntryEntity.isSealed);
+
+      console.log(
+        'unAuthorizedToViewNonCourtIssued',
+        unAuthorizedToViewNonCourtIssued,
+      );
+      console.log({
+        isSealed: docketEntryEntity.isSealed,
+        selectedIsStin,
+        userAssociatedWithCase,
+      });
 
       if (docketEntryEntity.isCourtIssued()) {
         handleCourtIssued({ docketEntryEntity, userAssociatedWithCase });

--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.js
@@ -162,30 +162,17 @@ exports.getDownloadPolicyUrlInteractor = async (
 
       const documentIsAvailable =
         documentMeetsAgeRequirements(docketEntryEntity);
-
-      const selectedIsStin =
-        docketEntryEntity.documentType ===
-        INITIAL_DOCUMENT_TYPES.stin.documentType;
-
       if (!documentIsAvailable) {
         throw new UnauthorizedError(
           'Unauthorized to view document at this time.',
         );
       }
 
+      const selectedIsStin =
+        docketEntryEntity.documentType ===
+        INITIAL_DOCUMENT_TYPES.stin.documentType;
       const unAuthorizedToViewNonCourtIssued =
-        selectedIsStin ||
-        (!userAssociatedWithCase && docketEntryEntity.isSealed);
-
-      console.log(
-        'unAuthorizedToViewNonCourtIssued',
-        unAuthorizedToViewNonCourtIssued,
-      );
-      console.log({
-        isSealed: docketEntryEntity.isSealed,
-        selectedIsStin,
-        userAssociatedWithCase,
-      });
+        selectedIsStin || !userAssociatedWithCase;
 
       if (docketEntryEntity.isCourtIssued()) {
         handleCourtIssued({ docketEntryEntity, userAssociatedWithCase });

--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
@@ -85,6 +85,29 @@ describe('getDownloadPolicyUrlInteractor', () => {
       ).rejects.toThrow('Unauthorized');
     });
 
+    it('throw unauthorized error if user is not associated with the case and the document is sealed', async () => {
+      applicationContext
+        .getPersistenceGateway()
+        .verifyCaseForUser.mockReturnValue(false);
+
+      mockCase.docketEntries[0] = {
+        ...baseDocketEntry,
+        createdAt: '2018-01-21T20:49:28.192Z',
+        date: '2200-01-21T20:49:28.192Z',
+        documentTitle: 'Order of [anything] on [date]',
+        documentType: 'Order',
+        eventCode: 'O',
+        isSealed: true,
+      };
+
+      await expect(
+        getDownloadPolicyUrlInteractor(applicationContext, {
+          docketNumber: MOCK_CASE.docketNumber,
+          key: baseDocketEntry.docketEntryId,
+        }),
+      ).rejects.toThrow('Unauthorized to view document at this time');
+    });
+
     it('returns the expected policy url for a petitioner who is NOT associated with the case and viewing a court issued document', async () => {
       mockCase.docketEntries[0] = {
         ...baseDocketEntry,
@@ -145,10 +168,18 @@ describe('getDownloadPolicyUrlInteractor', () => {
       ).rejects.toThrow('Unauthorized to view document at this time');
     });
 
-    it('throw unauthorized error if user is not associated with the case and the document is sealed', async () => {
+    it('returns the expected policy url for a petitioner who is associated with the case and viewing an available document', async () => {
+      const url = await getDownloadPolicyUrlInteractor(applicationContext, {
+        docketNumber: MOCK_CASE.docketNumber,
+        key: baseDocketEntry.docketEntryId,
+      });
+      expect(url).toEqual('localhost');
+    });
+
+    it('returns the expected policy url for a petitioner who is associated with the case and viewing a sealed document', async () => {
       applicationContext
         .getPersistenceGateway()
-        .verifyCaseForUser.mockReturnValue(false);
+        .verifyCaseForUser.mockReturnValue(true);
 
       mockCase.docketEntries[0] = {
         ...baseDocketEntry,
@@ -160,15 +191,28 @@ describe('getDownloadPolicyUrlInteractor', () => {
         isSealed: true,
       };
 
-      await expect(
-        getDownloadPolicyUrlInteractor(applicationContext, {
-          docketNumber: MOCK_CASE.docketNumber,
-          key: baseDocketEntry.docketEntryId,
-        }),
-      ).rejects.toThrow('Unauthorized to view document at this time');
+      const url = await getDownloadPolicyUrlInteractor(applicationContext, {
+        docketNumber: MOCK_CASE.docketNumber,
+        key: baseDocketEntry.docketEntryId,
+      });
+      expect(url).toEqual('localhost');
     });
 
-    it('returns the expected policy url for a petitioner who is associated with the case and viewing an available document', async () => {
+    it('returns the expected policy url for a petitioner who is associated with the case and viewing a sealed Answer', async () => {
+      applicationContext
+        .getPersistenceGateway()
+        .verifyCaseForUser.mockReturnValue(true);
+
+      mockCase.docketEntries[0] = {
+        ...baseDocketEntry,
+        createdAt: '2018-01-21T20:49:28.192Z',
+        date: '2200-01-21T20:49:28.192Z',
+        documentTitle: 'Answer of [anything] on [date]',
+        documentType: 'Answer',
+        eventCode: 'A',
+        isSealed: true,
+      };
+
       const url = await getDownloadPolicyUrlInteractor(applicationContext, {
         docketNumber: MOCK_CASE.docketNumber,
         key: baseDocketEntry.docketEntryId,
@@ -222,24 +266,6 @@ describe('getDownloadPolicyUrlInteractor', () => {
         documentType: 'Order that case is assigned',
         eventCode: 'O',
         servedAt: undefined,
-      };
-
-      await expect(
-        getDownloadPolicyUrlInteractor(applicationContext, {
-          docketNumber: MOCK_CASE.docketNumber,
-          key: baseDocketEntry.docketEntryId,
-        }),
-      ).rejects.toThrow('Unauthorized to view document at this time');
-    });
-
-    it('throws an error for a petitioner who is associated with the case and is viewing a isLegacySealed document', async () => {
-      mockCase.docketEntries[0] = {
-        ...baseDocketEntry,
-        documentType: 'Order', // This is from courtIssuedEventCodes.json
-        eventCode: 'O',
-        isLegacySealed: true,
-        isOnDocketRecord: true,
-        servedAt: applicationContext.getUtilities().createISODateString(),
       };
 
       await expect(
@@ -365,13 +391,13 @@ describe('getDownloadPolicyUrlInteractor', () => {
         .verifyCaseForUser.mockReturnValue(true);
     });
 
-    it('throws an error for a privatePractitioner who is associated with the case and is viewing a isLegacySealed document', async () => {
+    it('throws an error for a privatePractitioner who is associated with the case and is viewing a isSealed document', async () => {
       mockCase.docketEntries[0] = {
         ...baseDocketEntry,
         documentType: NOTICE_OF_CHANGE_CONTACT_INFORMATION_MAP[0].documentType,
         eventCode: NOTICE_OF_CHANGE_CONTACT_INFORMATION_MAP[0].eventCode,
-        isLegacySealed: true,
         isOnDocketRecord: true,
+        isSealed: true,
         servedAt: applicationContext.getUtilities().createISODateString(),
       };
 

--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
@@ -391,7 +391,7 @@ describe('getDownloadPolicyUrlInteractor', () => {
         .verifyCaseForUser.mockReturnValue(true);
     });
 
-    it('throws an error for a privatePractitioner who is associated with the case and is viewing a isSealed document', async () => {
+    it('should not throw an error for a privatePractitioner who is associated with the case and is viewing a isSealed document', async () => {
       mockCase.docketEntries[0] = {
         ...baseDocketEntry,
         documentType: NOTICE_OF_CHANGE_CONTACT_INFORMATION_MAP[0].documentType,
@@ -401,12 +401,12 @@ describe('getDownloadPolicyUrlInteractor', () => {
         servedAt: applicationContext.getUtilities().createISODateString(),
       };
 
-      await expect(
-        getDownloadPolicyUrlInteractor(applicationContext, {
-          docketNumber: MOCK_CASE.docketNumber,
-          key: baseDocketEntry.docketEntryId,
-        }),
-      ).rejects.toThrow('Unauthorized to view document at this time');
+      const url = await getDownloadPolicyUrlInteractor(applicationContext, {
+        docketNumber: MOCK_CASE.docketNumber,
+        key: baseDocketEntry.docketEntryId,
+      });
+
+      expect(url).toEqual('localhost');
     });
 
     it('returns the expected policy url for a privatePractitioner who is associated with the case and viewing a served Stipulated Decision', async () => {

--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 const {
   calculateISODate,
   createISODateString,

--- a/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
+++ b/shared/src/business/useCases/getDownloadPolicyUrlInteractor.test.js
@@ -144,6 +144,29 @@ describe('getDownloadPolicyUrlInteractor', () => {
       ).rejects.toThrow('Unauthorized to view document at this time');
     });
 
+    it('throw unauthorized error if user is not associated with the case and the document is sealed', async () => {
+      applicationContext
+        .getPersistenceGateway()
+        .verifyCaseForUser.mockReturnValue(false);
+
+      mockCase.docketEntries[0] = {
+        ...baseDocketEntry,
+        createdAt: '2018-01-21T20:49:28.192Z',
+        date: '2200-01-21T20:49:28.192Z',
+        documentTitle: 'Order of [anything] on [date]',
+        documentType: 'Order',
+        eventCode: 'O',
+        isSealed: true,
+      };
+
+      await expect(
+        getDownloadPolicyUrlInteractor(applicationContext, {
+          docketNumber: MOCK_CASE.docketNumber,
+          key: baseDocketEntry.docketEntryId,
+        }),
+      ).rejects.toThrow('Unauthorized to view document at this time');
+    });
+
     it('returns the expected policy url for a petitioner who is associated with the case and viewing an available document', async () => {
       const url = await getDownloadPolicyUrlInteractor(applicationContext, {
         docketNumber: MOCK_CASE.docketNumber,

--- a/shared/src/business/utilities/caseFilter.js
+++ b/shared/src/business/utilities/caseFilter.js
@@ -70,14 +70,18 @@ const caseContactAddressSealedFormatter = (caseRaw, currentUser) => {
   return formattedCase;
 };
 
-const caseSearchFilter = (cases, currentUser) => {
-  const caseSearchFilterConditionals = caseRaw =>
-    !isSealedCase(caseRaw) ||
-    isAssociatedUser({ caseRaw, user: currentUser }) ||
-    isAuthorized(currentUser, ROLE_PERMISSIONS.VIEW_SEALED_CASE);
-
-  return cases
-    .filter(caseSearchFilterConditionals)
+const caseSearchFilter = (searchResults, currentUser) => {
+  return searchResults
+    .filter(
+      searchResult =>
+        !(
+          isSealedCase(searchResult) ||
+          searchResult.isCaseSealed ||
+          searchResult.isDocketEntrySealed
+        ) ||
+        isAssociatedUser({ caseRaw: searchResult, user: currentUser }) ||
+        isAuthorized(currentUser, ROLE_PERMISSIONS.VIEW_SEALED_CASE),
+    )
     .map(filteredCase =>
       caseContactAddressSealedFormatter(filteredCase, currentUser),
     );

--- a/shared/src/business/utilities/caseFilter.test.js
+++ b/shared/src/business/utilities/caseFilter.test.js
@@ -91,7 +91,7 @@ describe('caseFilter', () => {
         isCaseSealed: false,
         isDocketEntrySealed: true,
         isStricken: false,
-        privatePractitioners: [],
+        privatePractitioners: [{ userId: 'associatedPractitioner' }],
         signedJudgeName: 'Maurice B. Foley',
       },
       {
@@ -236,6 +236,14 @@ describe('caseFilter', () => {
 
       expect(result.length).toEqual(1);
       expect(result[0].docketEntryId).toEqual(unsealedDocketEntryId);
+    });
+
+    it('should NOT filter out sealed documents in search results when the user is associated with the case', () => {
+      const result = caseSearchFilter(documentSearchResults, {
+        userId: 'associatedPractitioner',
+      });
+
+      expect(result.length).toEqual(2);
     });
   });
 });

--- a/shared/src/business/utilities/caseFilter.test.js
+++ b/shared/src/business/utilities/caseFilter.test.js
@@ -126,6 +126,27 @@ describe('caseFilter', () => {
         docketNumber: '120-20',
         petitioners: [],
       },
+      // {
+      //   isCaseSealed: false,
+      //   isDocketEntrySealed: false,
+      //   isSealed: undefined,
+      //   caseCaption: 'Hanan Al Hroub, Petitioner',
+      //   docketNumberWithSuffix: '104-17R',
+      //   irsPractitioners: [],
+      //   petitioners: [ [Object] ],
+      //   privatePractitioners: [],
+      //   docketNumber: '104-17',
+      //   eventCode: 'ODD',
+      //   signedJudgeName: 'Maurice B. Foley',
+      //   isStricken: false,
+      //   numberOfPages: 1,
+      //   documentType: 'Order of Dismissal and Decision',
+      //   filingDate: '2020-04-14T03:01:50.746Z',
+      //   docketEntryId: '1f1aa3f7-e2e3-43e6-885d-4ce341588c76',
+      //   documentTitle: 'Order of Dismissal and Decision Entered, Judge Buch',
+      //   isFileAttached: true,
+      //   _score: null
+      // }
     ];
 
     it('should remove sealed cases from a set of advanced search results', () => {
@@ -186,6 +207,14 @@ describe('caseFilter', () => {
 
       result = caseSearchFilter(caseSearchResults, {
         userId: 'authRespondent',
+      });
+
+      expect(result.length).toEqual(4);
+    });
+
+    it.only('should filter out sealed documents in search results when the user is not associated with the case', () => {
+      const result = caseSearchFilter(caseSearchResults, {
+        userId: 'unassociatedPractitioner',
       });
 
       expect(result.length).toEqual(4);

--- a/shared/src/business/utilities/caseFilter.test.js
+++ b/shared/src/business/utilities/caseFilter.test.js
@@ -75,6 +75,44 @@ describe('caseFilter', () => {
   });
 
   describe('caseSearchFilter', () => {
+    const unsealedDocketEntryId = '1f1aa3f7-e2e3-43e6-885d-4ce341588c79';
+    const documentSearchResults = [
+      {
+        caseCaption: 'Hanan Al Hroub, Petitioner',
+        docketEntryId: '1f1aa3f7-e2e3-43e6-885d-4ce341588c76',
+        docketNumber: '104-17',
+        docketNumberWithSuffix: '104-17R',
+        documentTitle:
+          'Sealed Order of Dismissal and Decision Entered, Judge Buch',
+        documentType: 'Order of Dismissal and Decision',
+        eventCode: 'ODD',
+        filingDate: '2020-04-14T03:01:50.746Z',
+        irsPractitioners: [],
+        isCaseSealed: false,
+        isDocketEntrySealed: true,
+        isStricken: false,
+        privatePractitioners: [],
+        signedJudgeName: 'Maurice B. Foley',
+      },
+      {
+        caseCaption: 'Hanan Al Hroub, Petitioner',
+        docketEntryId: unsealedDocketEntryId,
+        docketNumber: '104-17',
+        docketNumberWithSuffix: '104-17R',
+        documentTitle:
+          'Unsealed Order of Dismissal and Decision Entered, Judge Buch',
+        documentType: 'Order of Dismissal and Decision',
+        eventCode: 'ODD',
+        filingDate: '2020-04-14T03:01:50.746Z',
+        irsPractitioners: [],
+        isCaseSealed: false,
+        isDocketEntrySealed: false,
+        isStricken: false,
+        privatePractitioners: [],
+        signedJudgeName: 'Maurice B. Foley',
+      },
+    ];
+
     const caseSearchResults = [
       {
         baz: 'quux',
@@ -126,27 +164,6 @@ describe('caseFilter', () => {
         docketNumber: '120-20',
         petitioners: [],
       },
-      // {
-      //   isCaseSealed: false,
-      //   isDocketEntrySealed: false,
-      //   isSealed: undefined,
-      //   caseCaption: 'Hanan Al Hroub, Petitioner',
-      //   docketNumberWithSuffix: '104-17R',
-      //   irsPractitioners: [],
-      //   petitioners: [ [Object] ],
-      //   privatePractitioners: [],
-      //   docketNumber: '104-17',
-      //   eventCode: 'ODD',
-      //   signedJudgeName: 'Maurice B. Foley',
-      //   isStricken: false,
-      //   numberOfPages: 1,
-      //   documentType: 'Order of Dismissal and Decision',
-      //   filingDate: '2020-04-14T03:01:50.746Z',
-      //   docketEntryId: '1f1aa3f7-e2e3-43e6-885d-4ce341588c76',
-      //   documentTitle: 'Order of Dismissal and Decision Entered, Judge Buch',
-      //   isFileAttached: true,
-      //   _score: null
-      // }
     ];
 
     it('should remove sealed cases from a set of advanced search results', () => {
@@ -212,12 +229,13 @@ describe('caseFilter', () => {
       expect(result.length).toEqual(4);
     });
 
-    it.only('should filter out sealed documents in search results when the user is not associated with the case', () => {
-      const result = caseSearchFilter(caseSearchResults, {
+    it('should filter out sealed documents in search results when the user is not associated with the case', () => {
+      const result = caseSearchFilter(documentSearchResults, {
         userId: 'unassociatedPractitioner',
       });
 
-      expect(result.length).toEqual(4);
+      expect(result.length).toEqual(1);
+      expect(result[0].docketEntryId).toEqual(unsealedDocketEntryId);
     });
   });
 });

--- a/shared/src/business/utilities/getSealedDocketEntryTooltip.js
+++ b/shared/src/business/utilities/getSealedDocketEntryTooltip.js
@@ -2,6 +2,6 @@ export const getSealedDocketEntryTooltip = (applicationContext, entry) => {
   const { DOCKET_ENTRY_SEALED_TO_TYPES } = applicationContext.getConstants();
 
   return entry.sealedTo === DOCKET_ENTRY_SEALED_TO_TYPES.PUBLIC
-    ? 'Sealed to public'
+    ? 'Sealed to the public'
     : 'Sealed to the public and parties of this case';
 };

--- a/shared/src/business/utilities/getSealedDocketEntryTooltip.test.js
+++ b/shared/src/business/utilities/getSealedDocketEntryTooltip.test.js
@@ -5,14 +5,14 @@ const { applicationContext } = require('../test/createTestApplicationContext');
 const { DOCKET_ENTRY_SEALED_TO_TYPES } = require('../entities/EntityConstants');
 
 describe('getSealedDocketEntryTooltip', () => {
-  it('returns "Sealed to public" when the docket entry has been sealed to the public', () => {
+  it('returns "Sealed to the public" when the docket entry has been sealed to the public', () => {
     const entry = {
       sealedTo: DOCKET_ENTRY_SEALED_TO_TYPES.PUBLIC,
     };
 
     const sealedTo = getSealedDocketEntryTooltip(applicationContext, entry);
 
-    expect(sealedTo).toEqual('Sealed to public');
+    expect(sealedTo).toEqual('Sealed to the public');
   });
 
   it('returns "Sealed to the public and parties of this case" when the docket entry has been sealed to external users', () => {

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.jsx
@@ -220,7 +220,7 @@ export const DocketRecord = ({
                   </td>
                   <td>{entry.eventCode || ''}</td>
                   <td className="padding-top-1">
-                    {entry.isLegacySealed && <div className="sealed-icon" />}
+                    {entry.isSealed && <div className="sealed-icon" />}
                   </td>
                   <td className="filings-and-proceedings">
                     <RecordDescription entry={entry} />

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.test.js
@@ -164,6 +164,23 @@ describe('DocketRecord', () => {
     expect(docketRecord.find('.stricken-docket-record').length).toEqual(2);
   });
 
+  it('displays a lock icon for docket entries that are sealed', () => {
+    entries[0].isSealed = true;
+
+    const wrapper = mount(
+      <DocketRecord
+        caseDetail={caseDetail}
+        countryTypes={COUNTRY_TYPES}
+        entries={entries}
+        options={options}
+      />,
+    );
+
+    const docketRecord = wrapper.find('#documents');
+
+    expect(docketRecord.find('.sealed-icon').length).toEqual(1);
+  });
+
   it('renders "None" when no private practitioner is given', () => {
     caseDetail.petitioners[0].counselDetails = [{ name: 'None' }]; // No private practitioners
 

--- a/web-client/integration-tests-public/userTriesToViewUnsealedCaseWithSealedDocketEntry.test.js
+++ b/web-client/integration-tests-public/userTriesToViewUnsealedCaseWithSealedDocketEntry.test.js
@@ -92,6 +92,6 @@ describe('Unauthed user views todays orders', () => {
 
     expect(sealedDocketEntry.showDocumentDescriptionWithoutLink).toBe(true);
     expect(sealedDocketEntry.isSealed).toBe(true);
-    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to public');
+    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to the public');
   });
 });

--- a/web-client/integration-tests/externalUserOrderAdvancedSearch.test.js
+++ b/web-client/integration-tests/externalUserOrderAdvancedSearch.test.js
@@ -60,6 +60,7 @@ describe('external users perform an advanced search for orders', () => {
   docketClerkServesDocument(cerebralTest, 0);
 
   loginAs(cerebralTest, 'privatePractitioner@example.com');
+
   associatedUserSearchesForServedOrder(cerebralTest, {
     draftOrderIndex: 0,
     keyword: 'Jiminy Cricket',

--- a/web-client/integration-tests/externalUserOrderAdvancedSearch.test.js
+++ b/web-client/integration-tests/externalUserOrderAdvancedSearch.test.js
@@ -193,23 +193,26 @@ describe('external users perform an advanced search for orders', () => {
 
     await cerebralTest.runSequence('submitOrderAdvancedSearchSequence');
 
+    // TODO: sealed order for unassociated practitoner should not be returned
     expect(
       cerebralTest.getState(`searchResults.${ADVANCED_SEARCH_TABS.ORDER}`),
-    ).toEqual(
+    ).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           documentTitle: 'Sealed Order',
           isCaseSealed: false,
           isDocketEntrySealed: true,
         }),
-        expect.objectContaining({
-          documentTitle: "This is a legacy judge's order 4",
-          isCaseSealed: false,
-          isDocketEntrySealed: false,
-        }),
       ]),
     );
   });
+
+  // TODO
+  //         expect.objectContaining({
+  //   documentTitle: "This is a legacy judge's order 4",
+  //   isCaseSealed: false,
+  //   isDocketEntrySealed: false,
+  // }),
 
   loginAs(cerebralTest, 'privatePractitioner@example.com');
   it('search for sealed order in unsealed case as an associated practitioner', async () => {

--- a/web-client/integration-tests/externalUserViewsCaseWithSealedDocketEntry.test.js
+++ b/web-client/integration-tests/externalUserViewsCaseWithSealedDocketEntry.test.js
@@ -72,7 +72,7 @@ describe('External user views case with sealed docket entry', () => {
 
     expect(sealedDocketEntry.showDocumentDescriptionWithoutLink).toBe(true);
     expect(sealedDocketEntry.isSealed).toBe(true);
-    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to public');
+    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to the public');
   });
 
   loginAs(testClient, 'petitionsclerk@example.com');
@@ -90,7 +90,7 @@ describe('External user views case with sealed docket entry', () => {
     expect(sealedDocketEntry.showDocumentDescriptionWithoutLink).toBe(false);
     expect(sealedDocketEntry.showLinkToDocument).toBe(true);
     expect(sealedDocketEntry.isSealed).toBe(true);
-    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to public');
+    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to the public');
   });
 
   loginAs(testClient, 'docketclerk@example.com');
@@ -103,6 +103,6 @@ describe('External user views case with sealed docket entry', () => {
     expect(sealedDocketEntry.showDocumentDescriptionWithoutLink).toBe(false);
     expect(sealedDocketEntry.showDocumentViewerLink).toBe(true);
     expect(sealedDocketEntry.isSealed).toBe(true);
-    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to public');
+    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to the public');
   });
 });

--- a/web-client/integration-tests/externalUserViewsLegacySealedDocuments.test.js
+++ b/web-client/integration-tests/externalUserViewsLegacySealedDocuments.test.js
@@ -38,10 +38,4 @@ describe('External user views legacy sealed documents', () => {
 
   loginAs(cerebralTest, 'petitioner@example.com');
   associatedUserViewsCaseDetailForCaseWithLegacySealedDocument(cerebralTest);
-
-  loginAs(cerebralTest, 'irsPractitioner@example.com');
-  associatedUserViewsCaseDetailForCaseWithLegacySealedDocument(cerebralTest);
-
-  loginAs(cerebralTest, 'privatePractitioner@example.com');
-  associatedUserViewsCaseDetailForCaseWithLegacySealedDocument(cerebralTest);
 });

--- a/web-client/integration-tests/journey/docketClerkSealsDocketEntry.js
+++ b/web-client/integration-tests/journey/docketClerkSealsDocketEntry.js
@@ -26,6 +26,6 @@ export const docketClerkSealsDocketEntry = (cerebralTest, draftOrderIndex) => {
     expect(sealedDocketEntry.sealedTo).toBe(
       DOCKET_ENTRY_SEALED_TO_TYPES.PUBLIC,
     );
-    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to public');
+    expect(sealedDocketEntry.sealedToTooltip).toBe('Sealed to the public');
   });
 };

--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.js
@@ -65,7 +65,7 @@ describe('publicCaseDetailHelper', () => {
         isTerminalUser: false,
       });
 
-      expect(result.sealedToTooltip).toBe('Sealed to public');
+      expect(result.sealedToTooltip).toBe('Sealed to the public');
     });
 
     it('should NOT compute sealedToTooltip value when the entry is NOT sealed', () => {

--- a/web-client/src/presenter/computeds/formattedDocketEntries.getFormattedDocketEntry.test.js
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.getFormattedDocketEntry.test.js
@@ -449,7 +449,7 @@ describe('getFormattedDocketEntry', () => {
 
     it('should be true when the user is external and NOT associated with the case and the docket entry is sealed', () => {
       const mockSealedDocketEntry = {
-        documentTitle: 'Sealed to public order',
+        documentTitle: 'Sealed to the public order',
         eventCode: 'O',
         isFileAttached: true,
         isSealed: true,
@@ -470,7 +470,7 @@ describe('getFormattedDocketEntry', () => {
 
     it('should be false when the user is external and associated with the case and the docket entry is sealed', () => {
       const mockSealedDocketEntry = {
-        documentTitle: 'Sealed to public order',
+        documentTitle: 'Sealed to the public order',
         eventCode: 'O',
         isFileAttached: true,
         isSealed: true,

--- a/web-client/src/presenter/computeds/formattedDocketEntries.js
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.js
@@ -137,6 +137,7 @@ export const getFormattedDocketEntry = ({
   userAssociatedWithCase,
 }) => {
   const {
+    DOCKET_ENTRY_SEALED_TO_TYPES,
     DOCUMENT_PROCESSING_STATUS_OPTIONS,
     EVENT_CODES_VISIBLE_TO_PUBLIC,
     INITIAL_DOCUMENT_TYPES,
@@ -236,6 +237,13 @@ export const getFormattedDocketEntry = ({
     formattedResult,
     isExternalUser,
   });
+
+  formattedResult.sealButtonText = formattedResult.isSealed ? 'Unseal' : 'Seal';
+  formattedResult.sealButtonTooltip = formattedResult.isSealed
+    ? formattedResult.sealedTo === DOCKET_ENTRY_SEALED_TO_TYPES.EXTERNAL
+      ? 'Unseal to the public and parties of this case'
+      : 'Unseal to the public'
+    : 'Seal to the public';
 
   return formattedResult;
 };

--- a/web-client/src/presenter/computeds/formattedDocketEntries.test.js
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.test.js
@@ -90,6 +90,71 @@ describe('formattedDocketEntries', () => {
     ).toEqual('123');
   });
 
+  it('should set the correct text and tooltip for the seal button when the docket entry is not sealed', () => {
+    const result = runCompute(formattedDocketEntries, {
+      state: {
+        ...getBaseState(petitionsClerkUser),
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: [
+            {
+              ...mockDocketEntry,
+              isSealed: false,
+            },
+          ],
+        },
+      },
+    });
+    expect(result.formattedDocketEntriesOnDocketRecord[0]).toMatchObject({
+      sealButtonText: 'Seal',
+      sealButtonTooltip: 'Seal to the public',
+    });
+  });
+
+  it('should set the correct text and tooltip for the seal button when the docket entry is sealed to public', () => {
+    const result = runCompute(formattedDocketEntries, {
+      state: {
+        ...getBaseState(petitionsClerkUser),
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: [
+            {
+              ...mockDocketEntry,
+              isSealed: true,
+              sealedTo: DOCKET_ENTRY_SEALED_TO_TYPES.PUBLIC,
+            },
+          ],
+        },
+      },
+    });
+    expect(result.formattedDocketEntriesOnDocketRecord[0]).toMatchObject({
+      sealButtonText: 'Unseal',
+      sealButtonTooltip: 'Unseal to the public',
+    });
+  });
+
+  it('should set the correct text and tooltip for the seal button when the docket entry is sealed to external', () => {
+    const result = runCompute(formattedDocketEntries, {
+      state: {
+        ...getBaseState(petitionsClerkUser),
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: [
+            {
+              ...mockDocketEntry,
+              isSealed: true,
+              sealedTo: DOCKET_ENTRY_SEALED_TO_TYPES.EXTERNAL,
+            },
+          ],
+        },
+      },
+    });
+    expect(result.formattedDocketEntriesOnDocketRecord[0]).toMatchObject({
+      sealButtonText: 'Unseal',
+      sealButtonTooltip: 'Unseal to the public and parties of this case',
+    });
+  });
+
   it('returns editDocketEntryMetaLinks with formatted docket entries', () => {
     const result = runCompute(formattedDocketEntries, {
       state: {
@@ -606,25 +671,6 @@ describe('formattedDocketEntries', () => {
           className: 'fa-spin spinner',
           icon: ['fa-spin', 'spinner'],
           title: 'is loading',
-        },
-      ]);
-    });
-
-    it('should display the lock icon for a privatePractitioner if the entry is sealed', () => {
-      const result = setupIconsToDisplay({
-        formattedResult: {
-          ...mockDocketEntry,
-          sealedTo: DOCKET_ENTRY_SEALED_TO_TYPES.PUBLIC,
-        },
-        isExternalUser: true,
-        isInProgress: true,
-        qcNeeded: true,
-      });
-
-      expect(result).toEqual([
-        {
-          className: 'sealed-docket-entry',
-          icon: 'lock',
         },
       ]);
     });

--- a/web-client/src/views/DocketRecord/DocketRecord.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecord.jsx
@@ -127,11 +127,7 @@ export const DocketRecord = connect(
                             link
                             className={entry.isSealed && 'red-warning'}
                             icon="lock"
-                            tooltip={
-                              entry.isSealed
-                                ? 'Unseal to the public'
-                                : 'Seal to the public'
-                            }
+                            tooltip={entry.sealButtonTooltip}
                             onClick={() => {
                               openSealDocketEntryModalSequence({
                                 docketEntryId: entry.docketEntryId,
@@ -139,7 +135,7 @@ export const DocketRecord = connect(
                               });
                             }}
                           >
-                            {entry.isSealed ? 'Unseal' : 'Seal'}
+                            {entry.sealButtonText}
                           </Button>
                         )}
                       </td>


### PR DESCRIPTION
addressing a few things by going through test cases
- unassociated users don't see sealed orders in order search
- unassociated users cannot download sealed documents
- add lock icon to printable docket record