### PR TITLE
9147: Reinstate the fake-virus.pdf as a file we want in our repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ web-client/terraform/common/cloudfront-edge/header-security-lambda.js.zip
 web-client/terraform/common/cloudfront-edge/strip-basepath-lambda.js.zip
 web-client/tests_output/
 bulk-import-log.txt
-fake-virus.pdf


### PR DESCRIPTION
The `/shared/test-assets/fake-virus.pdf` should remain in our repository and not be added to the `.gitignore` file.