### PR TITLE
9479: Separate the due date input from the message radios

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -533,44 +533,8 @@ label.ustc-upload {
       margin: 0;
     }
 
-    .usa-date-picker__wrapper {
-      width: 350px;
-      justify-content: flex-end;
-      margin-left: -200px;
-    }
-
-    .usa-date-picker__external-input {
-      width: 110px;
-    }
-
-    .usa-date-picker__button {
-      width: 40px;
-    }
-
-    .usa-date-picker__calendar {
-      right: auto;
-      left: 200px;
-    }
-
-    &.radio-with-date-picker {
-      .usa-radio {
-        display: flex;
-        align-items: center;
-
-        .usa-radio__label {
-          align-items: center;
-
-          .label-text-with-date-picker {
-            display: inline;
-            min-height: 40px;
-          }
-        }
-
-        .usa-label {
-          display: none;
-          height: 0;
-        }
-      }
+    .width-150 {
+      width: 150px;
     }
   }
 

--- a/web-client/src/views/StampMotion/ApplyStamp.jsx
+++ b/web-client/src/views/StampMotion/ApplyStamp.jsx
@@ -6,7 +6,6 @@ import { FormGroup } from '../../ustc-ui/FormGroup/FormGroup';
 import { connect } from '@cerebral/react';
 import { sequences, state } from 'cerebral';
 import React, { useEffect, useRef } from 'react';
-import classNames from 'classnames';
 
 export const ApplyStamp = connect(
   {
@@ -279,10 +278,7 @@ export const ApplyStamp = connect(
                   </FormGroup>
                   <hr className="narrow-hr" />
                   <FormGroup
-                    className={classNames(
-                      applyStampFormHelper.dateErrorClass,
-                      'radio-with-date-picker',
-                    )}
+                    className={applyStampFormHelper.dateErrorClass}
                     errorText={validationErrors.date}
                   >
                     <div className="usa-radio" key="statusReportDueDate">
@@ -311,40 +307,7 @@ export const ApplyStamp = connect(
                         htmlFor="dueDateMessage-statusReportDueDate"
                         id="dueDateMessage-statusReportDueDate-label"
                       >
-                        <div className="label-text-with-date-picker">
-                          <span className="label-text">
-                            The parties shall file a status report by{' '}
-                          </span>
-                          <DateInput
-                            className="display-inline-block padding-0"
-                            disabled={
-                              form.dueDateMessage !==
-                              'The parties shall file a status report by'
-                            }
-                            id="due-date-input-statusReportDueDate"
-                            minDate={applyStampFormHelper.minDate}
-                            names={{
-                              day: 'day',
-                              month: 'month',
-                              year: 'year',
-                            }}
-                            placeholder={'MM/DD/YYYY'}
-                            shouldClearHiddenInput={true}
-                            showDateHint={false}
-                            values={{
-                              day: form.day,
-                              month: form.month,
-                              year: form.year,
-                            }}
-                            onBlur={validateStampSequence}
-                            onChange={({ key, value }) => {
-                              updateFormValueSequence({
-                                key,
-                                value,
-                              });
-                            }}
-                          />
-                        </div>
+                        The parties shall file a status report by:
                       </label>
                     </div>
                     <div
@@ -376,43 +339,36 @@ export const ApplyStamp = connect(
                         htmlFor="dueDateMessage-statusReportOrStipDecisionDueDate"
                         id="dueDateMessage-statusReportOrStipDecisionDueDate-label"
                       >
-                        <div className="label-text-with-date-picker">
-                          <span className="label-text">
-                            The parties shall file a status report or proposed
-                            stipulated decision by{' '}
-                          </span>
-                          <DateInput
-                            className="display-inline-block padding-0"
-                            disabled={
-                              form.dueDateMessage !==
-                              'The parties shall file a status report or proposed stipulated decision by'
-                            }
-                            id="due-date-input-statusReportOrStipDecisionDueDate"
-                            minDate={applyStampFormHelper.minDate}
-                            names={{
-                              day: 'day',
-                              month: 'month',
-                              year: 'year',
-                            }}
-                            placeholder={'MM/DD/YYYY'}
-                            shouldClearHiddenInput={true}
-                            showDateHint={false}
-                            values={{
-                              day: form.day,
-                              month: form.month,
-                              year: form.year,
-                            }}
-                            onBlur={validateStampSequence}
-                            onChange={({ key, value }) => {
-                              updateFormValueSequence({
-                                key,
-                                value,
-                              });
-                            }}
-                          />
-                        </div>
+                        The parties shall file a status report or proposed
+                        stipulated decision by:
                       </label>
                     </div>
+                    <DateInput
+                      className="display-inline-block padding-0 margin-left-5"
+                      disabled={!form.dueDateMessage}
+                      id="due-date-input-statusReportDueDate"
+                      minDate={applyStampFormHelper.minDate}
+                      names={{
+                        day: 'day',
+                        month: 'month',
+                        year: 'year',
+                      }}
+                      placeholder={'MM/DD/YYYY'}
+                      shouldClearHiddenInput={true}
+                      showDateHint={false}
+                      values={{
+                        day: form.day,
+                        month: form.month,
+                        year: form.year,
+                      }}
+                      onBlur={validateStampSequence}
+                      onChange={({ key, value }) => {
+                        updateFormValueSequence({
+                          key,
+                          value,
+                        });
+                      }}
+                    />
                   </FormGroup>
                   <hr className="narrow-hr" />
                   <FormGroup


### PR DESCRIPTION
# Problem

The date picker calendar buttons were unable to be interacted with because the element would lose focus when clicking on the arrows.

# Solution

Removes the `DateInput` field from the labels for the due date message. Now the user will select whichever message applies at which point the `DateInput` element becomes enabled and they need to enter a date.