### PR TITLE
9479: Give proper validation error for year less than 4 characters

### DIFF
--- a/cypress-integration/integration/date-picker-rejects-invalid-years.cy.js
+++ b/cypress-integration/integration/date-picker-rejects-invalid-years.cy.js
@@ -1,0 +1,17 @@
+describe('Date picker should replace years with fewer than 4 characters with empty string', () => {
+  before(() => {
+    cy.login('docketclerk');
+  });
+
+  it('should', () => {
+    cy.visit('case-detail/104-19/');
+    cy.get('#case-detail-menu-button').click();
+    cy.get('#menu-button-add-deadline').click();
+    cy.get('input#deadline-date-date').type('01/01/202');
+    cy.get('textarea#description').type('Test 3-digit year');
+    cy.get('#modal-button-confirm').click();
+    cy.get("span[class='usa-error-message']").contains(
+      'Enter a valid deadline date',
+    );
+  });
+});

--- a/web-client/src/ustc-ui/DateInput/DatePickerComponent.jsx
+++ b/web-client/src/ustc-ui/DateInput/DatePickerComponent.jsx
@@ -85,6 +85,9 @@ export const DatePickerComponent = ({
         if (month.length > 2) {
           [year, month, day] = splitDate(e.target.value);
         }
+        if (year.length < 4) {
+          year = '';
+        }
         onChange({
           key: names.day,
           value: day,


### PR DESCRIPTION
# Two-digit Year Gives Wrong Validation Error

Inputting the date with a two-digit year results in a date like `0022-09-21T04:56:02.000Z` which results in an error of the date being prior to today.

# Solution

Replace a year that is fewer than four digits with an empty string, which results in the `Enter a valid date` validation error as expected.