### PR TITLE
9479: Redirect to newly stamped draft

### DIFF
--- a/web-client/src/presenter/actions/completeMotionStampingAction.js
+++ b/web-client/src/presenter/actions/completeMotionStampingAction.js
@@ -19,7 +19,6 @@ export const completeMotionStampingAction = async ({
   const { docketNumber } = get(state.caseDetail);
   const stampFormData = get(state.form);
 
-  let docketEntryId;
   let newDocketEntryId;
 
   const { nameForSigning, nameForSigningLine2 } = get(state.pdfForSigning);
@@ -55,7 +54,7 @@ export const completeMotionStampingAction = async ({
   const redirectUrl = `/case-detail/${docketNumber}/draft-documents?docketEntryId=${newDocketEntryId}`;
 
   return {
-    docketEntryId,
+    docketEntryId: newDocketEntryId,
     docketNumber,
     redirectUrl,
     tab: 'docketRecord',

--- a/web-client/src/presenter/actions/completeMotionStampingAction.test.js
+++ b/web-client/src/presenter/actions/completeMotionStampingAction.test.js
@@ -98,4 +98,15 @@ describe('completeMotionStampingAction', () => {
       redirectUrl: `/case-detail/${docketNumber}/draft-documents?docketEntryId=${mockStampedDocketEntryId}`,
     });
   });
+
+  it('should return the stamped document docket entry id as props', async () => {
+    const result = await runAction(completeMotionStampingAction, {
+      modules: {
+        presenter,
+      },
+      state: mockState,
+    });
+
+    expect(result.output.docketEntryId).toEqual(mockStampedDocketEntryId);
+  });
 });


### PR DESCRIPTION
Redirect to the new draft instead of the first.