### PR TITLE
9479 status report due date alignment

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -551,6 +551,27 @@ label.ustc-upload {
       right: auto;
       left: 200px;
     }
+
+    &.radio-with-date-picker {
+      .usa-radio {
+        display: flex;
+        align-items: center;
+
+        .usa-radio__label {
+          align-items: center;
+
+          .label-text-with-date-picker {
+            display: inline;
+            min-height: 40px;
+          }
+        }
+
+        .usa-label {
+          display: none;
+          height: 0;
+        }
+      }
+    }
   }
 
   .narrow-hr {

--- a/web-client/src/views/StampMotion/ApplyStamp.jsx
+++ b/web-client/src/views/StampMotion/ApplyStamp.jsx
@@ -436,7 +436,7 @@ export const ApplyStamp = connect(
                         aria-describedby="dueDateMessage"
                         checked={
                           form.dueDateMessage ===
-                          'The parties shall file a status decision by'
+                          'The parties shall file a status report or proposed stipulated decision by'
                         }
                         className="usa-radio__input"
                         id="dueDateMessage-statusReportOrStipDecisionDueDate"

--- a/web-client/src/views/StampMotion/ApplyStamp.jsx
+++ b/web-client/src/views/StampMotion/ApplyStamp.jsx
@@ -6,6 +6,7 @@ import { FormGroup } from '../../ustc-ui/FormGroup/FormGroup';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React, { useEffect, useRef } from 'react';
+import classNames from 'classnames';
 
 export const ApplyStamp = connect(
   {
@@ -360,7 +361,10 @@ export const ApplyStamp = connect(
                   </FormGroup>
                   <hr className="narrow-hr" />
                   <FormGroup
-                    className={applyStampFormHelper.dateErrorClass}
+                    className={classNames(
+                      applyStampFormHelper.dateErrorClass,
+                      'radio-with-date-picker',
+                    )}
                     errorText={validationErrors.date}
                   >
                     <div className="usa-radio" key="statusReportDueDate">
@@ -389,35 +393,39 @@ export const ApplyStamp = connect(
                         htmlFor="dueDateMessage-statusReportDueDate"
                         id="dueDateMessage-statusReportDueDate-label"
                       >
-                        The parties shall file a status report by{' '}
-                        <DateInput
-                          className="display-inline-block padding-0"
-                          disabled={
-                            form.dueDateMessage !==
-                            'The parties shall file a status report by'
-                          }
-                          id="due-date-input-statusReportDueDate"
-                          minDate={applyStampFormHelper.minDate}
-                          names={{
-                            day: 'day',
-                            month: 'month',
-                            year: 'year',
-                          }}
-                          placeholder={'MM/DD/YYYY'}
-                          showDateHint={false}
-                          values={{
-                            day: form.day,
-                            month: form.month,
-                            year: form.year,
-                          }}
-                          onBlur={validateStampSequence}
-                          onChange={({ key, value }) => {
-                            updateFormValueSequence({
-                              key,
-                              value,
-                            });
-                          }}
-                        />
+                        <div className="label-text-with-date-picker">
+                          <span className="label-text">
+                            The parties shall file a status report by{' '}
+                          </span>
+                          <DateInput
+                            className="display-inline-block padding-0"
+                            disabled={
+                              form.dueDateMessage !==
+                              'The parties shall file a status report by'
+                            }
+                            id="due-date-input-statusReportDueDate"
+                            minDate={applyStampFormHelper.minDate}
+                            names={{
+                              day: 'day',
+                              month: 'month',
+                              year: 'year',
+                            }}
+                            placeholder={'MM/DD/YYYY'}
+                            showDateHint={false}
+                            values={{
+                              day: form.day,
+                              month: form.month,
+                              year: form.year,
+                            }}
+                            onBlur={validateStampSequence}
+                            onChange={({ key, value }) => {
+                              updateFormValueSequence({
+                                key,
+                                value,
+                              });
+                            }}
+                          />
+                        </div>
                       </label>
                     </div>
                     <div
@@ -428,7 +436,7 @@ export const ApplyStamp = connect(
                         aria-describedby="dueDateMessage"
                         checked={
                           form.dueDateMessage ===
-                          'The parties shall file a status report or proposed stipulated decision by'
+                          'The parties shall file a status decision by'
                         }
                         className="usa-radio__input"
                         id="dueDateMessage-statusReportOrStipDecisionDueDate"
@@ -449,36 +457,40 @@ export const ApplyStamp = connect(
                         htmlFor="dueDateMessage-statusReportOrStipDecisionDueDate"
                         id="dueDateMessage-statusReportOrStipDecisionDueDate-label"
                       >
-                        The parties shall file a status report or proposed
-                        stipulated decision by{' '}
-                        <DateInput
-                          className="display-inline-block padding-0"
-                          disabled={
-                            form.dueDateMessage !==
-                            'The parties shall file a status report or proposed stipulated decision by'
-                          }
-                          id="due-date-input-statusReportOrStipDecisionDueDate"
-                          minDate={applyStampFormHelper.minDate}
-                          names={{
-                            day: 'day',
-                            month: 'month',
-                            year: 'year',
-                          }}
-                          placeholder={'MM/DD/YYYY'}
-                          showDateHint={false}
-                          values={{
-                            day: form.day,
-                            month: form.month,
-                            year: form.year,
-                          }}
-                          onBlur={validateStampSequence}
-                          onChange={({ key, value }) => {
-                            updateFormValueSequence({
-                              key,
-                              value,
-                            });
-                          }}
-                        />
+                        <div className="label-text-with-date-picker">
+                          <span className="label-text">
+                            The parties shall file a status report or proposed
+                            stipulated decision by{' '}
+                          </span>
+                          <DateInput
+                            className="display-inline-block padding-0"
+                            disabled={
+                              form.dueDateMessage !==
+                              'The parties shall file a status report or proposed stipulated decision by'
+                            }
+                            id="due-date-input-statusReportOrStipDecisionDueDate"
+                            minDate={applyStampFormHelper.minDate}
+                            names={{
+                              day: 'day',
+                              month: 'month',
+                              year: 'year',
+                            }}
+                            placeholder={'MM/DD/YYYY'}
+                            showDateHint={false}
+                            values={{
+                              day: form.day,
+                              month: form.month,
+                              year: form.year,
+                            }}
+                            onBlur={validateStampSequence}
+                            onChange={({ key, value }) => {
+                              updateFormValueSequence({
+                                key,
+                                value,
+                              });
+                            }}
+                          />
+                        </div>
                       </label>
                     </div>
                   </FormGroup>


### PR DESCRIPTION
# Problem

The radio buttons for the status-report-related optional fields are aligned differently to their respective options. When the date picker is on the first line of label text, the radio button is too high.

# Cause

There are two main issues.

1. There is a non-visible element that is artificially increasing the height of the date input element
1. The `usa-radio__label` class has an effect on at least three elements:
    1. The radio button `::before`
    1. The text `No additional class`
    1. The date input element `usa-date-picker` 

Without being able to separately style the text, because it has no class which can be modified without also affecting the radio button and the date input, I have been unable to get the radio button aligned to the text.

# Solution

The general approach of this solution is to add some new classes that we use to only modify these particular fields because of the presence of the date input element in the label. The contents of the label are put into a flex container, but the non-radio-button portions must be `inline` in relation to each other, so there's another div with a new class to allow this while still getting the radio button to be centered with the rest.

![Screen Shot 2022-07-25 at 12 26 32 PM](https://user-images.githubusercontent.com/12275865/180838635-12092a63-d289-4d2b-b877-9b90e00e7d06.png)

