### PR TITLE
9493 display consolidated case docket numbers, save and serve

### DIFF
--- a/shared/src/business/entities/EntityConstants.js
+++ b/shared/src/business/entities/EntityConstants.js
@@ -434,7 +434,13 @@ const TRACKED_DOCUMENT_TYPES = {
 const SINGLE_DOCKET_RECORD_ONLY_EVENT_CODES = flatten([
   ...Object.values(DOCUMENT_EXTERNAL_CATEGORIES_MAP),
 ])
-  .filter(internalEvent => internalEvent.caseDecision)
+  .filter(externalEvent => externalEvent.caseDecision)
+  .map(x => x.eventCode);
+
+const MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES = flatten([
+  ...Object.values(DOCUMENT_EXTERNAL_CATEGORIES_MAP),
+])
+  .filter(externalEvent => !externalEvent.caseDecision)
   .map(x => x.eventCode);
 
 const STAMPED_DOCUMENTS_ALLOWLIST = uniq(
@@ -1456,6 +1462,7 @@ module.exports = deepFreeze({
   TODAYS_ORDERS_SORT_DEFAULT,
   TODAYS_ORDERS_SORTS,
   TRACKED_DOCUMENT_TYPES_EVENT_CODES,
+  MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES,
   TRANSCRIPT_EVENT_CODE,
   CORRECTED_TRANSCRIPT_EVENT_CODE,
   REVISED_TRANSCRIPT_EVENT_CODE,

--- a/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.js
+++ b/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.js
@@ -15,7 +15,7 @@ exports.formatConsolidatedCaseCoversheetData = async ({
   coverSheetData,
   docketEntryEntity,
 }) => {
-  const consolidatedCases = await applicationContext
+  let consolidatedCases = await applicationContext
     .getPersistenceGateway()
     .getCasesByLeadDocketNumber({
       applicationContext,
@@ -28,7 +28,7 @@ exports.formatConsolidatedCaseCoversheetData = async ({
       Case.getSortableDocketNumber(b.docketNumber),
   );
 
-  coverSheetData.consolidatedCases = consolidatedCases
+  consolidatedCases = consolidatedCases
     .map(consolidatedCase => ({
       docketNumber: consolidatedCase.docketNumber,
       documentNumber: (
@@ -39,6 +39,10 @@ exports.formatConsolidatedCaseCoversheetData = async ({
       ).index,
     }))
     .filter(consolidatedCase => consolidatedCase.documentNumber !== undefined);
+
+  if (consolidatedCases.length) {
+    coverSheetData.consolidatedCases = consolidatedCases;
+  }
 
   return coverSheetData;
 };

--- a/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
+++ b/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
@@ -50,14 +50,17 @@ describe('formatConsolidatedCaseCoversheetData', () => {
     expect(result.consolidatedCases.length).toEqual(2);
   });
 
-  it('should not add any consolidated group information to the coverhseet when the document has only been filed on the lead case', async () => {
+  it('should not add any consolidated group information to the coversheet when the document has only been filed on the lead case', async () => {
+    const docketEntryIdOnLeadCaseNotMultiDocketed =
+      'b0efe7fd-a8d6-4eb8-bf66-857bcb700483';
+
     const result = await formatConsolidatedCaseCoversheetData({
       applicationContext,
       caseEntity: MOCK_CASE,
       coverSheetData: {},
       docketEntryEntity: {
         ...mockDocketEntry,
-        docketEntryId: 'b0efe7fd-a8d6-4eb8-bf66-857bcb700483',
+        docketEntryId: docketEntryIdOnLeadCaseNotMultiDocketed,
       },
     });
 

--- a/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
+++ b/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
@@ -50,7 +50,7 @@ describe('formatConsolidatedCaseCoversheetData', () => {
     expect(result.consolidatedCases.length).toEqual(2);
   });
 
-  it.only('should not add any consolidated group information to the coverhseet when the document has only been filed on the lead case', async () => {
+  it('should not add any consolidated group information to the coverhseet when the document has only been filed on the lead case', async () => {
     const result = await formatConsolidatedCaseCoversheetData({
       applicationContext,
       caseEntity: MOCK_CASE,

--- a/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
+++ b/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
@@ -60,11 +60,9 @@ describe('formatConsolidatedCaseCoversheetData', () => {
 
     expect(result.consolidatedCases[0]).toMatchObject({
       docketNumber: '101-19',
-      documentNumber: 4,
     });
     expect(result.consolidatedCases[1]).toMatchObject({
       docketNumber: '101-30',
-      documentNumber: 3,
     });
   });
 

--- a/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
+++ b/shared/src/business/useCaseHelper/consolidatedCases/formatConsolidatedCaseCoversheetData.test.js
@@ -50,6 +50,20 @@ describe('formatConsolidatedCaseCoversheetData', () => {
     expect(result.consolidatedCases.length).toEqual(2);
   });
 
+  it.only('should not add any consolidated group information to the coverhseet when the document has only been filed on the lead case', async () => {
+    const result = await formatConsolidatedCaseCoversheetData({
+      applicationContext,
+      caseEntity: MOCK_CASE,
+      coverSheetData: {},
+      docketEntryEntity: {
+        ...mockDocketEntry,
+        docketEntryId: 'b0efe7fd-a8d6-4eb8-bf66-857bcb700483',
+      },
+    });
+
+    expect(result.consolidatedCases).toBeUndefined();
+  });
+
   it('should sort the docket numbers of all cases in the consolidated group by docketNumber, ascending', async () => {
     const result = await formatConsolidatedCaseCoversheetData({
       applicationContext,

--- a/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
+++ b/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
@@ -3,10 +3,7 @@ import { addCoverToPdf } from '../addCoverToPdf';
 const {
   aggregatePartiesForService,
 } = require('../../utilities/aggregatePartiesForService');
-const {
-  ALLOWLIST_FEATURE_FLAGS,
-  DOCKET_SECTION,
-} = require('../../entities/EntityConstants');
+const { ALLOWLIST_FEATURE_FLAGS } = require('../../entities/EntityConstants');
 const {
   createISODateString,
   formatDateString,
@@ -23,7 +20,6 @@ const { Case } = require('../../entities/cases/Case');
 const { DocketEntry } = require('../../entities/DocketEntry');
 const { NotFoundError, UnauthorizedError } = require('../../../errors/errors');
 const { omit } = require('lodash');
-const { WorkItem } = require('../../entities/WorkItem');
 
 /**
  * serveExternallyFiledDocumentInteractor

--- a/shared/src/business/useCases/generateCoverSheetData.test.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.test.ts
@@ -1,5 +1,4 @@
 import {
-  COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET,
   DOCKET_NUMBER_SUFFIXES,
   DOCUMENT_PROCESSING_STATUS_OPTIONS,
   MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES,
@@ -104,7 +103,7 @@ describe('generateCoverSheetData', () => {
     expect(result.documentTitle).toEqual(`Petition ${expectedAdditionalInfo}`);
   });
 
-  it('should append "Filed" as filing date to the coversheet when the document is NOT lodged', async () => {
+  it('should append a filing date label of Filed when the document is NOT lodged', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -117,7 +116,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateFiledLodgedLabel).toEqual('Filed');
   });
 
-  it('should append "Lodged" as filing date to the coversheet when the document is lodged', async () => {
+  it('should append a filing date label of Lodged when the document is lodged', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -130,7 +129,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateFiledLodgedLabel).toEqual('Lodged');
   });
 
-  it('should append the received date WITH time to the coversheet when the document is electronically filed', async () => {
+  it('should append the received date WITH time when the document is electronically filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -145,7 +144,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('04/19/19 10:45 am');
   });
 
-  it('should append the received date as an empty string to the coversheet when the document does not have a valid createdAt and is electronically filed', async () => {
+  it('should append the received date as an empty string when the document does not have a valid createdAt and is electronically filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -160,7 +159,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('');
   });
 
-  it('should append the received date WITHOUT time to the coversheet when the document is paper filed', async () => {
+  it('should append the received date WITHOUT time when the document is paper filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -174,7 +173,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('04/19/19');
   });
 
-  it('should NOT append the received date to the coversheet when the document does not have a valid createdAt and is filed by paper', async () => {
+  it('shows does not show the received date if the document does not have a valid createdAt and is filed by paper', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -188,7 +187,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('');
   });
 
-  it('should append the servedDate of the document to the coversheet when it is defined as "MM/DD/YY"', async () => {
+  it('displays the date served if present in MMDDYYYY format', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -201,7 +200,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateServed).toEqual('04/20/19');
   });
 
-  it('should append the servedDate of the document to the coversheet as an empty string when it is not defined', async () => {
+  it('does not display the service date if servedAt is not present', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -214,7 +213,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateServed).toEqual('');
   });
 
-  it('should append the docketNumberWithSuffix as the docketNumber to the coversheet when case type suffix is undefined', async () => {
+  it('returns the docket number along with a Docket Number label', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -224,7 +223,7 @@ describe('generateCoverSheetData', () => {
     expect(result.docketNumberWithSuffix).toEqual(MOCK_CASE.docketNumber);
   });
 
-  it('should append the docket number with suffix to the coversheet when the case has a suffix defined', async () => {
+  it('returns the docket number with suffix along with a Docket Number label', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: {
@@ -240,7 +239,7 @@ describe('generateCoverSheetData', () => {
     );
   });
 
-  it('should return electronicallyFiled as true when the document is not paper filed', async () => {
+  it('displays Electronically Filed when the document is filed electronically', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -253,7 +252,7 @@ describe('generateCoverSheetData', () => {
     expect(result.electronicallyFiled).toEqual(true);
   });
 
-  it('should return electronicallyFiled as false when the document is filed by paper', async () => {
+  it('does NOT display Electronically Filed when the document is filed by paper', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -266,7 +265,7 @@ describe('generateCoverSheetData', () => {
     expect(result.electronicallyFiled).toEqual(false);
   });
 
-  it('should append the mailing date to the coversheet when it is defined', async () => {
+  it('returns the mailing date if present', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -279,7 +278,7 @@ describe('generateCoverSheetData', () => {
     expect(result.mailingDate).toEqual('04/16/2019');
   });
 
-  it('should append the index of the docket entry to the coversheet', async () => {
+  it('returns the index of the docket entry as part of the coversheet data', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -292,7 +291,7 @@ describe('generateCoverSheetData', () => {
     expect(result.index).toEqual(testingCaseData.docketEntries[0].index);
   });
 
-  it('should append the mailingDate as an empty string to the coversheet when it is not defined', async () => {
+  it('returns an empty string for the mailing date if NOT present', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -305,7 +304,7 @@ describe('generateCoverSheetData', () => {
     expect(result.mailingDate).toEqual('');
   });
 
-  it('should append caseCaptionExtension to the coversheet as "Petitioners" when there are multiple petitioners on the case', async () => {
+  it('generates cover sheet data appropriate for multiple petitioners', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: {
@@ -318,7 +317,7 @@ describe('generateCoverSheetData', () => {
     expect(result.caseCaptionExtension).toEqual('Petitioners');
   });
 
-  it('should append caseCaptionExtension to the coversheet as "Petitioner" when there is a single petitioner on the case', async () => {
+  it('generates cover sheet data appropriate for a single petitioner', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -328,7 +327,7 @@ describe('generateCoverSheetData', () => {
     expect(result.caseCaptionExtension).toEqual(PARTY_TYPES.petitioner);
   });
 
-  it('should append an empty string for caseCaptionExtension to the coversheet when the caseCaption is not in the proper format', async () => {
+  it('generates empty string for caseCaptionExtension if the caseCaption is not in the proper format', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: {
@@ -341,7 +340,7 @@ describe('generateCoverSheetData', () => {
     expect(result.caseCaptionExtension).toEqual('');
   });
 
-  it('should append the original caseCaption and docketNumber to the coversheet when the useInitialData is true', async () => {
+  it('preserves the original case caption and docket number when the useInitialData is true', async () => {
     const mockInitialDocketNumberSuffix = 'Z';
 
     const result = await generateCoverSheetData({
@@ -363,15 +362,15 @@ describe('generateCoverSheetData', () => {
     expect(result.caseTitle).toEqual('Janie and Jackie Petitioner, ');
   });
 
-  it('should NOT append dateReceived, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', async () => {
+  it('does NOT display dateReceived, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
       docketEntryEntity: {
         ...testingCaseData.docketEntries[0],
-        dateReceived: '2012-04-20T14:45:15.595Z',
-        electronicallyFiled: true,
-        eventCode: COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET[0],
+        documentType: 'U.S.C.A',
+        eventCode: 'USCA',
+        lodged: true,
         servedAt: '2019-04-20T14:45:15.595Z',
       },
     } as any);
@@ -381,7 +380,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateServed).toBeUndefined();
   });
 
-  it('should append dateRecieved as formatted dateFiled to the coversheet when the filingDateUpdated is true', async () => {
+  it('sets the dateReceived to dateFiledFormatted when the filingDate has been updated', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -395,7 +394,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toBe('05/19/19');
   });
 
-  it('should append dateReceived as createdAt date when the filingDateUpdated is false', async () => {
+  it('sets the dateReceived to createdAt date when the filingDate has not been updated', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -411,7 +410,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toBe('02/15/19');
   });
 
-  it('should append documentType as documentTitle to the coversheet when documentTitle is undefined', async () => {
+  it('should use documentType as documentTitle if documentTitle is undefined', async () => {
     const mockDocumentType = 'test doc type';
 
     const result = await generateCoverSheetData({
@@ -428,9 +427,8 @@ describe('generateCoverSheetData', () => {
     expect(result.documentTitle).toBe(mockDocumentType);
   });
 
-  it('should append the formatted stamp date as "MM/DD/YYYY" to the coversheet when stampData.date is defined', async () => {
+  it('should formatDateString if stampData.date exists', async () => {
     const mockDate = applicationContext.getUtilities().createISODateString();
-
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,

--- a/shared/src/business/useCases/generateCoverSheetData.test.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.test.ts
@@ -1,6 +1,7 @@
 import {
   DOCKET_NUMBER_SUFFIXES,
   DOCUMENT_PROCESSING_STATUS_OPTIONS,
+  MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES,
   PARTY_TYPES,
 } from '../entities/EntityConstants';
 import { FORMATS, formatDateString } from '../utilities/DateHandler';
@@ -440,5 +441,24 @@ describe('generateCoverSheetData', () => {
     expect(result.stamp.date).toEqual(
       formatDateString(mockDate, FORMATS.MMDDYYYY),
     );
+  });
+
+  it('should append consolidated group information to the coversheet when the document filed is multi-docketable', async () => {
+    await generateCoverSheetData({
+      applicationContext,
+      caseEntity: {
+        ...testingCaseData,
+        leadDocketNumber: testingCaseData.docketNumber,
+      },
+      docketEntryEntity: {
+        ...testingCaseData.docketEntries[0],
+        eventCode: MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES[0],
+      },
+    } as any);
+
+    expect(
+      applicationContext.getUseCaseHelpers()
+        .formatConsolidatedCaseCoversheetData,
+    ).toHaveBeenCalled();
   });
 });

--- a/shared/src/business/useCases/generateCoverSheetData.test.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.test.ts
@@ -1,4 +1,5 @@
 import {
+  COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET,
   DOCKET_NUMBER_SUFFIXES,
   DOCUMENT_PROCESSING_STATUS_OPTIONS,
   MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES,
@@ -103,7 +104,7 @@ describe('generateCoverSheetData', () => {
     expect(result.documentTitle).toEqual(`Petition ${expectedAdditionalInfo}`);
   });
 
-  it('should append a filing date label of Filed when the document is NOT lodged', async () => {
+  it('should append "Filed" as filing date to the coversheet when the document is NOT lodged', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -116,7 +117,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateFiledLodgedLabel).toEqual('Filed');
   });
 
-  it('should append a filing date label of Lodged when the document is lodged', async () => {
+  it('should append "Lodged" as filing date to the coversheet when the document is lodged', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -129,7 +130,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateFiledLodgedLabel).toEqual('Lodged');
   });
 
-  it('should append the received date WITH time when the document is electronically filed', async () => {
+  it('should append the received date WITH time to the coversheet when the document is electronically filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -144,7 +145,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('04/19/19 10:45 am');
   });
 
-  it('should append the received date as an empty string when the document does not have a valid createdAt and is electronically filed', async () => {
+  it('should append the received date as an empty string to the coversheet when the document does not have a valid createdAt and is electronically filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -159,7 +160,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('');
   });
 
-  it('should append the received date WITHOUT time when the document is paper filed', async () => {
+  it('should append the received date WITHOUT time to the coversheet when the document is paper filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -173,7 +174,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('04/19/19');
   });
 
-  it('shows does not show the received date if the document does not have a valid createdAt and is filed by paper', async () => {
+  it('should NOT append the received date to the coversheet when the document does not have a valid createdAt and is filed by paper', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -187,7 +188,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toEqual('');
   });
 
-  it('displays the date served if present in MMDDYYYY format', async () => {
+  it('should append the servedDate of the document to the coversheet when it is defined as "MM/DD/YY"', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -200,7 +201,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateServed).toEqual('04/20/19');
   });
 
-  it('does not display the service date if servedAt is not present', async () => {
+  it('should append the servedDate of the document to the coversheet as an empty string when it is not defined', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -213,7 +214,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateServed).toEqual('');
   });
 
-  it('returns the docket number along with a Docket Number label', async () => {
+  it('should append the docketNumberWithSuffix as the docketNumber to the coversheet when case type suffix is undefined', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -223,7 +224,7 @@ describe('generateCoverSheetData', () => {
     expect(result.docketNumberWithSuffix).toEqual(MOCK_CASE.docketNumber);
   });
 
-  it('returns the docket number with suffix along with a Docket Number label', async () => {
+  it('should append the docket number with suffix to the coversheet when the case has a suffix defined', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: {
@@ -239,7 +240,7 @@ describe('generateCoverSheetData', () => {
     );
   });
 
-  it('displays Electronically Filed when the document is filed electronically', async () => {
+  it('should return electronicallyFiled as true when the document is not paper filed', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -252,7 +253,7 @@ describe('generateCoverSheetData', () => {
     expect(result.electronicallyFiled).toEqual(true);
   });
 
-  it('does NOT display Electronically Filed when the document is filed by paper', async () => {
+  it('should return electronicallyFiled as false when the document is filed by paper', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -265,7 +266,7 @@ describe('generateCoverSheetData', () => {
     expect(result.electronicallyFiled).toEqual(false);
   });
 
-  it('returns the mailing date if present', async () => {
+  it('should append the mailing date to the coversheet when it is defined', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -278,7 +279,7 @@ describe('generateCoverSheetData', () => {
     expect(result.mailingDate).toEqual('04/16/2019');
   });
 
-  it('returns the index of the docket entry as part of the coversheet data', async () => {
+  it('should append the index of the docket entry to the coversheet', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -291,7 +292,7 @@ describe('generateCoverSheetData', () => {
     expect(result.index).toEqual(testingCaseData.docketEntries[0].index);
   });
 
-  it('returns an empty string for the mailing date if NOT present', async () => {
+  it('should append the mailingDate as an empty string to the coversheet when it is not defined', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -304,7 +305,7 @@ describe('generateCoverSheetData', () => {
     expect(result.mailingDate).toEqual('');
   });
 
-  it('generates cover sheet data appropriate for multiple petitioners', async () => {
+  it('should append caseCaptionExtension to the coversheet as "Petitioners" when there are multiple petitioners on the case', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: {
@@ -317,7 +318,7 @@ describe('generateCoverSheetData', () => {
     expect(result.caseCaptionExtension).toEqual('Petitioners');
   });
 
-  it('generates cover sheet data appropriate for a single petitioner', async () => {
+  it('should append caseCaptionExtension to the coversheet as "Petitioner" when there is a single petitioner on the case', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -327,7 +328,7 @@ describe('generateCoverSheetData', () => {
     expect(result.caseCaptionExtension).toEqual(PARTY_TYPES.petitioner);
   });
 
-  it('generates empty string for caseCaptionExtension if the caseCaption is not in the proper format', async () => {
+  it('should append an empty string for caseCaptionExtension to the coversheet when the caseCaption is not in the proper format', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: {
@@ -340,7 +341,7 @@ describe('generateCoverSheetData', () => {
     expect(result.caseCaptionExtension).toEqual('');
   });
 
-  it('preserves the original case caption and docket number when the useInitialData is true', async () => {
+  it('should append the original caseCaption and docketNumber to the coversheet when the useInitialData is true', async () => {
     const mockInitialDocketNumberSuffix = 'Z';
 
     const result = await generateCoverSheetData({
@@ -362,15 +363,15 @@ describe('generateCoverSheetData', () => {
     expect(result.caseTitle).toEqual('Janie and Jackie Petitioner, ');
   });
 
-  it('does NOT display dateReceived, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', async () => {
+  it('should NOT append dateReceived, electronicallyFiled, and dateServed when the coversheet is being generated for a court issued document', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
       docketEntryEntity: {
         ...testingCaseData.docketEntries[0],
-        documentType: 'U.S.C.A',
-        eventCode: 'USCA',
-        lodged: true,
+        dateReceived: '2012-04-20T14:45:15.595Z',
+        electronicallyFiled: true,
+        eventCode: COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET[0],
         servedAt: '2019-04-20T14:45:15.595Z',
       },
     } as any);
@@ -380,7 +381,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateServed).toBeUndefined();
   });
 
-  it('sets the dateReceived to dateFiledFormatted when the filingDate has been updated', async () => {
+  it('should append dateRecieved as formatted dateFiled to the coversheet when the filingDateUpdated is true', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -394,7 +395,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toBe('05/19/19');
   });
 
-  it('sets the dateReceived to createdAt date when the filingDate has not been updated', async () => {
+  it('should append dateReceived as createdAt date when the filingDateUpdated is false', async () => {
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,
@@ -410,7 +411,7 @@ describe('generateCoverSheetData', () => {
     expect(result.dateReceived).toBe('02/15/19');
   });
 
-  it('should use documentType as documentTitle if documentTitle is undefined', async () => {
+  it('should append documentType as documentTitle to the coversheet when documentTitle is undefined', async () => {
     const mockDocumentType = 'test doc type';
 
     const result = await generateCoverSheetData({
@@ -427,8 +428,9 @@ describe('generateCoverSheetData', () => {
     expect(result.documentTitle).toBe(mockDocumentType);
   });
 
-  it('should formatDateString if stampData.date exists', async () => {
+  it('should append the formatted stamp date as "MM/DD/YYYY" to the coversheet when stampData.date is defined', async () => {
     const mockDate = applicationContext.getUtilities().createISODateString();
+
     const result = await generateCoverSheetData({
       applicationContext,
       caseEntity: testingCaseData,

--- a/shared/src/business/useCases/generateCoverSheetData.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.ts
@@ -108,6 +108,7 @@ export const generateCoverSheetData = async ({
       'dateServed',
     ]);
   }
+
   if (
     COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET.includes(
       docketEntryEntity.eventCode,

--- a/shared/src/business/useCases/generateCoverSheetData.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.ts
@@ -99,7 +99,8 @@ export const generateCoverSheetData = async ({
   if (
     COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET.includes(
       docketEntryEntity.eventCode,
-    )
+    ) ||
+    MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES
   ) {
     coverSheetData = omit(coverSheetData, [
       'dateReceived',
@@ -117,14 +118,14 @@ export const generateCoverSheetData = async ({
       });
 
     if (isLeadCase && isFeatureFlagEnabled) {
-      coverSheetData = (
-        await applicationContext.getUseCaseHelpers()
-      ).formatConsolidatedCaseCoversheetData({
-        applicationContext,
-        caseEntity,
-        coverSheetData,
-        docketEntryEntity,
-      });
+      coverSheetData = await applicationContext
+        .getUseCaseHelpers()
+        .formatConsolidatedCaseCoversheetData({
+          applicationContext,
+          caseEntity,
+          coverSheetData,
+          docketEntryEntity,
+        });
     }
   }
 

--- a/shared/src/business/useCases/generateCoverSheetData.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.ts
@@ -1,6 +1,7 @@
 import {
   ALLOWLIST_FEATURE_FLAGS,
   COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET,
+  MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES,
 } from '../entities/EntityConstants';
 import { FORMATS, formatDateString } from '../utilities/DateHandler';
 import { omit } from 'lodash';
@@ -99,15 +100,22 @@ export const generateCoverSheetData = async ({
   if (
     COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET.includes(
       docketEntryEntity.eventCode,
-    ) ||
-    MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES
+    )
   ) {
     coverSheetData = omit(coverSheetData, [
       'dateReceived',
       'electronicallyFiled',
       'dateServed',
     ]);
-
+  }
+  if (
+    COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET.includes(
+      docketEntryEntity.eventCode,
+    ) ||
+    MULTI_DOCKET_EXTERNAL_FILING_EVENT_CODES.includes(
+      docketEntryEntity.eventCode,
+    )
+  ) {
     const isLeadCase = caseEntity.leadDocketNumber === caseEntity.docketNumber;
     const isFeatureFlagEnabled = await applicationContext
       .getUseCases()

--- a/shared/src/business/useCases/generateCoverSheetData.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.ts
@@ -42,7 +42,7 @@ export const generateCoverSheetData = async ({
     ? formatDateString(docketEntryEntity.servedAt, FORMATS.MMDDYY)
     : '';
 
-  let dateReceivedFormatted = formatDateReceived({
+  const dateReceivedFormatted = formatDateReceived({
     docketEntryEntity,
     isPaper: docketEntryEntity.isPaper,
   });

--- a/shared/src/business/useCases/generateCoverSheetData.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.ts
@@ -118,15 +118,15 @@ export const generateCoverSheetData = async ({
     )
   ) {
     const isLeadCase = caseEntity.leadDocketNumber === caseEntity.docketNumber;
-    const isFeatureFlagEnabled = await applicationContext
-      .getUseCases()
-      .getFeatureFlagValueInteractor(applicationContext, {
-        featureFlag:
-          ALLOWLIST_FEATURE_FLAGS.CONSOLIDATED_CASES_PROPAGATE_DOCKET_ENTRIES
-            .key,
-      });
+    // const isFeatureFlagEnabled = await applicationContext
+    //   .getUseCases()
+    //   .getFeatureFlagValueInteractor(applicationContext, {
+    //     featureFlag:
+    //       ALLOWLIST_FEATURE_FLAGS.CONSOLIDATED_CASES_PROPAGATE_DOCKET_ENTRIES
+    //         .key,
+    //   });
 
-    if (isLeadCase && isFeatureFlagEnabled) {
+    if (isLeadCase) {
       coverSheetData = await applicationContext
         .getUseCaseHelpers()
         .formatConsolidatedCaseCoversheetData({

--- a/shared/src/business/useCases/generateCoverSheetData.ts
+++ b/shared/src/business/useCases/generateCoverSheetData.ts
@@ -118,13 +118,6 @@ export const generateCoverSheetData = async ({
     )
   ) {
     const isLeadCase = caseEntity.leadDocketNumber === caseEntity.docketNumber;
-    // const isFeatureFlagEnabled = await applicationContext
-    //   .getUseCases()
-    //   .getFeatureFlagValueInteractor(applicationContext, {
-    //     featureFlag:
-    //       ALLOWLIST_FEATURE_FLAGS.CONSOLIDATED_CASES_PROPAGATE_DOCKET_ENTRIES
-    //         .key,
-    //   });
 
     if (isLeadCase) {
       coverSheetData = await applicationContext

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/CoverSheet.jsx
@@ -54,7 +54,7 @@ export const CoverSheet = ({
         <div className="border-none" id="caption">
           <div id="caption-title">
             {caseTitle}
-            {consolidatedCases && ' et al.,'}
+            {consolidatedCases && ' ET AL.,'}
           </div>
           <div id="caption-extension">{caseCaptionExtension}</div>
           <div id="caption-v">v.</div>


### PR DESCRIPTION
For save and serve immediately flow, update docket numbers on coversheet to display for all selected cases in the consolidated group
![image](https://user-images.githubusercontent.com/16403861/191296649-fa4fd68d-c023-4108-9cde-6e3b9b4231fb.png)
