### PR TITLE
9479 date validation

### DIFF
--- a/shared/src/business/entities/Stamp.js
+++ b/shared/src/business/entities/Stamp.js
@@ -1,8 +1,8 @@
 const joi = require('joi');
 const {
+  createISODateAtStartOfDayEST,
   formatDateString,
   FORMATS,
-  getMidnightIsoDateString,
 } = require('../utilities/DateHandler');
 const {
   joiValidationDecorator,
@@ -12,7 +12,7 @@ const { JoiValidationConstants } = require('./JoiValidationConstants');
 const { MOTION_STATUSES } = require('./EntityConstants');
 
 const todayFormatted = formatDateString(
-  getMidnightIsoDateString(),
+  createISODateAtStartOfDayEST(),
   FORMATS.ISO,
 );
 

--- a/shared/src/business/entities/Stamp.test.js
+++ b/shared/src/business/entities/Stamp.test.js
@@ -1,9 +1,9 @@
 const {
   calculateISODate,
+  createISODateAtStartOfDayEST,
   createISODateString,
   formatDateString,
   FORMATS,
-  getMidnightIsoDateString,
 } = require('../utilities/DateHandler');
 const { formatNow } = require('../utilities/DateHandler');
 const { MOTION_STATUSES } = require('./EntityConstants');
@@ -22,7 +22,7 @@ describe('Stamp entity', () => {
     });
 
     it('should be invalid when date is yesterday', () => {
-      let yesterdayIso = getMidnightIsoDateString();
+      let yesterdayIso = createISODateAtStartOfDayEST();
       yesterdayIso = calculateISODate({
         dateString: yesterdayIso,
         howMuch: -1,

--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -336,9 +336,6 @@ const createTestApplicationContext = ({ user } = {}) => {
       .fn()
       .mockImplementation(getFormattedPartiesNameAndTitle),
     getJudgeLastName: jest.fn().mockImplementation(getJudgeLastName),
-    getMidnightIsoDateString: jest
-      .fn()
-      .mockImplementation(DateHandler.getMidnightIsoDateString),
     getMonthDayYearInETObj: jest
       .fn()
       .mockImplementation(DateHandler.getMonthDayYearInETObj),

--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -119,16 +119,6 @@ const calculateISODate = ({ dateString, howMuch = 0, units = 'days' }) => {
 };
 
 /**
- * getMidnightIsoDateString
- *
- * @returns {string} the ISO formatted date set at midnight UTC of today
- */
-const getMidnightIsoDateString = () => {
-  const midnight = DateTime.now().setZone('utc').startOf('days');
-  return midnight.toISO();
-};
-
-/**
  * @param {string} dateString a date string to be sent to persistence
  * @param {string} inputFormat optional parameter containing hints on how to parse dateString
  * @returns {string} a formatted ISO date string
@@ -145,6 +135,12 @@ const createISODateString = (dateString, inputFormat) => {
   return result && result.setZone('utc').toISO();
 };
 
+/**
+ * createISODateAtStartOfDayEST
+ *
+ * @param {string} dateString a date string to be updated to ISO in USTC_TZ (ET)
+ * @returns {string} the ISO formatted date set at midnight of today USTC_TZ (ET)
+ */
 const createISODateAtStartOfDayEST = dateString => {
   const dtObj = dateString
     ? DateTime.fromISO(dateString, { zone: USTC_TZ })
@@ -515,7 +511,6 @@ module.exports = {
   formatDateString,
   formatNow,
   getBusinessDateInFuture,
-  getMidnightIsoDateString,
   getMonthDayYearInETObj,
   isStringISOFormatted,
   isValidDateString,

--- a/shared/src/business/utilities/DateHandler.test.js
+++ b/shared/src/business/utilities/DateHandler.test.js
@@ -5,7 +5,7 @@ const { FORMATS, PATTERNS } = DateHandler;
 describe('DateHandler', () => {
   // Takes an ISO-8601 timestamp representing UTC and temporarily
   // mocks the system's current time by overriding global Date implementation
-  const setupTeardownTestsForMockDate = isoTimestamp => {
+  const setupMockTestCurrentTime = isoTimestamp => {
     const originalDateImpl = Date.now.bind(global.Date);
     const dateNowMock = jest.fn();
 
@@ -242,9 +242,7 @@ describe('DateHandler', () => {
 
   describe('createISODateAtStartOfDayEST', () => {
     describe('around midnight', () => {
-      const mockTimeFunc = setupTeardownTestsForMockDate(
-        '2021-10-07T00:31:51.621Z',
-      );
+      const mockTimeFunc = setupMockTestCurrentTime('2021-10-07T00:31:51.621Z');
       beforeAll(mockTimeFunc.setupDateMock);
       afterAll(mockTimeFunc.restoreDateMock);
 
@@ -525,9 +523,7 @@ describe('DateHandler', () => {
     });
 
     it('takes no arguments to create an object with keys month, day, and year according to Eastern Time with numeric strings', () => {
-      const mockTimeFunc = setupTeardownTestsForMockDate(
-        '2021-10-07T00:31:51.621Z',
-      );
+      const mockTimeFunc = setupMockTestCurrentTime('2021-10-07T00:31:51.621Z');
 
       mockTimeFunc.setupDateMock();
       const result = DateHandler.getMonthDayYearInETObj();

--- a/shared/src/business/utilities/DateHandler.test.js
+++ b/shared/src/business/utilities/DateHandler.test.js
@@ -3,6 +3,27 @@ const DateHandler = require('./DateHandler');
 const { FORMATS, PATTERNS } = DateHandler;
 
 describe('DateHandler', () => {
+  // Takes an ISO-8601 timestamp representing UTC and temporarily
+  //  mocks the system's current time by overriding global Date implementation
+  const setupTeardownTestsForMockDate = isoTimestamp => {
+    const originalDateImpl = Date.now.bind(global.Date);
+    const dateNowMock = jest.fn();
+
+    const setDateMockValue = timestamp => {
+      // eslint-disable-next-line @miovision/disallow-date/no-new-date
+      dateNowMock.mockReturnValue(new Date(timestamp).valueOf());
+    };
+    const setupDateMock = () => {
+      setDateMockValue(isoTimestamp);
+      global.Date.now = dateNowMock;
+    };
+    const restoreDateMock = () => {
+      global.Date.now = originalDateImpl;
+    };
+
+    return { restoreDateMock, setDateMockValue, setupDateMock };
+  };
+
   describe('combine ISO date and EST time', () => {
     it('should combine ISO datestamp and a string representing hours and minutes in Eastern time', () => {
       const inputISO = '2021-11-11T05:00:00.000Z';
@@ -218,7 +239,37 @@ describe('DateHandler', () => {
       expect(formattedInEastern).toEqual('04/07/20 11:59 pm'); // the moment before midnight the next day
     });
   });
+
   describe('createISODateAtStartOfDayEST', () => {
+    describe('around midnight', () => {
+      const mockTimeFunc = setupTeardownTestsForMockDate(
+        '2021-10-07T00:31:51.621Z',
+      );
+      beforeAll(mockTimeFunc.setupDateMock);
+      afterAll(mockTimeFunc.restoreDateMock);
+
+      const midnightTests = [
+        // input in ISO UTC, output in ET start of day
+        ['2021-10-07T00:31:51.621Z', '2021-10-06T04:00:00.000Z'], // 10/6 at midnight ET
+        ['2021-10-07T11:01:51.621Z', '2021-10-07T04:00:00.000Z'],
+        ['2022-01-01T01:02:21.729Z', '2021-12-31T05:00:00.000Z'], // Jan 1 at 1am UTC is still Dec 31 ET
+      ];
+
+      midnightTests.forEach(([input, output]) => {
+        it(`gets an ISO Date String representing Midnight when given ${input}`, () => {
+          const result = DateHandler.createISODateAtStartOfDayEST(input);
+          expect(result).toBe(output);
+        });
+      });
+
+      it('gets an ISO Date String representing today at Midnight when given no arguments', () => {
+        const sameDay = '2022-07-16';
+        mockTimeFunc.setDateMockValue(`${sameDay}T18:54:00.000Z`);
+        const result = DateHandler.createISODateAtStartOfDayEST();
+        expect(result).toBe(`${sameDay}T04:00:00.000Z`);
+      });
+    });
+
     it('creates a timestamp at start of day EST when provided YYYY-MM-DD', () => {
       const myDate = DateHandler.createISODateAtStartOfDayEST('2020-03-15');
       expect(myDate).toEqual('2020-03-15T04:00:00.000Z');

--- a/shared/src/business/utilities/DateHandler.test.js
+++ b/shared/src/business/utilities/DateHandler.test.js
@@ -4,7 +4,7 @@ const { FORMATS, PATTERNS } = DateHandler;
 
 describe('DateHandler', () => {
   // Takes an ISO-8601 timestamp representing UTC and temporarily
-  //  mocks the system's current time by overriding global Date implementation
+  // mocks the system's current time by overriding global Date implementation
   const setupTeardownTestsForMockDate = isoTimestamp => {
     const originalDateImpl = Date.now.bind(global.Date);
     const dateNowMock = jest.fn();
@@ -523,18 +523,15 @@ describe('DateHandler', () => {
         },
       });
     });
+
     it('takes no arguments to create an object with keys month, day, and year according to Eastern Time with numeric strings', () => {
-      // mock the date implementation and returning original value upon test completion
-      const mockTimeValue = 1633566711621; // Thu, 07 Oct 2021 00:31:51 GMT
+      const mockTimeFunc = setupTeardownTestsForMockDate(
+        '2021-10-07T00:31:51.621Z',
+      );
 
-      const realDateNow = Date.now.bind(global.Date);
-      const dateNowStub = jest.fn().mockReturnValue(mockTimeValue);
-      global.Date.now = dateNowStub;
-
+      mockTimeFunc.setupDateMock();
       const result = DateHandler.getMonthDayYearInETObj();
-      expect(dateNowStub).toHaveBeenCalled();
-
-      global.Date.now = realDateNow;
+      mockTimeFunc.restoreDateMock();
 
       expect(result).toEqual({
         day: '6',


### PR DESCRIPTION
- Remove `getMidnightIsoDateString` and instead use existing `createISODateAtStartOfDayEST`
- More specific tests around checking `createISODateAtStartOfDayEST` output is correct around midnight 

Thanks so much @kkoskelin!