### PR TITLE
Devex 859: Part 1

### DIFF
--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.js
@@ -17,8 +17,9 @@ export const setCourtIssuedDocumentInitialDataAction = ({
   props,
   store,
 }) => {
-  const caseDetail = get(state.caseDetail);
-  const docketEntry = (caseDetail.docketEntries || []).find(
+  const { docketEntries } = get(state.caseDetail);
+
+  const docketEntry = docketEntries.find(
     item => item.docketEntryId === props.docketEntryId,
   );
 

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setCourtIssuedDocumentInitialDataAction.test.js
@@ -4,24 +4,26 @@ import { presenter } from '../../presenter-mock';
 import { runAction } from 'cerebral/test';
 import { setCourtIssuedDocumentInitialDataAction } from './setCourtIssuedDocumentInitialDataAction';
 
-presenter.providers.applicationContext = applicationContext;
-
-const docketEntryIds = [
-  'ddfd978d-6be6-4877-b004-2b5735a41fee',
-  '11597d22-0874-4c5e-ac98-a843d1472baf',
-];
-
-MOCK_CASE.docketEntries.push({
-  docketEntryId: docketEntryIds[0],
-  eventCode: 'OF',
-});
-MOCK_CASE.docketEntries.push({
-  docketEntryId: docketEntryIds[1],
-  eventCode: 'O',
-  freeText: 'something',
-});
-
 describe('setCourtIssuedDocumentInitialDataAction', () => {
+  const docketEntryIds = [
+    'ddfd978d-6be6-4877-b004-2b5735a41fee',
+    '11597d22-0874-4c5e-ac98-a843d1472baf',
+  ];
+
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+
+    MOCK_CASE.docketEntries.push({
+      docketEntryId: docketEntryIds[0],
+      eventCode: 'OF',
+    });
+    MOCK_CASE.docketEntries.push({
+      docketEntryId: docketEntryIds[1],
+      eventCode: 'O',
+      freeText: 'something',
+    });
+  });
+
   it('should set correct values on state.form for the docketEntryId passed in via props', async () => {
     const result = await runAction(setCourtIssuedDocumentInitialDataAction, {
       modules: {

--- a/web-client/src/presenter/actions/WorkItem/assignPetitionToAuthenticatedUserAction.js
+++ b/web-client/src/presenter/actions/WorkItem/assignPetitionToAuthenticatedUserAction.js
@@ -13,9 +13,10 @@ export const assignPetitionToAuthenticatedUserAction = async ({
   get,
 }) => {
   const { INITIAL_DOCUMENT_TYPES } = applicationContext.getConstants();
+  const { docketEntries } = get(state.caseDetail);
   const user = applicationContext.getCurrentUser();
 
-  const petitionDocument = (get(state.caseDetail.docketEntries) || []).find(
+  const petitionDocument = docketEntries.find(
     document =>
       document.documentType === INITIAL_DOCUMENT_TYPES.petition.documentType,
   );

--- a/web-client/src/presenter/actions/WorkItem/assignPetitionToAuthenticatedUserAction.test.js
+++ b/web-client/src/presenter/actions/WorkItem/assignPetitionToAuthenticatedUserAction.test.js
@@ -21,6 +21,11 @@ describe('assignPetitionToAuthenticatedUserAction', () => {
       modules: {
         presenter,
       },
+      state: {
+        caseDetail: {
+          docketEntries: [],
+        },
+      },
     });
 
     expect(assignWorkItemsInteractor).not.toHaveBeenCalled();


### PR DESCRIPTION
Trying to reduce the number of defaults we use in web-client helpers and computeds. Docket entries and petitioners are both required properties on the Case entity that are safe to assume they will be defined in the client.

Note: Petitioners are forbidden in public cases that are sealed but in that case we don't use any of the computeds so I believe this should be ok.