### PR TITLE
9479 date picker wrapper size

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -546,6 +546,11 @@ label.ustc-upload {
     .usa-date-picker__button {
       width: 40px;
     }
+
+    .usa-date-picker__calendar {
+      right: auto;
+      left: 200px;
+    }
   }
 
   .narrow-hr {

--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -565,6 +565,10 @@ label.ustc-upload {
   .usa-date-picker__button {
     margin-top: 0;
   }
+
+  .usa-date-picker__calendar {
+    width: 250%;
+  }
 }
 
 .usa-date-range-picker.grid-row {

--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -533,8 +533,18 @@ label.ustc-upload {
       margin: 0;
     }
 
-    .width-150 {
-      width: 150px;
+    .usa-date-picker__wrapper {
+      width: 350px;
+      justify-content: flex-end;
+      margin-left: -200px;
+    }
+
+    .usa-date-picker__external-input {
+      width: 110px;
+    }
+
+    .usa-date-picker__button {
+      width: 40px;
     }
   }
 
@@ -564,10 +574,6 @@ label.ustc-upload {
 
   .usa-date-picker__button {
     margin-top: 0;
-  }
-
-  .usa-date-picker__calendar {
-    width: 250%;
   }
 }
 

--- a/web-client/src/views/StampMotion/ApplyStamp.jsx
+++ b/web-client/src/views/StampMotion/ApplyStamp.jsx
@@ -381,7 +381,7 @@ export const ApplyStamp = connect(
                       >
                         The parties shall file a status report by{' '}
                         <DateInput
-                          className="display-inline-block width-150 padding-0"
+                          className="display-inline-block padding-0"
                           disabled={
                             form.dueDateMessage !==
                             'The parties shall file a status report by'
@@ -442,7 +442,7 @@ export const ApplyStamp = connect(
                         The parties shall file a status report or proposed
                         stipulated decision by{' '}
                         <DateInput
-                          className="display-inline-block width-150 padding-0"
+                          className="display-inline-block padding-0"
                           disabled={
                             form.dueDateMessage !==
                             'The parties shall file a status report or proposed stipulated decision by'


### PR DESCRIPTION
# Problem
The date picker component relies upon the width of the `DateInput` component (one level up) and so when the date field on a form is made more narrow, the calendar may also be made smaller as can be seen below:
![Screen Shot 2022-07-19 at 5 57 59 PM](https://user-images.githubusercontent.com/12275865/179862358-d37aedee-2bc7-4f1e-9be0-4e1deade6f91.png)

# Possible Solution
Instead of adding `width: 150px` to the DateInput component, explicitly set the width, justify-content, and margin-left of `usa-date-picker__wrapper`. This seems to never cause overlap between the date input and the rest of the label while resizing the page.
<img width="486" alt="Screen Shot 2022-07-19 at 9 31 09 PM" src="https://user-images.githubusercontent.com/12275865/179883300-90ea7e4e-dcaf-495a-a5b0-cb3cd5cae5ae.png">

# Another Option
#9545 