### PR TITLE
Fix migration: Always send at least one message to the migration-segments queue 

### DIFF
--- a/web-api/send-migration-segment-messages.js
+++ b/web-api/send-migration-segment-messages.js
@@ -41,7 +41,7 @@ let sent = 0;
 (async () => {
   const itemCount = await getItemCount();
 
-  const totalSegments = Math.ceil(itemCount / SEGMENT_SIZE);
+  const totalSegments = Math.max(1, Math.ceil(itemCount / SEGMENT_SIZE));
 
   const segments = shuffle(
     new Array(totalSegments).fill(null).map((v, i) => ({


### PR DESCRIPTION
Dynamo live count is at least 6 hours behind (probably more) so experimental environment deploys running a migration were often failing because the "live count" was 0 and therefore our code thought there were no items to migrate. This change ensures that even if Dynamo thinks there are no items in the table, at least one message is sent.