### PR TITLE
9479: Set custom text to '' and allow '' in validation

### DIFF
--- a/shared/src/business/entities/Stamp.js
+++ b/shared/src/business/entities/Stamp.js
@@ -54,7 +54,7 @@ Stamp.VALIDATION_ERROR_MESSAGES = {
 };
 
 Stamp.schema = joi.object().keys({
-  customText: JoiValidationConstants.STRING.max(60).optional(),
+  customText: JoiValidationConstants.STRING.max(60).optional().allow(''),
   date: joi.when('dueDateMessage', {
     is: joi.exist().not(null),
     otherwise: joi.optional().allow(null),

--- a/web-client/src/presenter/actions/StampMotion/clearOptionalFieldsStampFormAction.js
+++ b/web-client/src/presenter/actions/StampMotion/clearOptionalFieldsStampFormAction.js
@@ -11,7 +11,7 @@ export const clearOptionalFieldsStampFormAction = ({ store }) => {
   store.unset(state.form.jurisdictionalOption);
 
   store.unset(state.form.dueDateMessage);
-  store.unset(state.form.customText);
+  store.set(state.form.customText, '');
   store.unset(state.form['day']);
   store.unset(state.form['month']);
   store.unset(state.form['year']);

--- a/web-client/src/presenter/actions/StampMotion/clearOptionalFieldsStampFormAction.test.js
+++ b/web-client/src/presenter/actions/StampMotion/clearOptionalFieldsStampFormAction.test.js
@@ -25,6 +25,6 @@ describe('clearOptionalFieldsStampFormAction', () => {
     expect(state.form['month']).toBeUndefined();
     expect(state.form['year']).toBeUndefined();
 
-    expect(state.form.customText).toBeUndefined();
+    expect(state.form.customText).toEqual('');
   });
 });

--- a/web-client/src/ustc-ui/DateInput/DateInput.jsx
+++ b/web-client/src/ustc-ui/DateInput/DateInput.jsx
@@ -15,6 +15,7 @@ export const DateInput = props => {
     hideLegend,
     hintText,
     useHintNoWrap,
+    shouldClearHiddenInput,
     showDateHint,
     titleHintText,
     optional,
@@ -39,6 +40,7 @@ export const DateInput = props => {
       names={names}
       optional={optional}
       placeholder={placeholder}
+      shouldClearHiddenInput={shouldClearHiddenInput}
       showDateHint={showDateHint}
       titleHintText={titleHintText}
       useHintNoWrap={useHintNoWrap}

--- a/web-client/src/ustc-ui/DateInput/DatePickerComponent.jsx
+++ b/web-client/src/ustc-ui/DateInput/DatePickerComponent.jsx
@@ -51,6 +51,9 @@ export const DatePickerComponent = ({
     if (values.month && values.day && values.year) {
       input.value = `${values.month}/${values.day}/${values.year}`;
     } else {
+      // a hack because the inputRef points to the hidden input instead of the visible input on the page
+      const actualInput = window.document.getElementById(`${name}-date`);
+      actualInput.value = null;
       input.value = null;
     }
   }, [datePickerRef, values]);

--- a/web-client/src/ustc-ui/DateInput/DatePickerComponent.jsx
+++ b/web-client/src/ustc-ui/DateInput/DatePickerComponent.jsx
@@ -17,6 +17,7 @@ export const DatePickerComponent = ({
   onChange,
   optional,
   placeholder,
+  shouldClearHiddenInput,
   showDateHint = true,
   titleHintText,
   useHintNoWrap,
@@ -51,9 +52,11 @@ export const DatePickerComponent = ({
     if (values.month && values.day && values.year) {
       input.value = `${values.month}/${values.day}/${values.year}`;
     } else {
-      // a hack because the inputRef points to the hidden input instead of the visible input on the page
-      const actualInput = window.document.getElementById(`${name}-date`);
-      actualInput.value = null;
+      if (shouldClearHiddenInput) {
+        // a hack because the inputRef points to the hidden input instead of the visible input on the page
+        const actualInput = window.document.getElementById(`${name}-date`);
+        actualInput.value = null;
+      }
       input.value = null;
     }
   }, [datePickerRef, values]);

--- a/web-client/src/views/StampMotion/ApplyStamp.jsx
+++ b/web-client/src/views/StampMotion/ApplyStamp.jsx
@@ -329,6 +329,7 @@ export const ApplyStamp = connect(
                               year: 'year',
                             }}
                             placeholder={'MM/DD/YYYY'}
+                            shouldClearHiddenInput={true}
                             showDateHint={false}
                             values={{
                               day: form.day,


### PR DESCRIPTION
We need to set the customText to an empty string, but this causes validation failure so we need to allow a value of `''`.