### PR TITLE
9493: Don't need to fetch case before navigating to case detail

### DIFF
--- a/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
+++ b/shared/src/business/useCases/docketEntry/addPaperFilingInteractor.test.ts
@@ -52,7 +52,7 @@ describe('addPaperFilingInteractor', () => {
       addPaperFilingInteractor(applicationContext, {
         clientConnectionId: undefined,
         consolidatedGroupDocketNumbers: undefined,
-        documentMetadata: {},
+        documentMetadata: undefined,
         isSavingForLater: undefined,
         primaryDocumentFileId: undefined,
       }),

--- a/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
+++ b/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
@@ -29,14 +29,16 @@ export const serveDocumentCompleteSequence = [
   isPrintPreviewPreparedAction,
   {
     no: [
-      getCaseAction,
-      setCaseAction,
-      getConsolidatedCasesByCaseAction,
-      setConsolidatedCasesForCaseAction,
       followRedirectAction,
       {
         default: [navigateToCaseDetailAction],
-        success: [setDocumentToDisplayFromDocumentIdAction],
+        success: [
+          getCaseAction,
+          setCaseAction,
+          getConsolidatedCasesByCaseAction,
+          setConsolidatedCasesForCaseAction,
+          setDocumentToDisplayFromDocumentIdAction,
+        ],
       },
     ],
     yes: [navigateToPrintPaperServiceAction],

--- a/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
+++ b/web-client/src/presenter/sequences/serveDocumentCompleteSequence.js
@@ -29,12 +29,12 @@ export const serveDocumentCompleteSequence = [
   isPrintPreviewPreparedAction,
   {
     no: [
+      getCaseAction,
+      setCaseAction,
       followRedirectAction,
       {
         default: [navigateToCaseDetailAction],
         success: [
-          getCaseAction,
-          setCaseAction,
           getConsolidatedCasesByCaseAction,
           setConsolidatedCasesForCaseAction,
           setDocumentToDisplayFromDocumentIdAction,


### PR DESCRIPTION
This addresses the feedback that we only saw on `test` - "After I click Save and Serve, I get a confirmation screen on the "add paper filing" page, and then it reloads again. After reload, I am navigated back to the docket record screen with the updated green banner."

We were able to reproduce this issue on `exp4` and verify that updating the sequence fixes the issue
