### PR TITLE
9479: Set width on usa-date-picker__calendar

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -565,6 +565,10 @@ label.ustc-upload {
   .usa-date-picker__button {
     margin-top: 0;
   }
+
+  .usa-date-picker__calendar {
+    width: 250%;
+  }
 }
 
 .usa-date-range-picker.grid-row {


### PR DESCRIPTION
# Problem
The date picker component relies upon the width of the `DateInput` component (one level up) and so when the date field on a form is made more narrow, the calendar may also be made smaller as can be seen below:
![Screen Shot 2022-07-19 at 5 57 59 PM](https://user-images.githubusercontent.com/12275865/179862358-d37aedee-2bc7-4f1e-9be0-4e1deade6f91.png)

# Possible Solution
Add a `width` property under the `.usa-date-picker__calendar` element to `forms.scss`. It seems that the width needs to be `>=` 213% to not be limited by the width of this specific use of `DateInput`. While the current use is probably about as narrow as we'll go for the input, this is not a very strong solution. I would prefer to allow the width to be separated from the container or to have its container not be a `flex` container. The problem with that is that I cannot find where this container, `usa-date-picker__wrapper`, is even defined.
![Screen Shot 2022-07-19 at 5 57 24 PM](https://user-images.githubusercontent.com/12275865/179862367-f5bbf386-27aa-4a17-b62c-0d244fa5d2bb.png)

# Another Option
#9546