### PR TITLE
Devex 1018: refactor advancedDocumentSearch

### DIFF
--- a/shared/src/business/entities/EntityConstants.js
+++ b/shared/src/business/entities/EntityConstants.js
@@ -1099,7 +1099,7 @@ const DATE_RANGE_SEARCH_OPTIONS = {
 };
 
 const DOCKET_ENTRY_SEALED_TO_TYPES = {
-  EXTERNAL: 'External', // Do not allow practitioners, petiioners, and irs practitioners to view the documents even when associated
+  EXTERNAL: 'External', // Do not allow practitioners, petitioners, and irs practitioners to view the documents even when associated
   PUBLIC: 'Public', // associated privatePractitioners, irsPractitioner, petitioner can still view the docket entry if they are associated
 };
 

--- a/shared/src/business/entities/documents/DocumentSearch.js
+++ b/shared/src/business/entities/documents/DocumentSearch.js
@@ -1,9 +1,5 @@
 const joi = require('joi');
 const {
-  ADVANCED_SEARCH_OPINION_TYPES,
-  DATE_RANGE_SEARCH_OPTIONS,
-} = require('../EntityConstants');
-const {
   calculateISODate,
   createEndOfDayISO,
   createStartOfDayISO,
@@ -12,6 +8,7 @@ const {
   joiValidationDecorator,
   validEntityDecorator,
 } = require('../JoiValidationDecorator');
+const { DATE_RANGE_SEARCH_OPTIONS } = require('../EntityConstants');
 const { JoiValidationConstants } = require('../JoiValidationConstants');
 
 DocumentSearch.DOCUMENT_SEARCH_PAGE_LOAD_SIZE = 6;
@@ -36,8 +33,6 @@ function DocumentSearch() {
 
 DocumentSearch.prototype.init = function init(rawProps = {}) {
   this.judge = rawProps.judge;
-
-  this.opinionTypes = rawProps.opinionTypes;
 
   this.from = rawProps.from ?? 0;
   this.userRole = rawProps.userRole;
@@ -140,17 +135,6 @@ DocumentSearch.schema = joi
     keyword: JoiValidationConstants.STRING.optional()
       .allow('')
       .description('The keyword to search by'),
-    opinionTypes: joi
-      .array()
-      .items(
-        JoiValidationConstants.STRING.valid(
-          ...Object.values(ADVANCED_SEARCH_OPINION_TYPES),
-        ).allow(''),
-      )
-      .optional()
-      .description(
-        'The opinion document types to filter the search results by',
-      ),
     startDate: joi.alternatives().conditional('dateRange', {
       is: DATE_RANGE_SEARCH_OPTIONS.CUSTOM_DATES,
       otherwise: joi.forbidden(),

--- a/shared/src/business/entities/documents/DocumentSearch.test.js
+++ b/shared/src/business/entities/documents/DocumentSearch.test.js
@@ -70,17 +70,6 @@ describe('Document Search entity', () => {
     expect(validationErrors).toBeNull();
   });
 
-  it('should pass validation with multiple opinionTypes', () => {
-    const documentSearch = new DocumentSearch({
-      opinionTypes: ['OST', 'TCOP'],
-    });
-
-    const validationErrors = documentSearch.getFormattedValidationErrors();
-
-    expect(documentSearch.opinionTypes).toBeDefined();
-    expect(validationErrors).toBeNull();
-  });
-
   describe('date search validation', () => {
     it('should not validate end date date when no date range is provided', () => {
       const documentSearch = new DocumentSearch({

--- a/shared/src/business/useCases/opinionAdvancedSearchInteractor.js
+++ b/shared/src/business/useCases/opinionAdvancedSearchInteractor.js
@@ -33,6 +33,7 @@ exports.opinionAdvancedSearchInteractor = async (
     endDate,
     judge,
     keyword,
+    // todo: rename to selected/filterby opion types
     opinionTypes,
     startDate,
   },
@@ -50,7 +51,6 @@ exports.opinionAdvancedSearchInteractor = async (
     endDate,
     judge,
     keyword,
-    opinionTypes,
     startDate,
   });
 
@@ -60,7 +60,7 @@ exports.opinionAdvancedSearchInteractor = async (
     .getPersistenceGateway()
     .advancedDocumentSearch({
       applicationContext,
-      documentEventCodes: OPINION_EVENT_CODES_WITH_BENCH_OPINION,
+      documentEventCodes: opinionTypes,
       isOpinionSearch: true,
       ...rawSearch,
     });

--- a/shared/src/business/useCases/opinionAdvancedSearchInteractor.js
+++ b/shared/src/business/useCases/opinionAdvancedSearchInteractor.js
@@ -10,7 +10,6 @@ const {
 } = require('../../authorization/authorizationClientService');
 const {
   MAX_SEARCH_RESULTS,
-  OPINION_EVENT_CODES_WITH_BENCH_OPINION,
 } = require('../../business/entities/EntityConstants');
 const { formatNow, FORMATS } = require('../utilities/DateHandler');
 const { omit } = require('lodash');
@@ -33,7 +32,6 @@ exports.opinionAdvancedSearchInteractor = async (
     endDate,
     judge,
     keyword,
-    // todo: rename to selected/filterby opion types
     opinionTypes,
     startDate,
   },

--- a/shared/src/business/useCases/opinionAdvancedSearchInteractor.test.js
+++ b/shared/src/business/useCases/opinionAdvancedSearchInteractor.test.js
@@ -108,6 +108,7 @@ describe('opinionAdvancedSearchInteractor', () => {
     await opinionAdvancedSearchInteractor(applicationContext, {
       dateRange: DATE_RANGE_SEARCH_OPTIONS.CUSTOM_DATES,
       keyword,
+      opinionTypes: OPINION_EVENT_CODES_WITH_BENCH_OPINION,
       startDate: '01/01/2001',
     });
 

--- a/shared/src/business/useCases/public/getTodaysOrdersInteractor.js
+++ b/shared/src/business/useCases/public/getTodaysOrdersInteractor.js
@@ -36,7 +36,7 @@ exports.getTodaysOrdersInteractor = async (
       from,
       omitSealed: true,
       overrideResultSize: TODAYS_ORDERS_PAGE_SIZE,
-      sortOrder: todaysOrdersSort,
+      sortField: todaysOrdersSort,
       startDate: currentDateStart,
     });
 

--- a/shared/src/business/useCases/public/getTodaysOrdersInteractor.test.js
+++ b/shared/src/business/useCases/public/getTodaysOrdersInteractor.test.js
@@ -109,7 +109,7 @@ describe('getTodaysOrdersInteractor', () => {
     ).toBe(TODAYS_ORDERS_PAGE_SIZE);
     expect(
       applicationContext.getPersistenceGateway().advancedDocumentSearch.mock
-        .calls[0][0].sortOrder,
+        .calls[0][0].sortField,
     ).toBe('filingDateDesc');
   });
 

--- a/shared/src/business/useCases/public/opinionPublicSearchInteractor.js
+++ b/shared/src/business/useCases/public/opinionPublicSearchInteractor.js
@@ -1,12 +1,9 @@
 const {
-  MAX_SEARCH_RESULTS,
-  OPINION_EVENT_CODES_WITH_BENCH_OPINION,
-} = require('../../entities/EntityConstants');
-const {
   PublicDocumentSearchResult,
 } = require('../../entities/documents/PublicDocumentSearchResult');
 const { DocumentSearch } = require('../../entities/documents/DocumentSearch');
 const { formatNow, FORMATS } = require('../../utilities/DateHandler');
+const { MAX_SEARCH_RESULTS } = require('../../entities/EntityConstants');
 const { omit } = require('lodash');
 
 /**
@@ -32,7 +29,6 @@ exports.opinionPublicSearchInteractor = async (
     endDate,
     judge,
     keyword,
-    // todo: rename to selected/filterby opion types
     opinionTypes,
     startDate,
   },

--- a/shared/src/business/useCases/public/opinionPublicSearchInteractor.js
+++ b/shared/src/business/useCases/public/opinionPublicSearchInteractor.js
@@ -32,6 +32,7 @@ exports.opinionPublicSearchInteractor = async (
     endDate,
     judge,
     keyword,
+    // todo: rename to selected/filterby opion types
     opinionTypes,
     startDate,
   },
@@ -43,7 +44,6 @@ exports.opinionPublicSearchInteractor = async (
     endDate,
     judge,
     keyword,
-    opinionTypes,
     startDate,
   });
 
@@ -53,9 +53,9 @@ exports.opinionPublicSearchInteractor = async (
     .getPersistenceGateway()
     .advancedDocumentSearch({
       applicationContext,
-      ...rawSearch,
-      documentEventCodes: OPINION_EVENT_CODES_WITH_BENCH_OPINION,
+      documentEventCodes: opinionTypes,
       isOpinionSearch: true,
+      ...rawSearch,
     });
 
   const timestamp = formatNow(FORMATS.LOG_TIMESTAMP);

--- a/shared/src/business/useCases/public/opinionPublicSearchInteractor.test.js
+++ b/shared/src/business/useCases/public/opinionPublicSearchInteractor.test.js
@@ -37,6 +37,7 @@ describe('opinionPublicSearchInteractor', () => {
     await opinionPublicSearchInteractor(applicationContext, {
       dateRange: DATE_RANGE_SEARCH_OPTIONS.CUSTOM_DATES,
       keyword: 'fish',
+      opinionTypes: OPINION_EVENT_CODES_WITH_BENCH_OPINION,
       startDate: '01/01/2001',
     });
 

--- a/shared/src/business/useCases/public/orderPublicSearchInteractor.js
+++ b/shared/src/business/useCases/public/orderPublicSearchInteractor.js
@@ -50,9 +50,9 @@ exports.orderPublicSearchInteractor = async (
     .getPersistenceGateway()
     .advancedDocumentSearch({
       applicationContext,
-      ...rawSearch,
       documentEventCodes: ORDER_EVENT_CODES,
       omitSealed: true,
+      ...rawSearch,
     });
 
   const timestamp = formatNow(FORMATS.LOG_TIMESTAMP);

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -129,15 +129,17 @@ exports.advancedDocumentSearch = async ({
   if (judge) {
     const judgeName = judge.replace(/Chief\s|Legacy\s|Judge\s/g, '');
     if (isOpinionSearch) {
-      getJudgeFilterForOpinionSearch({
-        documentMustQuery: documentMust,
+      const judgeFilter = getJudgeFilterForOpinionSearch({
         judgeName,
       });
+
+      documentMust.push(judgeFilter);
     } else {
-      getJudgeFilterForOrderSearch({
-        documentMustQuery: documentMust,
+      const judgeFilter = getJudgeFilterForOrderSearch({
         judgeName,
       });
+
+      documentMust.push(judgeFilter);
     }
   }
 

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -144,6 +144,8 @@ exports.advancedDocumentSearch = async ({
     { term: { 'isFileAttached.BOOL': true } },
   ];
 
+  // todo: is there a way to combine how we're using isOpinionSearch for judge vs. judgeName
+  // and opinionTypes to update the eventCode search
   if (opinionTypes && opinionTypes.length) {
     if (opinionTypes.length === 1) {
       documentQueryFilter.push({

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -29,7 +29,6 @@ exports.advancedDocumentSearch = async ({
   judge,
   keyword,
   omitSealed,
-  opinionTypes,
   overrideResultSize,
   sortField,
   startDate,
@@ -140,7 +139,7 @@ exports.advancedDocumentSearch = async ({
         field: 'servedAt',
       },
     },
-    { terms: { 'eventCode.S': opinionTypes || documentEventCodes } },
+    { terms: { 'eventCode.S': documentEventCodes } },
     { term: { 'isFileAttached.BOOL': true } },
   ];
 

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -126,23 +126,6 @@ exports.advancedDocumentSearch = async ({
     ];
   }
 
-  if (judge) {
-    const judgeName = judge.replace(/Chief\s|Legacy\s|Judge\s/g, '');
-    if (isOpinionSearch) {
-      const judgeFilter = getJudgeFilterForOpinionSearch({
-        judgeName,
-      });
-
-      documentMust.push(judgeFilter);
-    } else {
-      const judgeFilter = getJudgeFilterForOrderSearch({
-        judgeName,
-      });
-
-      documentMust.push(judgeFilter);
-    }
-  }
-
   const documentFilter = [
     { term: { 'entityName.S': 'DocketEntry' } },
     {
@@ -150,9 +133,26 @@ exports.advancedDocumentSearch = async ({
         field: 'servedAt',
       },
     },
-    { terms: { 'eventCode.S': documentEventCodes } },
     { term: { 'isFileAttached.BOOL': true } },
+    { terms: { 'eventCode.S': documentEventCodes } },
   ];
+
+  if (judge) {
+    const judgeName = judge.replace(/Chief\s|Legacy\s|Judge\s/g, '');
+    if (isOpinionSearch) {
+      const judgeFilter = getJudgeFilterForOpinionSearch({
+        judgeName,
+      });
+
+      documentFilter.push(judgeFilter);
+    } else {
+      const judgeFilter = getJudgeFilterForOrderSearch({
+        judgeName,
+      });
+
+      documentFilter.push(judgeFilter);
+    }
+  }
 
   if (endDate && startDate) {
     documentFilter.push({

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -88,10 +88,10 @@ exports.advancedDocumentSearch = async ({
 
   let documentMustNot = [{ term: { 'isStricken.BOOL': true } }];
   if (omitSealed) {
-    getSealedQuery({
-      caseQueryParams,
-      documentMustNotQuery: documentMustNot,
-    });
+    const { sealedCaseQuery, sealedDocumentMustNotQuery } = getSealedQuery();
+
+    caseQueryParams.has_parent.query.bool.filter.push(sealedCaseQuery);
+    documentMustNot = [...documentMustNot, ...sealedDocumentMustNotQuery];
   } else {
     if (isExternalUser) {
       documentMustNot.push({

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -140,27 +140,9 @@ exports.advancedDocumentSearch = async ({
         field: 'servedAt',
       },
     },
-    { terms: { 'eventCode.S': documentEventCodes } },
+    { terms: { 'eventCode.S': opinionTypes || documentEventCodes } },
     { term: { 'isFileAttached.BOOL': true } },
   ];
-
-  // todo: is there a way to combine how we're using isOpinionSearch for judge vs. judgeName
-  // and opinionTypes to update the eventCode search
-  if (opinionTypes && opinionTypes.length) {
-    if (opinionTypes.length === 1) {
-      documentQueryFilter.push({
-        term: { 'eventCode.S': opinionTypes[0] },
-      });
-    } else {
-      documentQueryFilter.push({
-        bool: {
-          should: opinionTypes.map(opinionType => ({
-            term: { 'eventCode.S': opinionType },
-          })),
-        },
-      });
-    }
-  }
 
   if (endDate && startDate) {
     documentQueryFilter.push({

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -224,9 +224,8 @@ describe('advancedDocumentSearch', () => {
   it('does a search by a single opinion type when an opinion document type is provided', async () => {
     await advancedDocumentSearch({
       applicationContext,
-      documentEventCodes: orderEventCodes,
+      documentEventCodes: ['SOP'],
       omitSealed: true,
-      opinionTypes: ['SOP'],
     });
 
     const expectation = [
@@ -251,17 +250,12 @@ describe('advancedDocumentSearch', () => {
       },
       {
         terms: {
-          'eventCode.S': ['O', 'OOD'],
+          'eventCode.S': ['SOP'],
         },
       },
       {
         term: {
           'isFileAttached.BOOL': true,
-        },
-      },
-      {
-        term: {
-          'eventCode.S': 'SOP',
         },
       },
     ]);

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -523,12 +523,12 @@ describe('advancedDocumentSearch', () => {
     );
   });
 
-  it('should sort by filingDate when sortOrder is provided as DOCUMENT_SEARCH_SORT.FILING_DATE_ASC', async () => {
+  it('should sort by filingDate when sortField is provided as DOCUMENT_SEARCH_SORT.FILING_DATE_ASC', async () => {
     await advancedDocumentSearch({
       applicationContext,
       documentEventCodes: opinionEventCodes,
       endDate: '2020-02-21T04:59:59.999Z',
-      sortOrder: TODAYS_ORDERS_SORTS.FILING_DATE_ASC,
+      sortField: TODAYS_ORDERS_SORTS.FILING_DATE_ASC,
       startDate: '2020-02-20T05:00:00.000Z',
     });
 
@@ -537,12 +537,12 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('should sort by numberOfPages when sortOrder is provided as DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC', async () => {
+  it('should sort by numberOfPages when sortField is provided as DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC', async () => {
     await advancedDocumentSearch({
       applicationContext,
       documentEventCodes: opinionEventCodes,
       endDate: '2020-02-21T04:59:59.999Z',
-      sortOrder: TODAYS_ORDERS_SORTS.NUMBER_OF_PAGES_ASC,
+      sortField: TODAYS_ORDERS_SORTS.NUMBER_OF_PAGES_ASC,
       startDate: '2020-02-20T05:00:00.000Z',
     });
 
@@ -551,7 +551,7 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('should use default sorting option (filing date, descending) when sortOrder is not passed in', async () => {
+  it('should use default sorting option (filing date, descending) when sortField is not passed in', async () => {
     await advancedDocumentSearch({
       applicationContext,
       documentEventCodes: opinionEventCodes,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -264,8 +264,7 @@ describe('advancedDocumentSearch', () => {
   it('does a search by multiple opinion types when multiple opinion document types are provided', async () => {
     await advancedDocumentSearch({
       applicationContext,
-      documentEventCodes: orderEventCodes,
-      opinionTypes: ['SOP', 'OST'],
+      documentEventCodes: ['SOP', 'OST'],
     });
 
     expect(
@@ -273,19 +272,8 @@ describe('advancedDocumentSearch', () => {
     ).toEqual(
       expect.arrayContaining([
         {
-          bool: {
-            should: [
-              {
-                term: {
-                  'eventCode.S': 'SOP',
-                },
-              },
-              {
-                term: {
-                  'eventCode.S': 'OST',
-                },
-              },
-            ],
+          terms: {
+            'eventCode.S': ['SOP', 'OST'],
           },
         },
       ]),

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -161,10 +161,9 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('does a search for a signed judge when searching for bench opinions', async () => {
+  it('does a search for a signed judge when searching for opinions', async () => {
     await advancedDocumentSearch({
       applicationContext,
-      documentEventCodes: [BENCH_OPINION_EVENT_CODE],
       isOpinionSearch: true,
       judge: 'Judge Guy Fieri',
     });
@@ -195,7 +194,7 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('does a search for a signed judge when searching for orders, not opinions', async () => {
+  it('does a search for a signed judge when searching for orders', async () => {
     await advancedDocumentSearch({
       applicationContext,
       documentEventCodes: orderEventCodes,
@@ -219,65 +218,6 @@ describe('advancedDocumentSearch', () => {
         },
       },
     ]);
-  });
-
-  it('does a search by a single opinion type when an opinion document type is provided', async () => {
-    await advancedDocumentSearch({
-      applicationContext,
-      documentEventCodes: ['SOP'],
-      omitSealed: true,
-    });
-
-    const expectation = [
-      getCaseMappingQueryParams(), // match all parents
-    ];
-    expectation[0].has_parent.query.bool.must_not = [
-      { term: { 'isSealed.BOOL': true } },
-    ];
-
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.filter,
-    ).toEqual([
-      {
-        term: {
-          'entityName.S': 'DocketEntry',
-        },
-      },
-      {
-        exists: {
-          field: 'servedAt',
-        },
-      },
-      {
-        terms: {
-          'eventCode.S': ['SOP'],
-        },
-      },
-      {
-        term: {
-          'isFileAttached.BOOL': true,
-        },
-      },
-    ]);
-  });
-
-  it('does a search by multiple opinion types when multiple opinion document types are provided', async () => {
-    await advancedDocumentSearch({
-      applicationContext,
-      documentEventCodes: ['SOP', 'OST'],
-    });
-
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.filter,
-    ).toEqual(
-      expect.arrayContaining([
-        {
-          terms: {
-            'eventCode.S': ['SOP', 'OST'],
-          },
-        },
-      ]),
-    );
   });
 
   it('should only include sealed docket entries in the search results when they are sealed to the public', async () => {
@@ -337,7 +277,7 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('omits docket entries with isSealed:true when doing an opinion search', async () => {
+  it('must not include sealed documents when doing an opinion search', async () => {
     await advancedDocumentSearch({
       applicationContext,
       documentEventCodes: [BENCH_OPINION_EVENT_CODE],
@@ -504,34 +444,7 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('should sort by numberOfPages when sortField is provided as DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC', async () => {
-    await advancedDocumentSearch({
-      applicationContext,
-      documentEventCodes: opinionEventCodes,
-      endDate: '2020-02-21T04:59:59.999Z',
-      sortField: TODAYS_ORDERS_SORTS.NUMBER_OF_PAGES_ASC,
-      startDate: '2020-02-20T05:00:00.000Z',
-    });
-
-    expect(search.mock.calls[0][0].searchParameters.body.sort).toEqual([
-      { 'numberOfPages.N': 'asc' },
-    ]);
-  });
-
-  it('should use default sorting option (filing date, descending) when sortField is not passed in', async () => {
-    await advancedDocumentSearch({
-      applicationContext,
-      documentEventCodes: opinionEventCodes,
-      endDate: '2020-02-21T04:59:59.999Z',
-      startDate: '2020-02-20T05:00:00.000Z',
-    });
-
-    expect(search.mock.calls[0][0].searchParameters.body.sort).toEqual([
-      { 'filingDate.S': 'desc' },
-    ]);
-  });
-
-  it('should return the results and totalCount of results1', async () => {
+  it('should return the results and totalCount of results', async () => {
     applicationContextForClient.i;
     const result = await advancedDocumentSearch({
       applicationContext,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -314,6 +314,29 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
+  it('should not include docket entries in the search results when they are sealed to the "External" even when they are not sealed documents', async () => {
+    await advancedDocumentSearch({
+      applicationContext,
+      isExternalUser: true,
+      omitSealed: false,
+    });
+
+    expect(
+      search.mock.calls[0][0].searchParameters.body.query.bool.must_not,
+    ).toEqual([
+      {
+        term: {
+          'isStricken.BOOL': true,
+        },
+      },
+      {
+        term: {
+          'sealedTo.S': 'External',
+        },
+      },
+    ]);
+  });
+
   it('omits docket entries with isSealed:true when doing an opinion search', async () => {
     await advancedDocumentSearch({
       applicationContext,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -161,40 +161,6 @@ describe('advancedDocumentSearch', () => {
     ]);
   });
 
-  it('does a search for a signed judge when searching for bench opinions', async () => {
-    await advancedDocumentSearch({
-      applicationContext,
-      documentEventCodes: [BENCH_OPINION_EVENT_CODE],
-      isOpinionSearch: true,
-      judge: 'Judge Guy Fieri',
-    });
-
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must,
-    ).toEqual([
-      getCaseMappingQueryParams(null), // match all parents
-      {
-        bool: {
-          should: [
-            {
-              match: {
-                'judge.S': 'Guy Fieri',
-              },
-            },
-            {
-              match: {
-                'signedJudgeName.S': {
-                  operator: 'and',
-                  query: 'Guy Fieri',
-                },
-              },
-            },
-          ],
-        },
-      },
-    ]);
-  });
-
   it('does a search for a signed judge when searching for orders, not opinions', async () => {
     await advancedDocumentSearch({
       applicationContext,
@@ -330,44 +296,6 @@ describe('advancedDocumentSearch', () => {
         },
       },
     ]);
-  });
-
-  it('does a search for a judge when searching for opinions', async () => {
-    await advancedDocumentSearch({
-      applicationContext,
-      documentEventCodes: opinionEventCodes,
-      isOpinionSearch: true,
-      judge: 'Judge Guy Fieri',
-    });
-
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool,
-    ).toMatchObject({
-      filter: expect.arrayContaining(opinionQueryParams),
-      must: [
-        getCaseMappingQueryParams(null), // match all parents
-        {
-          bool: {
-            should: [
-              {
-                match: {
-                  'judge.S': 'Guy Fieri',
-                },
-              },
-              {
-                match: {
-                  'signedJudgeName.S': {
-                    operator: 'and',
-                    query: 'Guy Fieri',
-                  },
-                },
-              },
-            ],
-          },
-        },
-      ],
-      must_not: expect.anything(),
-    });
   });
 
   it('omits docket entries with isSealed:true when doing an opinion search', async () => {
@@ -576,55 +504,5 @@ describe('advancedDocumentSearch', () => {
 
     expect(result.results).toBeDefined();
     expect(result.totalCount).toBeDefined();
-  });
-
-  describe('judge filter search', () => {
-    it('should strip out the "Chief" title from a judge\'s name', async () => {
-      await advancedDocumentSearch({
-        applicationContext,
-        documentEventCodes: opinionEventCodes,
-        isOpinionSearch: true,
-        judge: 'Chief Guy Fieri',
-      });
-
-      expect(
-        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
-          .should[0].match,
-      ).toEqual({
-        'judge.S': 'Guy Fieri',
-      });
-    });
-
-    it('should strip out the "Legacy" title from a judge\'s name', async () => {
-      await advancedDocumentSearch({
-        applicationContext,
-        documentEventCodes: opinionEventCodes,
-        judge: 'Legacy Guy Fieri',
-      });
-
-      expect(
-        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
-          .should.match,
-      ).toEqual({
-        'signedJudgeName.S': {
-          operator: 'and',
-          query: 'Guy Fieri',
-        },
-      });
-    });
-
-    it('should strip out the "Judge" title from a judge\'s name', async () => {
-      await advancedDocumentSearch({
-        applicationContext,
-        documentEventCodes: opinionEventCodes,
-        isOpinionSearch: true,
-        judge: 'Legacy Judge Guy Fieri',
-      });
-
-      expect(
-        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
-          .should[0].match,
-      ).toEqual({ 'judge.S': 'Guy Fieri' });
-    });
   });
 });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -1,0 +1,29 @@
+const {
+  OPINION_JUDGE_FIELD,
+  ORDER_JUDGE_FIELD,
+} = require('../../../business/entities/EntityConstants');
+
+export const getJudgeFilterForOpinionSearch = ({
+  docketEntryQueryParams,
+  judgeName,
+}) => {
+  docketEntryQueryParams.push({
+    bool: {
+      should: [
+        {
+          match: {
+            [`${OPINION_JUDGE_FIELD}.S`]: judgeName,
+          },
+        },
+        {
+          match: {
+            [`${ORDER_JUDGE_FIELD}.S`]: {
+              operator: 'and',
+              query: judgeName,
+            },
+          },
+        },
+      ],
+    },
+  });
+};

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -1,7 +1,8 @@
-import {
+const {
   OPINION_JUDGE_FIELD,
   ORDER_JUDGE_FIELD,
-} from '../../../business/entities/EntityConstants';
+} = require('../../../business/entities/EntityConstants');
+
 exports.getJudgeFilterForOpinionSearch = ({
   docketEntryQueryParams,
   judgeName,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -3,8 +3,8 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-exports.getJudgeFilterForOpinionSearch = ({ documentMust, judgeName }) => {
-  documentMust.push({
+exports.getJudgeFilterForOpinionSearch = ({ judgeName }) => {
+  return {
     bool: {
       should: [
         {
@@ -22,5 +22,5 @@ exports.getJudgeFilterForOpinionSearch = ({ documentMust, judgeName }) => {
         },
       ],
     },
-  });
+  };
 };

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -3,8 +3,8 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-exports.getJudgeFilterForOpinionSearch = ({ documentMustQuery, judgeName }) => {
-  documentMustQuery.push({
+exports.getJudgeFilterForOpinionSearch = ({ documentMust, judgeName }) => {
+  documentMust.push({
     bool: {
       should: [
         {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -1,7 +1,7 @@
-const {
+import {
   OPINION_JUDGE_FIELD,
   ORDER_JUDGE_FIELD,
-} = require('../../../business/entities/EntityConstants');
+} from '../../../business/entities/EntityConstants';
 exports.getJudgeFilterForOpinionSearch = ({
   docketEntryQueryParams,
   judgeName,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -3,11 +3,8 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-exports.getJudgeFilterForOpinionSearch = ({
-  docketEntryQueryParams,
-  judgeName,
-}) => {
-  docketEntryQueryParams.push({
+exports.getJudgeFilterForOpinionSearch = ({ documentMustQuery, judgeName }) => {
+  documentMustQuery.push({
     bool: {
       should: [
         {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.js
@@ -2,8 +2,7 @@ const {
   OPINION_JUDGE_FIELD,
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
-
-export const getJudgeFilterForOpinionSearch = ({
+exports.getJudgeFilterForOpinionSearch = ({
   docketEntryQueryParams,
   judgeName,
 }) => {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -1,41 +1,30 @@
-/* eslint-disable max-lines */
-const {
-  applicationContext,
-} = require('../../../business/test/createTestApplicationContext');
-const {
-  BENCH_OPINION_EVENT_CODE,
-} = require('../../../business/entities/EntityConstants');
 const {
   getJudgeFilterForOpinionSearch,
-} = require('../getJudgeFilterForOpinionSearch');
+} = require('./getJudgeFilterForOpinionSearch');
 
 describe('getJudgeFilterForOpinionSearch', () => {
-  // dpes a search for signedjudgename because bench opinions are technally orders
-  it('does a search for a signed judge when searching for bench opinions', async () => {
-    await getJudgeFilterForOpinionSearch({
-      applicationContext,
-      documentEventCodes: [BENCH_OPINION_EVENT_CODE],
-      isOpinionSearch: true,
-      judge: 'Judge Guy Fieri',
+  it('does a search for both judge and signed judge since bench opinions are technically orders', async () => {
+    let mockDocketEntryQueryParams = [];
+
+    getJudgeFilterForOpinionSearch({
+      docketEntryQueryParams: mockDocketEntryQueryParams,
+      judgeName: 'Judge Antonia Lofaso',
     });
 
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must,
-    ).toEqual([
-      getCaseMappingQueryParams(null), // match all parents
+    expect(mockDocketEntryQueryParams).toEqual([
       {
         bool: {
           should: [
             {
               match: {
-                'judge.S': 'Guy Fieri',
+                'judge.S': 'Judge Antonia Lofaso',
               },
             },
             {
               match: {
                 'signedJudgeName.S': {
                   operator: 'and',
-                  query: 'Guy Fieri',
+                  query: 'Judge Antonia Lofaso',
                 },
               },
             },
@@ -43,94 +32,5 @@ describe('getJudgeFilterForOpinionSearch', () => {
         },
       },
     ]);
-  });
-
-  it('does a search for a judge when searching for opinions', async () => {
-    await getJudgeFilterForOpinionSearch({
-      applicationContext,
-      documentEventCodes: opinionEventCodes,
-      isOpinionSearch: true,
-      judge: 'Judge Guy Fieri',
-    });
-
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool,
-    ).toMatchObject({
-      filter: expect.arrayContaining(opinionQueryParams),
-      must: [
-        getCaseMappingQueryParams(null), // match all parents
-        {
-          bool: {
-            should: [
-              {
-                match: {
-                  'judge.S': 'Guy Fieri',
-                },
-              },
-              {
-                match: {
-                  'signedJudgeName.S': {
-                    operator: 'and',
-                    query: 'Guy Fieri',
-                  },
-                },
-              },
-            ],
-          },
-        },
-      ],
-      must_not: expect.anything(),
-    });
-  });
-
-  describe('judge filter search', () => {
-    //todo: change this name
-    it('should strip out the "Chief" title from a judge\'s name', async () => {
-      await getJudgeFilterForOpinionSearch({
-        applicationContext,
-        documentEventCodes: opinionEventCodes,
-        isOpinionSearch: true,
-        judge: 'Chief Guy Fieri',
-      });
-
-      expect(
-        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
-          .should[0].match,
-      ).toEqual({
-        'judge.S': 'Guy Fieri',
-      });
-    });
-
-    it('should strip out the "Legacy" title from a judge\'s name', async () => {
-      await getJudgeFilterForOpinionSearch({
-        applicationContext,
-        documentEventCodes: opinionEventCodes,
-        judge: 'Legacy Guy Fieri',
-      });
-
-      expect(
-        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
-          .should.match,
-      ).toEqual({
-        'signedJudgeName.S': {
-          operator: 'and',
-          query: 'Guy Fieri',
-        },
-      });
-    });
-
-    it('should strip out the "Judge" title from a judge\'s name', async () => {
-      await getJudgeFilterForOpinionSearch({
-        applicationContext,
-        documentEventCodes: opinionEventCodes,
-        isOpinionSearch: true,
-        judge: 'Legacy Judge Guy Fieri',
-      });
-
-      expect(
-        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
-          .should[0].match,
-      ).toEqual({ 'judge.S': 'Guy Fieri' });
-    });
   });
 });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -1,4 +1,6 @@
-import { getJudgeFilterForOpinionSearch } from './getJudgeFilterForOpinionSearch';
+const {
+  getJudgeFilterForOpinionSearch,
+} = require('./getJudgeFilterForOpinionSearch');
 
 describe('getJudgeFilterForOpinionSearch', () => {
   it('does a search for both judge and signed judge since bench opinions are technically orders', () => {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -4,14 +4,14 @@ const {
 
 describe('getJudgeFilterForOpinionSearch', () => {
   it('does a search for both judge and signed judge since bench opinions are technically orders', () => {
-    let mockDocketEntryQueryParams = [];
+    let mockDocumentMust = [];
 
     getJudgeFilterForOpinionSearch({
-      docketEntryQueryParams: mockDocketEntryQueryParams,
+      documentMust: mockDocumentMust,
       judgeName: 'Judge Antonia Lofaso',
     });
 
-    expect(mockDocketEntryQueryParams).toEqual([
+    expect(mockDocumentMust).toEqual([
       {
         bool: {
           should: [

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -1,0 +1,220 @@
+/* eslint-disable max-lines */
+const {
+  applicationContext,
+} = require('../../../business/test/createTestApplicationContext');
+const {
+  BENCH_OPINION_EVENT_CODE,
+} = require('../../../business/entities/EntityConstants');
+const {
+  getJudgeFilterForOpinionSearch,
+} = require('../getJudgeFilterForOpinionSearch');
+const { search } = require('../searchClient');
+jest.mock('./searchClient');
+
+describe('getJudgeFilterForOpinionSearch', () => {
+  const opinionEventCodes = ['MOP', 'TCOP'];
+
+  const SOURCE = {
+    includes: [
+      'caseCaption',
+      'docketEntryId',
+      'docketNumber',
+      'docketNumberWithSuffix',
+      'documentTitle',
+      'documentType',
+      'eventCode',
+      'filingDate',
+      'irsPractitioners',
+      'isFileAttached',
+      'isSealed',
+      'isStricken',
+      'judge',
+      'numberOfPages',
+      'petitioners',
+      'privatePractitioners',
+      'sealedDate',
+      'sealedTo',
+      'signedJudgeName',
+    ],
+  };
+
+  const opinionQueryParams = [
+    { term: { 'entityName.S': 'DocketEntry' } },
+    {
+      exists: {
+        field: 'servedAt',
+      },
+    },
+    {
+      terms: {
+        'eventCode.S': [opinionEventCodes[0], opinionEventCodes[1]],
+      },
+    },
+  ];
+
+  const getCaseMappingQueryParams = (caseTitleOrPetitioner, docketNumber) => {
+    let query = {
+      bool: {
+        filter: [],
+      },
+    };
+
+    if (caseTitleOrPetitioner) {
+      query.bool.must = {
+        simple_query_string: {
+          default_operator: 'and',
+          fields: ['caseCaption.S', 'petitioners.L.M.name.S'],
+          flags: 'OR|AND|ESCAPE|PHRASE',
+          query: caseTitleOrPetitioner,
+        },
+      };
+    }
+
+    if (docketNumber) {
+      query.bool.filter.push({
+        term: {
+          'docketNumber.S': docketNumber,
+        },
+      });
+    }
+
+    return {
+      has_parent: {
+        inner_hits: {
+          _source: SOURCE,
+          name: 'case-mappings',
+        },
+        parent_type: 'case',
+        query,
+        score: true,
+      },
+    };
+  };
+
+  beforeEach(() => {
+    search.mockReturnValue({ results: [], total: 0 });
+  });
+
+  it('does a search for a signed judge when searching for bench opinions', async () => {
+    await getJudgeFilterForOpinionSearch({
+      applicationContext,
+      documentEventCodes: [BENCH_OPINION_EVENT_CODE],
+      isOpinionSearch: true,
+      judge: 'Judge Guy Fieri',
+    });
+
+    expect(
+      search.mock.calls[0][0].searchParameters.body.query.bool.must,
+    ).toEqual([
+      getCaseMappingQueryParams(null), // match all parents
+      {
+        bool: {
+          should: [
+            {
+              match: {
+                'judge.S': 'Guy Fieri',
+              },
+            },
+            {
+              match: {
+                'signedJudgeName.S': {
+                  operator: 'and',
+                  query: 'Guy Fieri',
+                },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('does a search for a judge when searching for opinions', async () => {
+    await getJudgeFilterForOpinionSearch({
+      applicationContext,
+      documentEventCodes: opinionEventCodes,
+      isOpinionSearch: true,
+      judge: 'Judge Guy Fieri',
+    });
+
+    expect(
+      search.mock.calls[0][0].searchParameters.body.query.bool,
+    ).toMatchObject({
+      filter: expect.arrayContaining(opinionQueryParams),
+      must: [
+        getCaseMappingQueryParams(null), // match all parents
+        {
+          bool: {
+            should: [
+              {
+                match: {
+                  'judge.S': 'Guy Fieri',
+                },
+              },
+              {
+                match: {
+                  'signedJudgeName.S': {
+                    operator: 'and',
+                    query: 'Guy Fieri',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      must_not: expect.anything(),
+    });
+  });
+
+  describe('judge filter search', () => {
+    //todo: change this name
+    it('should strip out the "Chief" title from a judge\'s name', async () => {
+      await getJudgeFilterForOpinionSearch({
+        applicationContext,
+        documentEventCodes: opinionEventCodes,
+        isOpinionSearch: true,
+        judge: 'Chief Guy Fieri',
+      });
+
+      expect(
+        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
+          .should[0].match,
+      ).toEqual({
+        'judge.S': 'Guy Fieri',
+      });
+    });
+
+    it('should strip out the "Legacy" title from a judge\'s name', async () => {
+      await getJudgeFilterForOpinionSearch({
+        applicationContext,
+        documentEventCodes: opinionEventCodes,
+        judge: 'Legacy Guy Fieri',
+      });
+
+      expect(
+        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
+          .should.match,
+      ).toEqual({
+        'signedJudgeName.S': {
+          operator: 'and',
+          query: 'Guy Fieri',
+        },
+      });
+    });
+
+    it('should strip out the "Judge" title from a judge\'s name', async () => {
+      await getJudgeFilterForOpinionSearch({
+        applicationContext,
+        documentEventCodes: opinionEventCodes,
+        isOpinionSearch: true,
+        judge: 'Legacy Judge Guy Fieri',
+      });
+
+      expect(
+        search.mock.calls[0][0].searchParameters.body.query.bool.must[1].bool
+          .should[0].match,
+      ).toEqual({ 'judge.S': 'Guy Fieri' });
+    });
+  });
+});

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -4,33 +4,28 @@ const {
 
 describe('getJudgeFilterForOpinionSearch', () => {
   it('does a search for both judge and signed judge since bench opinions are technically orders', () => {
-    let mockDocumentMust = [];
-
-    getJudgeFilterForOpinionSearch({
-      documentMust: mockDocumentMust,
+    const result = getJudgeFilterForOpinionSearch({
       judgeName: 'Judge Antonia Lofaso',
     });
 
-    expect(mockDocumentMust).toEqual([
-      {
-        bool: {
-          should: [
-            {
-              match: {
-                'judge.S': 'Judge Antonia Lofaso',
+    expect(result).toEqual({
+      bool: {
+        should: [
+          {
+            match: {
+              'judge.S': 'Judge Antonia Lofaso',
+            },
+          },
+          {
+            match: {
+              'signedJudgeName.S': {
+                operator: 'and',
+                query: 'Judge Antonia Lofaso',
               },
             },
-            {
-              match: {
-                'signedJudgeName.S': {
-                  operator: 'and',
-                  query: 'Judge Antonia Lofaso',
-                },
-              },
-            },
-          ],
-        },
+          },
+        ],
       },
-    ]);
+    });
   });
 });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -8,93 +8,9 @@ const {
 const {
   getJudgeFilterForOpinionSearch,
 } = require('../getJudgeFilterForOpinionSearch');
-const { search } = require('../searchClient');
-jest.mock('./searchClient');
 
 describe('getJudgeFilterForOpinionSearch', () => {
-  const opinionEventCodes = ['MOP', 'TCOP'];
-
-  const SOURCE = {
-    includes: [
-      'caseCaption',
-      'docketEntryId',
-      'docketNumber',
-      'docketNumberWithSuffix',
-      'documentTitle',
-      'documentType',
-      'eventCode',
-      'filingDate',
-      'irsPractitioners',
-      'isFileAttached',
-      'isSealed',
-      'isStricken',
-      'judge',
-      'numberOfPages',
-      'petitioners',
-      'privatePractitioners',
-      'sealedDate',
-      'sealedTo',
-      'signedJudgeName',
-    ],
-  };
-
-  const opinionQueryParams = [
-    { term: { 'entityName.S': 'DocketEntry' } },
-    {
-      exists: {
-        field: 'servedAt',
-      },
-    },
-    {
-      terms: {
-        'eventCode.S': [opinionEventCodes[0], opinionEventCodes[1]],
-      },
-    },
-  ];
-
-  const getCaseMappingQueryParams = (caseTitleOrPetitioner, docketNumber) => {
-    let query = {
-      bool: {
-        filter: [],
-      },
-    };
-
-    if (caseTitleOrPetitioner) {
-      query.bool.must = {
-        simple_query_string: {
-          default_operator: 'and',
-          fields: ['caseCaption.S', 'petitioners.L.M.name.S'],
-          flags: 'OR|AND|ESCAPE|PHRASE',
-          query: caseTitleOrPetitioner,
-        },
-      };
-    }
-
-    if (docketNumber) {
-      query.bool.filter.push({
-        term: {
-          'docketNumber.S': docketNumber,
-        },
-      });
-    }
-
-    return {
-      has_parent: {
-        inner_hits: {
-          _source: SOURCE,
-          name: 'case-mappings',
-        },
-        parent_type: 'case',
-        query,
-        score: true,
-      },
-    };
-  };
-
-  beforeEach(() => {
-    search.mockReturnValue({ results: [], total: 0 });
-  });
-
+  // dpes a search for signedjudgename because bench opinions are technally orders
   it('does a search for a signed judge when searching for bench opinions', async () => {
     await getJudgeFilterForOpinionSearch({
       applicationContext,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -1,9 +1,7 @@
-const {
-  getJudgeFilterForOpinionSearch,
-} = require('./getJudgeFilterForOpinionSearch');
+import { getJudgeFilterForOpinionSearch } from './getJudgeFilterForOpinionSearch';
 
 describe('getJudgeFilterForOpinionSearch', () => {
-  it('does a search for both judge and signed judge since bench opinions are technically orders', async () => {
+  it('does a search for both judge and signed judge since bench opinions are technically orders', () => {
     let mockDocketEntryQueryParams = [];
 
     getJudgeFilterForOpinionSearch({

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOpinionSearch.test.js
@@ -1,11 +1,19 @@
 const {
   getJudgeFilterForOpinionSearch,
 } = require('./getJudgeFilterForOpinionSearch');
+const {
+  OPINION_JUDGE_FIELD,
+  ORDER_JUDGE_FIELD,
+} = require('../../../business/entities/EntityConstants');
 
 describe('getJudgeFilterForOpinionSearch', () => {
   it('does a search for both judge and signed judge since bench opinions are technically orders', () => {
+    const expectedOrderJudgeFilter = `${ORDER_JUDGE_FIELD}.S`;
+    const expectedOpinionJudgeFilter = `${OPINION_JUDGE_FIELD}.S`;
+    const expectedJudgeName = 'Judge Antonia Lofaso';
+
     const result = getJudgeFilterForOpinionSearch({
-      judgeName: 'Judge Antonia Lofaso',
+      judgeName: expectedJudgeName,
     });
 
     expect(result).toEqual({
@@ -13,14 +21,14 @@ describe('getJudgeFilterForOpinionSearch', () => {
         should: [
           {
             match: {
-              'judge.S': 'Judge Antonia Lofaso',
+              [expectedOpinionJudgeFilter]: expectedJudgeName,
             },
           },
           {
             match: {
-              'signedJudgeName.S': {
+              [expectedOrderJudgeFilter]: {
                 operator: 'and',
-                query: 'Judge Antonia Lofaso',
+                query: expectedJudgeName,
               },
             },
           },

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -2,8 +2,8 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-exports.getJudgeFilterForOrderSearch = ({ documentMustQuery, judgeName }) => {
-  documentMustQuery.push({
+exports.getJudgeFilterForOrderSearch = ({ documentMust, judgeName }) => {
+  documentMust.push({
     bool: {
       should: {
         match: {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -2,8 +2,8 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-exports.getJudgeFilterForOrderSearch = ({ documentMust, judgeName }) => {
-  documentMust.push({
+exports.getJudgeFilterForOrderSearch = ({ judgeName }) => {
+  return {
     bool: {
       should: {
         match: {
@@ -14,5 +14,5 @@ exports.getJudgeFilterForOrderSearch = ({ documentMust, judgeName }) => {
         },
       },
     },
-  });
+  };
 };

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -2,7 +2,7 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-export const getJudgeFilterForOrderSearch = ({
+exports.getJudgeFilterForOrderSearch = ({
   docketEntryQueryParams,
   judgeName,
 }) => {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -2,11 +2,8 @@ const {
   ORDER_JUDGE_FIELD,
 } = require('../../../business/entities/EntityConstants');
 
-exports.getJudgeFilterForOrderSearch = ({
-  docketEntryQueryParams,
-  judgeName,
-}) => {
-  docketEntryQueryParams.push({
+exports.getJudgeFilterForOrderSearch = ({ documentMustQuery, judgeName }) => {
+  documentMustQuery.push({
     bool: {
       should: {
         match: {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -1,0 +1,21 @@
+const {
+  ORDER_JUDGE_FIELD,
+} = require('../../../business/entities/EntityConstants');
+
+export const getJudgeFilterForOrderSearch = ({
+  docketEntryQueryParams,
+  judgeName,
+}) => {
+  docketEntryQueryParams.push({
+    bool: {
+      should: {
+        match: {
+          [`${ORDER_JUDGE_FIELD}.S`]: {
+            operator: 'and',
+            query: judgeName,
+          },
+        },
+      },
+    },
+  });
+};

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -1,6 +1,4 @@
-const {
-  ORDER_JUDGE_FIELD,
-} = require('../../../business/entities/EntityConstants');
+import { ORDER_JUDGE_FIELD } from '../../../business/entities/EntityConstants';
 
 exports.getJudgeFilterForOrderSearch = ({
   docketEntryQueryParams,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.js
@@ -1,4 +1,6 @@
-import { ORDER_JUDGE_FIELD } from '../../../business/entities/EntityConstants';
+const {
+  ORDER_JUDGE_FIELD,
+} = require('../../../business/entities/EntityConstants');
 
 exports.getJudgeFilterForOrderSearch = ({
   docketEntryQueryParams,

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
@@ -1,14 +1,12 @@
-const {
-  getJudgeFilterForOrderSearch,
-} = require('./getJudgeFilterForOrderSearch');
+import { getJudgeFilterForOrderSearch } from './getJudgeFilterForOrderSearch';
 
 describe('getJudgeFilterForOrderSearch', () => {
-  it('does a search for signed judge name', async () => {
+  it('does a search for signed judge name', () => {
     let mockDocketEntryQueryParams = [];
 
     getJudgeFilterForOrderSearch({
       docketEntryQueryParams: mockDocketEntryQueryParams,
-      judgeName: 'Judge Antonia Lofaso',
+      judgeName: 'Judge Alex Guarnaschelli',
     });
 
     expect(mockDocketEntryQueryParams).toEqual([
@@ -18,7 +16,7 @@ describe('getJudgeFilterForOrderSearch', () => {
             match: {
               'signedJudgeName.S': {
                 operator: 'and',
-                query: 'Judge Antonia Lofaso',
+                query: 'Judge Alex Guarnaschelli',
               },
             },
           },

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
@@ -1,20 +1,26 @@
 const {
   getJudgeFilterForOrderSearch,
 } = require('./getJudgeFilterForOrderSearch');
+const {
+  ORDER_JUDGE_FIELD,
+} = require('../../../business/entities/EntityConstants');
 
 describe('getJudgeFilterForOrderSearch', () => {
   it('does a search for signed judge name', () => {
+    const expectedJudgeFilter = `${ORDER_JUDGE_FIELD}.S`;
+    const expectedJudgeName = 'Judge Alex Guarnaschelli';
+
     const result = getJudgeFilterForOrderSearch({
-      judgeName: 'Judge Alex Guarnaschelli',
+      judgeName: expectedJudgeName,
     });
 
     expect(result).toEqual({
       bool: {
         should: {
           match: {
-            'signedJudgeName.S': {
+            [expectedJudgeFilter]: {
               operator: 'and',
-              query: 'Judge Alex Guarnaschelli',
+              query: expectedJudgeName,
             },
           },
         },

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
@@ -1,0 +1,29 @@
+const {
+  getJudgeFilterForOrderSearch,
+} = require('./getJudgeFilterForOrderSearch');
+
+describe('getJudgeFilterForOrderSearch', () => {
+  it('does a search for signed judge name', async () => {
+    let mockDocketEntryQueryParams = [];
+
+    getJudgeFilterForOrderSearch({
+      docketEntryQueryParams: mockDocketEntryQueryParams,
+      judgeName: 'Judge Antonia Lofaso',
+    });
+
+    expect(mockDocketEntryQueryParams).toEqual([
+      {
+        bool: {
+          should: {
+            match: {
+              'signedJudgeName.S': {
+                operator: 'and',
+                query: 'Judge Antonia Lofaso',
+              },
+            },
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
@@ -1,4 +1,6 @@
-import { getJudgeFilterForOrderSearch } from './getJudgeFilterForOrderSearch';
+const {
+  getJudgeFilterForOrderSearch,
+} = require('./getJudgeFilterForOrderSearch');
 
 describe('getJudgeFilterForOrderSearch', () => {
   it('does a search for signed judge name', () => {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
@@ -4,14 +4,14 @@ const {
 
 describe('getJudgeFilterForOrderSearch', () => {
   it('does a search for signed judge name', () => {
-    let mockDocketEntryQueryParams = [];
+    let mockDocumentMust = [];
 
     getJudgeFilterForOrderSearch({
-      docketEntryQueryParams: mockDocketEntryQueryParams,
+      documentMust: mockDocumentMust,
       judgeName: 'Judge Alex Guarnaschelli',
     });
 
-    expect(mockDocketEntryQueryParams).toEqual([
+    expect(mockDocumentMust).toEqual([
       {
         bool: {
           should: {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getJudgeFilterForOrderSearch.test.js
@@ -4,26 +4,21 @@ const {
 
 describe('getJudgeFilterForOrderSearch', () => {
   it('does a search for signed judge name', () => {
-    let mockDocumentMust = [];
-
-    getJudgeFilterForOrderSearch({
-      documentMust: mockDocumentMust,
+    const result = getJudgeFilterForOrderSearch({
       judgeName: 'Judge Alex Guarnaschelli',
     });
 
-    expect(mockDocumentMust).toEqual([
-      {
-        bool: {
-          should: {
-            match: {
-              'signedJudgeName.S': {
-                operator: 'and',
-                query: 'Judge Alex Guarnaschelli',
-              },
+    expect(result).toEqual({
+      bool: {
+        should: {
+          match: {
+            'signedJudgeName.S': {
+              operator: 'and',
+              query: 'Judge Alex Guarnaschelli',
             },
           },
         },
       },
-    ]);
+    });
   });
 });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
@@ -1,0 +1,36 @@
+export const getSealedQuery = ({ caseQueryParams, docketEntryMustNot }) => {
+  docketEntryMustNot.push({
+    term: { 'isSealed.BOOL': true },
+  });
+  docketEntryMustNot.push({
+    term: { 'sealedTo.S': 'External' },
+  });
+
+  caseQueryParams.has_parent.query.bool.filter.push({
+    bool: {
+      must: [
+        {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: {
+                    term: { 'isSealed.BOOL': false },
+                  },
+                },
+              },
+              {
+                bool: {
+                  must_not: {
+                    exists: { field: 'isSealed' },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+};

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
@@ -1,4 +1,4 @@
-export const getSealedQuery = ({ caseQueryParams, docketEntryMustNot }) => {
+exports.getSealedQuery = ({ caseQueryParams, docketEntryMustNot }) => {
   docketEntryMustNot.push({
     term: { 'isSealed.BOOL': true },
   });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
@@ -1,13 +1,12 @@
-exports.getSealedQuery = ({ caseQueryParams, documentMustNot }) => {
-  documentMustNot.push({
-    term: { 'isSealed.BOOL': true },
-  });
+exports.getSealedQuery = () => {
+  const sealedDocumentMustNotQuery = [
+    {
+      term: { 'isSealed.BOOL': true },
+    },
+    { term: { 'sealedTo.S': 'External' } },
+  ];
 
-  documentMustNot.push({
-    term: { 'sealedTo.S': 'External' },
-  });
-
-  caseQueryParams.has_parent.query.bool.filter.push({
+  const sealedCaseQuery = {
     bool: {
       must: [
         {
@@ -33,5 +32,7 @@ exports.getSealedQuery = ({ caseQueryParams, documentMustNot }) => {
         },
       ],
     },
-  });
+  };
+
+  return { sealedCaseQuery, sealedDocumentMustNotQuery };
 };

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
@@ -1,9 +1,9 @@
-exports.getSealedQuery = ({ caseQueryParams, docketEntryMustNot }) => {
-  docketEntryMustNot.push({
+exports.getSealedQuery = ({ caseQueryParams, documentMustNotQuery }) => {
+  documentMustNotQuery.push({
     term: { 'isSealed.BOOL': true },
   });
 
-  docketEntryMustNot.push({
+  documentMustNotQuery.push({
     term: { 'sealedTo.S': 'External' },
   });
 

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
@@ -2,6 +2,7 @@ exports.getSealedQuery = ({ caseQueryParams, docketEntryMustNot }) => {
   docketEntryMustNot.push({
     term: { 'isSealed.BOOL': true },
   });
+
   docketEntryMustNot.push({
     term: { 'sealedTo.S': 'External' },
   });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.js
@@ -1,9 +1,9 @@
-exports.getSealedQuery = ({ caseQueryParams, documentMustNotQuery }) => {
-  documentMustNotQuery.push({
+exports.getSealedQuery = ({ caseQueryParams, documentMustNot }) => {
+  documentMustNot.push({
     term: { 'isSealed.BOOL': true },
   });
 
-  documentMustNotQuery.push({
+  documentMustNot.push({
     term: { 'sealedTo.S': 'External' },
   });
 

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
@@ -1,7 +1,7 @@
-const { getSealedQuery } = require('./getSealedQuery');
+import { getSealedQuery } from './getSealedQuery';
 
 describe('getSealedQuery', () => {
-  it.skip('searches for a case that either must be isSealed: false OR isSealed field should not exist', async () => {
+  it('searches for a case that either must be isSealed: false OR isSealed field should not exist', async () => {
     let mockCaseQueryParams = {
       has_parent: { query: { bool: { filter: [] } } },
     };
@@ -12,33 +12,35 @@ describe('getSealedQuery', () => {
       docketEntryMustNot: mockDocketEntryMustNot,
     });
 
-    expect(mockCaseQueryParams.has_parent.query.bool.filter).toMatchObject({
-      bool: {
-        must: [
-          {
-            bool: {
-              minimum_should_match: 1,
-              should: [
-                {
-                  bool: {
-                    must: {
-                      term: { 'isSealed.BOOL': false },
+    expect(mockCaseQueryParams.has_parent.query.bool.filter).toEqual([
+      {
+        bool: {
+          must: [
+            {
+              bool: {
+                minimum_should_match: 1,
+                should: [
+                  {
+                    bool: {
+                      must: {
+                        term: { 'isSealed.BOOL': false },
+                      },
                     },
                   },
-                },
-                {
-                  bool: {
-                    must_not: {
-                      exists: { field: 'isSealed' },
+                  {
+                    bool: {
+                      must_not: {
+                        exists: { field: 'isSealed' },
+                      },
                     },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    });
+    ]);
   });
 
   it('searches for docket entries that are not sealed AND not sealed to "External"', async () => {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
@@ -1,60 +1,42 @@
 const { getSealedQuery } = require('./getSealedQuery');
 
 describe('getSealedQuery', () => {
-  it('searches for a case that either must be isSealed: false OR isSealed field should not exist', () => {
-    let mockCaseQueryParams = {
-      has_parent: { query: { bool: { filter: [] } } },
-    };
-    let mockDocumentMustNot = [];
+  it('returns a query for cases where they either must have "isSealed: false" OR the isSealed field should not exist', () => {
+    const result = getSealedQuery();
 
-    getSealedQuery({
-      caseQueryParams: mockCaseQueryParams,
-      documentMustNot: mockDocumentMustNot,
-    });
-
-    expect(mockCaseQueryParams.has_parent.query.bool.filter).toEqual([
-      {
-        bool: {
-          must: [
-            {
-              bool: {
-                minimum_should_match: 1,
-                should: [
-                  {
-                    bool: {
-                      must: {
-                        term: { 'isSealed.BOOL': false },
-                      },
+    expect(result.sealedCaseQuery).toEqual({
+      bool: {
+        must: [
+          {
+            bool: {
+              minimum_should_match: 1,
+              should: [
+                {
+                  bool: {
+                    must: {
+                      term: { 'isSealed.BOOL': false },
                     },
                   },
-                  {
-                    bool: {
-                      must_not: {
-                        exists: { field: 'isSealed' },
-                      },
+                },
+                {
+                  bool: {
+                    must_not: {
+                      exists: { field: 'isSealed' },
                     },
                   },
-                ],
-              },
+                },
+              ],
             },
-          ],
-        },
+          },
+        ],
       },
-    ]);
+    });
   });
 
-  it('searches for docket entries that are not sealed AND not sealed to "External"', async () => {
-    let mockCaseQueryParams = {
-      has_parent: { query: { bool: { filter: [] } } },
-    };
-    let mockDocumentMustNot = [];
+  it('returns a query for docket entries to not be sealed AND not sealed to "External"', () => {
+    const result = getSealedQuery();
 
-    await getSealedQuery({
-      caseQueryParams: mockCaseQueryParams,
-      documentMustNot: mockDocumentMustNot,
-    });
-
-    expect(mockDocumentMustNot).toEqual([
+    expect(result.sealedDocumentMustNotQuery).toEqual([
       { term: { 'isSealed.BOOL': true } },
       { term: { 'sealedTo.S': 'External' } },
     ]);

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
@@ -1,7 +1,7 @@
 import { getSealedQuery } from './getSealedQuery';
 
 describe('getSealedQuery', () => {
-  it('searches for a case that either must be isSealed: false OR isSealed field should not exist', async () => {
+  it('searches for a case that either must be isSealed: false OR isSealed field should not exist', () => {
     let mockCaseQueryParams = {
       has_parent: { query: { bool: { filter: [] } } },
     };

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
@@ -1,0 +1,60 @@
+const { getSealedQuery } = require('./getSealedQuery');
+
+describe('getSealedQuery', () => {
+  it.skip('searches for a case that either must be isSealed: false OR isSealed field should not exist', async () => {
+    let mockCaseQueryParams = {
+      has_parent: { query: { bool: { filter: [] } } },
+    };
+    let mockDocketEntryMustNot = [];
+
+    getSealedQuery({
+      caseQueryParams: mockCaseQueryParams,
+      docketEntryMustNot: mockDocketEntryMustNot,
+    });
+
+    expect(mockCaseQueryParams.has_parent.query.bool.filter).toMatchObject({
+      bool: {
+        must: [
+          {
+            bool: {
+              minimum_should_match: 1,
+              should: [
+                {
+                  bool: {
+                    must: {
+                      term: { 'isSealed.BOOL': false },
+                    },
+                  },
+                },
+                {
+                  bool: {
+                    must_not: {
+                      exists: { field: 'isSealed' },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('searches for docket entries that are not sealed AND not sealed to "External"', async () => {
+    let mockCaseQueryParams = {
+      has_parent: { query: { bool: { filter: [] } } },
+    };
+    let mockDocketEntryMustNot = [];
+
+    await getSealedQuery({
+      caseQueryParams: mockCaseQueryParams,
+      docketEntryMustNot: mockDocketEntryMustNot,
+    });
+
+    expect(mockDocketEntryMustNot).toEqual([
+      { term: { 'isSealed.BOOL': true } },
+      { term: { 'sealedTo.S': 'External' } },
+    ]);
+  });
+});

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
@@ -1,4 +1,4 @@
-import { getSealedQuery } from './getSealedQuery';
+const { getSealedQuery } = require('./getSealedQuery');
 
 describe('getSealedQuery', () => {
   it('searches for a case that either must be isSealed: false OR isSealed field should not exist', () => {

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSealedQuery.test.js
@@ -5,11 +5,11 @@ describe('getSealedQuery', () => {
     let mockCaseQueryParams = {
       has_parent: { query: { bool: { filter: [] } } },
     };
-    let mockDocketEntryMustNot = [];
+    let mockDocumentMustNot = [];
 
     getSealedQuery({
       caseQueryParams: mockCaseQueryParams,
-      docketEntryMustNot: mockDocketEntryMustNot,
+      documentMustNot: mockDocumentMustNot,
     });
 
     expect(mockCaseQueryParams.has_parent.query.bool.filter).toEqual([
@@ -47,14 +47,14 @@ describe('getSealedQuery', () => {
     let mockCaseQueryParams = {
       has_parent: { query: { bool: { filter: [] } } },
     };
-    let mockDocketEntryMustNot = [];
+    let mockDocumentMustNot = [];
 
     await getSealedQuery({
       caseQueryParams: mockCaseQueryParams,
-      docketEntryMustNot: mockDocketEntryMustNot,
+      documentMustNot: mockDocumentMustNot,
     });
 
-    expect(mockDocketEntryMustNot).toEqual([
+    expect(mockDocumentMustNot).toEqual([
       { term: { 'isSealed.BOOL': true } },
       { term: { 'sealedTo.S': 'External' } },
     ]);

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
@@ -1,0 +1,31 @@
+const {
+  DOCUMENT_SEARCH_SORT,
+} = require('../../../business/entities/EntityConstants');
+
+export const getSortQuery = sortField => {
+  let sort;
+  let sortOrder = 'desc';
+
+  if (
+    [
+      DOCUMENT_SEARCH_SORT.FILING_DATE_ASC,
+      DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC,
+    ].includes(sortField)
+  ) {
+    sortOrder = 'asc';
+  }
+
+  switch (sortField) {
+    case DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC: // fall through
+    case DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_DESC:
+      sort = [{ 'numberOfPages.N': sortOrder }];
+      break;
+    case DOCUMENT_SEARCH_SORT.FILING_DATE_ASC: // fall through
+    case DOCUMENT_SEARCH_SORT.FILING_DATE_DESC: // fall through
+    default:
+      sort = [{ 'filingDate.S': sortOrder }];
+      break;
+  }
+
+  return sort;
+};

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
@@ -1,4 +1,6 @@
-import { DOCUMENT_SEARCH_SORT } from '../../../business/entities/EntityConstants';
+const {
+  DOCUMENT_SEARCH_SORT,
+} = require('../../../business/entities/EntityConstants');
 
 exports.getSortQuery = sortField => {
   let sort;

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
@@ -2,7 +2,7 @@ const {
   DOCUMENT_SEARCH_SORT,
 } = require('../../../business/entities/EntityConstants');
 
-export const getSortQuery = sortField => {
+exports.getSortQuery = sortField => {
   let sort;
   let sortOrder = 'desc';
 

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.js
@@ -1,6 +1,4 @@
-const {
-  DOCUMENT_SEARCH_SORT,
-} = require('../../../business/entities/EntityConstants');
+import { DOCUMENT_SEARCH_SORT } from '../../../business/entities/EntityConstants';
 
 exports.getSortQuery = sortField => {
   let sort;

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.test.js
@@ -1,0 +1,32 @@
+import { DOCUMENT_SEARCH_SORT } from '../../../business/entities/EntityConstants';
+import { getSortQuery } from './getSortQuery';
+
+describe('getSortQuery', () => {
+  it('sets sort to numberOfPages: asc when sortField is "DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC"', () => {
+    expect(getSortQuery(DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC)).toEqual([
+      { 'numberOfPages.N': 'asc' },
+    ]);
+  });
+
+  it('sets sort to numberOfPages: asc when sortField is "DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_DESC"', () => {
+    expect(getSortQuery(DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_DESC)).toEqual([
+      { 'numberOfPages.N': 'desc' },
+    ]);
+  });
+
+  it('sets sort to filingDate: desc when sortField is "DOCUMENT_SEARCH_SORT.FILING_DATE_ASC"', () => {
+    expect(getSortQuery(DOCUMENT_SEARCH_SORT.FILING_DATE_ASC)).toEqual([
+      { 'filingDate.S': 'asc' },
+    ]);
+  });
+
+  it('sets sort to filingDate: desc when sortField is "DOCUMENT_SEARCH_SORT.FILING_DATE_DESC"', () => {
+    expect(getSortQuery(DOCUMENT_SEARCH_SORT.FILING_DATE_DESC)).toEqual([
+      { 'filingDate.S': 'desc' },
+    ]);
+  });
+
+  it('sets sort to filingDate: desc by default', () => {
+    expect(getSortQuery('TRASH')).toEqual([{ 'filingDate.S': 'desc' }]);
+  });
+});

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearchHelpers/getSortQuery.test.js
@@ -1,5 +1,7 @@
-import { DOCUMENT_SEARCH_SORT } from '../../../business/entities/EntityConstants';
-import { getSortQuery } from './getSortQuery';
+const {
+  DOCUMENT_SEARCH_SORT,
+} = require('../../../business/entities/EntityConstants');
+const { getSortQuery } = require('./getSortQuery');
 
 describe('getSortQuery', () => {
   it('sets sort to numberOfPages: asc when sortField is "DOCUMENT_SEARCH_SORT.NUMBER_OF_PAGES_ASC"', () => {

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -17,14 +17,14 @@ const allowAccessOriginFunction = (origin, callback) => {
     return;
   }
 
-  //if the backend is running locally or if an official deployed frontend called the backend, parrot out the Origin
+  //if the backend is running locally or if an official deployed front-end called the backend, parrot out the Origin
   //this is required for the browser to support receiving and sending cookies
   if (process.env.IS_LOCAL || origin.includes(process.env.EFCMS_DOMAIN)) {
     callback(null, origin);
     return;
   }
 
-  //some unknown frontend called us
+  //some unknown front-end called us
   callback(null, '*');
 };
 

--- a/web-client/integration-tests/admissionsClerkPractitionerJourney.test.js
+++ b/web-client/integration-tests/admissionsClerkPractitionerJourney.test.js
@@ -17,7 +17,12 @@ import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkA
 import { petitionsClerkServesPetitionFromDocumentView } from './journey/petitionsClerkServesPetitionFromDocumentView';
 import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCaseDetail';
 
-const cerebralTest = setupTest();
+const CASE_SEARCH_PAGE_SIZE_OVERRIDE = 1;
+const cerebralTest = setupTest({
+  constantsOverrides: {
+    CASE_SEARCH_PAGE_SIZE: CASE_SEARCH_PAGE_SIZE_OVERRIDE,
+  },
+});
 
 describe('admissions clerk practitioner journey', () => {
   const { COUNTRY_TYPES, PARTY_TYPES, SERVICE_INDICATOR_TYPES } =

--- a/web-client/integration-tests/admissionsClerkPractitionerJourney.test.js
+++ b/web-client/integration-tests/admissionsClerkPractitionerJourney.test.js
@@ -17,10 +17,9 @@ import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkA
 import { petitionsClerkServesPetitionFromDocumentView } from './journey/petitionsClerkServesPetitionFromDocumentView';
 import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCaseDetail';
 
-const CASE_SEARCH_PAGE_SIZE_OVERRIDE = 1;
 const cerebralTest = setupTest({
   constantsOverrides: {
-    CASE_SEARCH_PAGE_SIZE: CASE_SEARCH_PAGE_SIZE_OVERRIDE,
+    CASE_SEARCH_PAGE_SIZE: 1,
   },
 });
 

--- a/web-client/integration-tests/caseDeadlineReportJourney.test.js
+++ b/web-client/integration-tests/caseDeadlineReportJourney.test.js
@@ -8,7 +8,11 @@ import {
 import { petitionsClerkCreatesACaseDeadline } from './journey/petitionsClerkCreatesACaseDeadline';
 import { petitionsClerkViewsDeadlineReport } from './journey/petitionsClerkViewsDeadlineReport';
 
-const cerebralTest = setupTest();
+const cerebralTest = setupTest({
+  constantsOverrides: {
+    DEADLINE_REPORT_PAGE_SIZE: 1,
+  },
+});
 
 describe('Case deadline report journey', () => {
   const randomDay = `1${Math.floor(Math.random() * 9) + 1}`;

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -762,7 +762,6 @@ export const setupTest = ({ useCases = {} } = {}) => {
   };
 
   const constantsOverrides = {
-    CASE_SEARCH_PAGE_SIZE: 1,
     DEADLINE_REPORT_PAGE_SIZE: 1,
   };
   const originalConstants = applicationContext.getConstants();

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -665,7 +665,7 @@ export const loginAs = (cerebralTest, user) =>
     expect(cerebralTest.getState('user.email')).toBeDefined();
   });
 
-export const setupTest = ({ useCases = {} } = {}) => {
+export const setupTest = ({ useCases = {}, constantsOverrides = {} } = {}) => {
   let cerebralTest;
   global.FormData = FormDataHelper;
   global.Blob = () => {
@@ -761,9 +761,6 @@ export const setupTest = ({ useCases = {} } = {}) => {
     };
   };
 
-  const constantsOverrides = {
-    DEADLINE_REPORT_PAGE_SIZE: 1,
-  };
   const originalConstants = applicationContext.getConstants();
   presenter.providers.applicationContext.getConstants = () => {
     return {

--- a/web-client/integration-tests/journey/admissionsClerkSearchesForPractitionersByName.js
+++ b/web-client/integration-tests/journey/admissionsClerkSearchesForPractitionersByName.js
@@ -66,9 +66,23 @@ export const admissionsClerkSearchesForPractitionersByName = cerebralTest => {
         `searchResults.${ADVANCED_SEARCH_TABS.PRACTITIONER}`,
       ).length,
     ).toBeGreaterThan(0);
+
+    const CASE_SEARCH_PAGE_SIZE_OVERRIDE = 1;
+    cerebralTest.setState(
+      'constants.CASE_SEARCH_PAGE_SIZE',
+      CASE_SEARCH_PAGE_SIZE_OVERRIDE,
+    );
+
+    console.log('Before call to advancedSearchHelper');
+
     let helper = runCompute(withAppContextDecorator(advancedSearchHelper), {
       state: cerebralTest.getState(),
     });
+
+    console.log(
+      'state**** ',
+      cerebralTest.getState('constants.CASE_SEARCH_PAGE_SIZE'),
+    );
 
     expect(helper.formattedSearchResults.length).toEqual(
       cerebralTest.getState('constants.CASE_SEARCH_PAGE_SIZE'),

--- a/web-client/integration-tests/journey/admissionsClerkSearchesForPractitionersByName.js
+++ b/web-client/integration-tests/journey/admissionsClerkSearchesForPractitionersByName.js
@@ -67,22 +67,9 @@ export const admissionsClerkSearchesForPractitionersByName = cerebralTest => {
       ).length,
     ).toBeGreaterThan(0);
 
-    const CASE_SEARCH_PAGE_SIZE_OVERRIDE = 1;
-    cerebralTest.setState(
-      'constants.CASE_SEARCH_PAGE_SIZE',
-      CASE_SEARCH_PAGE_SIZE_OVERRIDE,
-    );
-
-    console.log('Before call to advancedSearchHelper');
-
     let helper = runCompute(withAppContextDecorator(advancedSearchHelper), {
       state: cerebralTest.getState(),
     });
-
-    console.log(
-      'state**** ',
-      cerebralTest.getState('constants.CASE_SEARCH_PAGE_SIZE'),
-    );
 
     expect(helper.formattedSearchResults.length).toEqual(
       cerebralTest.getState('constants.CASE_SEARCH_PAGE_SIZE'),

--- a/web-client/integration-tests/viewManageDeadlinesOfCase.test.js
+++ b/web-client/integration-tests/viewManageDeadlinesOfCase.test.js
@@ -6,7 +6,11 @@ import { petitionsClerkViewCaseDeadline } from './journey/petitionsClerkViewCase
 import { petitionsClerkViewsCaseWithNoDeadlines } from './journey/petitionsClerkViewsCaseWithNoDeadlines';
 import { petitionsClerkViewsDeadlineReportForSingleCase } from './journey/petitionsClerkViewsDeadlineReportForSingleCase';
 
-const cerebralTest = setupTest();
+const cerebralTest = setupTest({
+  constantsOverrides: {
+    DEADLINE_REPORT_PAGE_SIZE: 1,
+  },
+});
 
 describe('View and manage the deadlines of a case', () => {
   const randomDay = `0${Math.floor(Math.random() * 9) + 1}`;

--- a/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.js
+++ b/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.js
@@ -45,6 +45,8 @@ export const advancedSearchHelper = (get, applicationContext) => {
     showStateSelect: countryType === COUNTRY_TYPES.DOMESTIC,
   };
 
+  console.log('In Helper: ', CASE_SEARCH_PAGE_SIZE);
+
   if (searchResults) {
     const paginatedResults = paginationHelper(
       searchResults,

--- a/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.js
+++ b/web-client/src/presenter/computeds/AdvancedSearch/advancedSearchHelper.js
@@ -45,8 +45,6 @@ export const advancedSearchHelper = (get, applicationContext) => {
     showStateSelect: countryType === COUNTRY_TYPES.DOMESTIC,
   };
 
-  console.log('In Helper: ', CASE_SEARCH_PAGE_SIZE);
-
   if (searchResults) {
     const paginatedResults = paginationHelper(
       searchResults,


### PR DESCRIPTION
- Extract methods from advancedDocumentSearch including: getSortQuery, getSealedQuery, getJudgeFilterForOrderSearch, getJudgeFilterForOpinionSearch and added unit tests
- Consolidate naming in advancedDocumentSearch to use document instead of docketEntry
- Use documentEventCodes for both opinionTypes AND order event codes which cleans up duplication
- Rename sortOrder to sortField, which is more accurate to what it's used for
- Move variable declarations closer to invocations
- Change judge filtering for order & opinion search to be in the documentQuery.filter instead of documentQuery.must since scoring shouldn't be needed for judge names.