### PR TITLE
9479: feedback from Demo: un-bold due date message, remove duplicate served date label from served Stamp Order

### DIFF
--- a/shared/src/business/useCases/generateStampedCoversheetInteractor.js
+++ b/shared/src/business/useCases/generateStampedCoversheetInteractor.js
@@ -17,6 +17,8 @@ exports.createStampedCoversheetPdf = async ({
   docketEntryEntity,
   stampData,
 }) => {
+  docketEntryEntity.servedAt = undefined;
+
   const coverSheetData = await generateCoverSheetData({
     applicationContext,
     caseEntity,

--- a/shared/src/business/useCases/generateStampedCoversheetInteractor.test.js
+++ b/shared/src/business/useCases/generateStampedCoversheetInteractor.test.js
@@ -15,10 +15,11 @@ describe('generateStampedCoversheetInteractor', () => {
         ...MOCK_CASE.docketEntries[0],
         certificateOfService: false,
         createdAt: '2019-04-19T14:45:15.595Z',
-        documentType: 'Answer',
-        eventCode: 'A',
+        documentType: 'Motion',
+        eventCode: 'M102',
         filingDate: '2019-04-19T14:45:15.595Z',
         isPaper: false,
+        servedAt: '2019-04-19T14:45:15.595Z',
       },
     ],
   };
@@ -33,6 +34,20 @@ describe('generateStampedCoversheetInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockReturnValue(mockCase);
+  });
+
+  it('clears the servedAt property of the motion docket entry used for coversheet generation', async () => {
+    await generateStampedCoversheetInteractor(applicationContext, {
+      docketEntryId: mockDocketEntryId,
+      docketNumber: MOCK_CASE.docketNumber,
+      stampData: mockStampData,
+      stampedDocketEntryId: mockStampedDocketEntryId,
+    });
+
+    expect(
+      applicationContext.getDocumentGenerators().coverSheet.mock.calls[0][0]
+        .data.dateServed,
+    ).toEqual('');
   });
 
   it('generates a stamped coversheet pdf document with stampData', async () => {

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.jsx
@@ -124,15 +124,13 @@ export const CoverSheet = ({
                 - {stamp.jurisdictionalOption} -<br />
               </>
             )}
-            <span className="text-bold">
-              {stamp.dueDateMessage && (
-                <>
-                  {stamp.dueDateMessage} {stamp.date}
-                  <br />
-                </>
-              )}
-              {stamp.customText}
-            </span>
+            {stamp.dueDateMessage && (
+              <>
+                {stamp.dueDateMessage} {stamp.date}
+                <br />
+              </>
+            )}
+            {stamp.customText}
             <hr className="narrow-hr" />
             <span className="text-bold" id="stamp-signature">
               (Signed) {stamp.nameForSigning}

--- a/web-client/src/views/StampMotion/ApplyStamp.jsx
+++ b/web-client/src/views/StampMotion/ApplyStamp.jsx
@@ -509,7 +509,7 @@ export const ApplyStamp = connect(
                             - {form.jurisdictionalOption} -<br />
                           </>
                         )}
-                        <span className="text-semibold">
+                        <span>
                           {form.day && (
                             <>
                               {form.dueDateMessage} {form.month}/{form.day}/


### PR DESCRIPTION
Apply stamp form no longer displays Proposed stip due date message + date in bold: 
![image](https://user-images.githubusercontent.com/20514925/182669857-7e589a80-d2d2-419f-905d-58a45f0b77f4.png)








Generated order no longer displays Proposed stip due date message + date in bold, no duplicate served at label:
![image](https://user-images.githubusercontent.com/20514925/182669968-69bdc7f0-2728-40de-8018-06d8ab25f573.png)
