### PR TITLE
9493 po feedback after async issues

### DIFF
--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
@@ -125,6 +125,48 @@ describe('addPaperFilingInteractor', () => {
     ).toEqual(mockPdfUrl);
   });
 
+  it.only('should return paper service url as part of the "serve_document_complete" message when the document is filed on a lead case and one of the member cases has a party with paper service', async () => {
+    const mockPdfUrl = 'www.example.com';
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValueOnce(mockCase)
+      .mockReturnValueOnce({
+        ...MOCK_CONSOLIDATED_1_CASE_WITH_PAPER_SERVICE,
+        leadDocketNumber: mockCase.docketNumber,
+      });
+
+    applicationContext
+      .getUseCaseHelpers()
+      .serveDocumentAndGetPaperServicePdf.mockReturnValue({
+        pdfUrl: mockPdfUrl,
+      });
+
+    await addPaperFilingInteractor(applicationContext, {
+      clientConnectionId: mockClientConnectionId,
+      consolidatedGroupDocketNumbers: [
+        mockCase.docketNumber,
+        MOCK_CONSOLIDATED_1_CASE_WITH_PAPER_SERVICE.docketNumber,
+      ],
+      documentMetadata: {
+        docketEntryId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+        docketNumber: mockCase.docketNumber,
+        documentTitle: 'Memorandum in Support',
+        documentType: 'Memorandum in Support',
+        eventCode: 'MISP',
+        filedBy: 'Test Petitioner',
+        isFileAttached: true,
+        isPaper: true,
+      },
+      isSavingForLater: false,
+      primaryDocumentFileId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+    });
+
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser.mock
+        .calls[0][0].message.pdfUrl,
+    ).toEqual(mockPdfUrl);
+  });
+
   it('should add documents and workItem to inbox when saving for later when a document is attached', async () => {
     await addPaperFilingInteractor(applicationContext, {
       clientConnectionId: mockClientConnectionId,

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
@@ -125,7 +125,7 @@ describe('addPaperFilingInteractor', () => {
     ).toEqual(mockPdfUrl);
   });
 
-  it.only('should return paper service url as part of the "serve_document_complete" message when the document is filed on a lead case and one of the member cases has a party with paper service', async () => {
+  it('should return paper service url as part of the "serve_document_complete" message when the document is filed on a lead case and one of the member cases has a party with paper service', async () => {
     const mockPdfUrl = 'www.example.com';
     applicationContext
       .getPersistenceGateway()

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
@@ -432,6 +432,52 @@ describe('addPaperFilingInteractor', () => {
     });
   });
 
+  it('should send a serve_document_complete notification with generateCoversheet true when the docket entry has a file attached and the user is NOT saving for later', async () => {
+    await addPaperFilingInteractor(applicationContext, {
+      clientConnectionId: mockClientConnectionId,
+      consolidatedGroupDocketNumbers: [mockCase.docketNumber],
+      documentMetadata: {
+        docketNumber: mockCase.docketNumber,
+        documentTitle: 'Memorandum in Support',
+        documentType: 'Memorandum in Support',
+        eventCode: 'MISP',
+        filedBy: 'Test Petitioner',
+        isFileAttached: true,
+        isPaper: true,
+      },
+      isSavingForLater: false,
+      primaryDocumentFileId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+    });
+
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser.mock
+        .calls[0][0].message.generateCoversheet,
+    ).toBe(true);
+  });
+
+  it('should send a serve_document_complete notification with generateCoversheet false when the docket entry does NOT have a file attached', async () => {
+    await addPaperFilingInteractor(applicationContext, {
+      clientConnectionId: mockClientConnectionId,
+      consolidatedGroupDocketNumbers: [mockCase.docketNumber],
+      documentMetadata: {
+        docketNumber: mockCase.docketNumber,
+        documentTitle: 'Memorandum in Support',
+        documentType: 'Memorandum in Support',
+        eventCode: 'MISP',
+        filedBy: 'Test Petitioner',
+        isFileAttached: false,
+        isPaper: true,
+      },
+      isSavingForLater: true,
+      primaryDocumentFileId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+    });
+
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser.mock
+        .calls[0][0].message.generateCoversheet,
+    ).toBe(false);
+  });
+
   describe('consolidated groups', () => {
     it('should create a work item and add it to the outbox for each case', async () => {
       const mockConsolidatedGroup = [

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -225,6 +225,8 @@ export const addPaperFilingInteractor = async (
         docketEntryId,
       });
 
+    console.log('*****', servedParties);
+
     if (servedParties.paper.length > 0) {
       paperServicePdfUrl = paperServiceResult && paperServiceResult.pdfUrl;
     }

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -110,9 +110,13 @@ export const addPaperFilingInteractor = async (
   }
 
   let filedByFromLeadCase;
-  let servedParties;
+  let consolidatedGroupHasPaperServiceCase: boolean;
+
   for (const caseEntity of caseEntities) {
-    servedParties = aggregatePartiesForService(caseEntity);
+    const servedParties = aggregatePartiesForService(caseEntity);
+    if (servedParties.paper.length > 0) {
+      consolidatedGroupHasPaperServiceCase = true;
+    }
 
     const docketEntryEntity = new DocketEntry(
       {
@@ -225,9 +229,7 @@ export const addPaperFilingInteractor = async (
         docketEntryId,
       });
 
-    console.log('*****', servedParties);
-
-    if (servedParties.paper.length > 0) {
+    if (consolidatedGroupHasPaperServiceCase) {
       paperServicePdfUrl = paperServiceResult && paperServiceResult.pdfUrl;
     }
   }

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -245,6 +245,7 @@ export const addPaperFilingInteractor = async (
         message: successMessage,
         overwritable: false,
       },
+      needsCoversheet: true,
       pdfUrl: paperServicePdfUrl,
     },
     userId: user.userId,

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -248,6 +248,7 @@ export const addPaperFilingInteractor = async (
         message: successMessage,
         overwritable: false,
       },
+      docketEntryId,
       generateCoversheet: true,
       pdfUrl: paperServicePdfUrl,
     },

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -75,8 +75,6 @@ export const addPaperFilingInteractor = async (
       docketNumber,
     });
 
-  let caseEntityToUpdate = new Case(caseToUpdate, { applicationContext });
-
   const baseMetadata = pick(documentMetadata, [
     'filers',
     'partyIrsPractitioner',
@@ -95,8 +93,6 @@ export const addPaperFilingInteractor = async (
     throw new Error('Did not receive a primaryDocumentFileId');
   }
 
-  const servedParties = aggregatePartiesForService(caseEntityToUpdate);
-
   const docketRecordEditState =
     metadata.isFileAttached === false ? documentMetadata : {};
 
@@ -114,7 +110,10 @@ export const addPaperFilingInteractor = async (
   }
 
   let filedByFromLeadCase;
+  let servedParties;
   for (const caseEntity of caseEntities) {
+    servedParties = aggregatePartiesForService(caseEntity);
+
     const docketEntryEntity = new DocketEntry(
       {
         ...baseMetadata,

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -249,7 +249,7 @@ export const addPaperFilingInteractor = async (
         overwritable: false,
       },
       docketEntryId,
-      generateCoversheet: true,
+      generateCoversheet: readyForService,
       pdfUrl: paperServicePdfUrl,
     },
     userId: user.userId,

--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -248,7 +248,7 @@ export const addPaperFilingInteractor = async (
         message: successMessage,
         overwritable: false,
       },
-      needsCoversheet: true,
+      generateCoversheet: true,
       pdfUrl: paperServicePdfUrl,
     },
     userId: user.userId,

--- a/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.js
+++ b/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.js
@@ -1,0 +1,20 @@
+import { state } from 'cerebral';
+
+/**
+ * Generates a coversheet for the docket entry set on state
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext the application context
+ * @param {Function} providers.get the cerebral get function
+ */
+export const generateCoversheetAction = async ({ applicationContext, get }) => {
+  const docketNumber = get(state.caseDetail.docketNumber);
+  const docketEntryId = get(state.docketEntryId);
+
+  await applicationContext
+    .getUseCases()
+    .addCoversheetInteractor(applicationContext, {
+      docketEntryId,
+      docketNumber,
+    });
+};

--- a/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.js
+++ b/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.js
@@ -6,10 +6,15 @@ import { state } from 'cerebral';
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
  * @param {Function} providers.get the cerebral get function
+ * @param {Function} providers.props the cerebral props function
  */
-export const generateCoversheetAction = async ({ applicationContext, get }) => {
+export const generateCoversheetAction = async ({
+  applicationContext,
+  get,
+  props,
+}) => {
   const docketNumber = get(state.caseDetail.docketNumber);
-  const docketEntryId = get(state.docketEntryId);
+  const { docketEntryId } = props;
 
   await applicationContext
     .getUseCases()

--- a/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.test.js
@@ -1,0 +1,5 @@
+import { generateCoversheetAction } from './generateCoversheetAction';
+import { presenter } from '../../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('generateCoversheetAction', () => {});

--- a/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.test.js
@@ -1,5 +1,33 @@
+import { applicationContextForClient as applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
 import { generateCoversheetAction } from './generateCoversheetAction';
 import { presenter } from '../../presenter-mock';
 import { runAction } from 'cerebral/test';
 
-describe('generateCoversheetAction', () => {});
+describe('generateCoversheetAction', () => {
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
+  it('should call addCoversheetInteractor', async () => {
+    const mockDocketEntryId = '456';
+    const mockDocketNumber = '123-45';
+    await runAction(generateCoversheetAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        caseDetail: {
+          docketNumber: mockDocketNumber,
+        },
+        docketEntryId: mockDocketEntryId,
+      },
+    });
+
+    expect(
+      applicationContext.getUseCases().addCoversheetInteractor.mock.calls[0][1],
+    ).toMatchObject({
+      docketEntryId: mockDocketEntryId,
+      docketNumber: mockDocketNumber,
+    });
+  });
+});

--- a/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/generateCoversheetAction.test.js
@@ -15,11 +15,13 @@ describe('generateCoversheetAction', () => {
       modules: {
         presenter,
       },
+      props: {
+        docketEntryId: mockDocketEntryId,
+      },
       state: {
         caseDetail: {
           docketNumber: mockDocketNumber,
         },
-        docketEntryId: mockDocketEntryId,
       },
     });
 

--- a/web-client/src/presenter/actions/DocketEntry/isCoversheetNeededAction.js
+++ b/web-client/src/presenter/actions/DocketEntry/isCoversheetNeededAction.js
@@ -1,0 +1,17 @@
+/**
+ * Determines if a coversheet needs to be generated
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.path the next object in the path
+ * @param {object} providers.props the cerebral props object
+ * @returns {*} returns the next action in the sequence's path
+ */
+export const isCoversheetNeededAction = async ({ path, props }) => {
+  const { generateCoversheet } = props;
+
+  if (generateCoversheet) {
+    return path.yes();
+  }
+
+  return path.no();
+};

--- a/web-client/src/presenter/actions/DocketEntry/isCoversheetNeededAction.test.js
+++ b/web-client/src/presenter/actions/DocketEntry/isCoversheetNeededAction.test.js
@@ -1,0 +1,41 @@
+import { isCoversheetNeededAction } from './isCoversheetNeededAction';
+import { presenter } from '../../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('isCoversheetNeededAction', () => {
+  const noStub = jest.fn();
+  const yesStub = jest.fn();
+
+  presenter.providers.path = {
+    no: noStub,
+    yes: yesStub,
+  };
+
+  it('should return yes path when props.generateCoversheet is true', async () => {
+    runAction(isCoversheetNeededAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        generateCoversheet: true,
+      },
+      state: {},
+    });
+
+    expect(yesStub).toHaveBeenCalled();
+  });
+
+  it('should return no path when props.generateCoversheet is false', async () => {
+    runAction(isCoversheetNeededAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        generateCoversheet: false,
+      },
+      state: {},
+    });
+
+    expect(noStub).toHaveBeenCalled();
+  });
+});

--- a/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
+++ b/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
@@ -1,5 +1,6 @@
 import { clearModalAction } from '../actions/clearModalAction';
 import { followRedirectAction } from '../actions/followRedirectAction';
+import { generateCoversheetAction } from '../actions/DocketEntry/generateCoversheetAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getConsolidatedCasesByCaseAction } from '../actions/CaseConsolidation/getConsolidatedCasesByCaseAction';
 import { isCoversheetNeededAction } from '../actions/DocketEntry/isCoversheetNeededAction';

--- a/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
+++ b/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
@@ -2,6 +2,7 @@ import { clearModalAction } from '../actions/clearModalAction';
 import { followRedirectAction } from '../actions/followRedirectAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getConsolidatedCasesByCaseAction } from '../actions/CaseConsolidation/getConsolidatedCasesByCaseAction';
+import { isCoversheetNeededAction } from '../actions/DocketEntry/isCoversheetNeededAction';
 import { isPrintPreviewPreparedAction } from '../actions/CourtIssuedOrder/isPrintPreviewPreparedAction';
 import { navigateToCaseDetailAction } from '../actions/navigateToCaseDetailAction';
 import { navigateToPrintPaperServiceAction } from '../actions/navigateToPrintPaperServiceAction';
@@ -18,7 +19,7 @@ export const serveDocumentCompleteSequence = [
   isCoversheetNeededAction,
   {
     no: [],
-    yes: [],
+    yes: [generateCoversheetAction],
   },
   unsetWaitingForResponseAction,
   setAlertSuccessAction,

--- a/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
+++ b/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
@@ -14,11 +14,16 @@ import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNav
 import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
 
 export const serveDocumentCompleteSequence = [
-  setPdfPreviewUrlAction,
-  setAlertSuccessAction,
   clearModalAction,
-  setSaveAlertsForNavigationAction,
+  isCoversheetNeededAction,
+  {
+    no: [],
+    yes: [],
+  },
   unsetWaitingForResponseAction,
+  setAlertSuccessAction,
+  setSaveAlertsForNavigationAction,
+  setPdfPreviewUrlAction,
   isPrintPreviewPreparedAction,
   {
     no: [


### PR DESCRIPTION
Fixes the following feedback:

- Test Case 1.3 - Still not seeing a print for paper service screen appear, and I am no longer seeing a cover sheet on the documents filed.
- After I click Save and Serve, I get a confirmation screen on the "add paper filing" page, and then it reloads again. After reload, I am navigated back to the docket record screen with the updated green banner.