### PR TITLE
9594: Add links to unassociated consolidated cases

### DIFF
--- a/shared/src/business/entities/EntityConstants.js
+++ b/shared/src/business/entities/EntityConstants.js
@@ -62,6 +62,11 @@ const ALLOWLIST_FEATURE_FLAGS = {
       'The ability to add multiple docket entries to an order is disabled.',
     key: 'consolidated-cases-add-docket-numbers',
   },
+  CONSOLIDATED_CASES_PARTY_ASSOCIATION: {
+    disabledMessage:
+      'Parties to consolidated group member cases are not being treated as associated.',
+    key: 'consolidated-cases-party-association',
+  },
   CONSOLIDATED_CASES_PROPAGATE_DOCKET_ENTRIES: {
     disabledMessage:
       'Docket entries are not being duplicated across consolidated cases temporarily.',

--- a/web-client/src/presenter/computeds/FeatureFlags/featureFlagHelper.js
+++ b/web-client/src/presenter/computeds/FeatureFlags/featureFlagHelper.js
@@ -40,7 +40,14 @@ export const featureFlagHelper = (get, applicationContext) => {
     );
   }
 
+  const consolidatedCasesPartyAssociation = get(
+    state.featureFlags[
+      ALLOWLIST_FEATURE_FLAGS.CONSOLIDATED_CASES_PARTY_ASSOCIATION.key
+    ],
+  );
+
   return {
+    consolidatedCasesPartyAssociation,
     consolidatedCasesPropagateDocketEntries,
     isOpinionSearchEnabledForRole,
     isOrderSearchEnabledForRole,

--- a/web-client/src/presenter/sequences/gotoDashboardSequence.js
+++ b/web-client/src/presenter/sequences/gotoDashboardSequence.js
@@ -2,6 +2,7 @@ import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { clearSelectedWorkItemsAction } from '../actions/clearSelectedWorkItemsAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
 import { getConstants } from '../../getConstants';
+import { getFeatureFlagValueFactoryAction } from '../actions/getFeatureFlagValueFactoryAction';
 import { getInboxMessagesForUserAction } from '../actions/getInboxMessagesForUserAction';
 import { getJudgeForCurrentUserAction } from '../actions/getJudgeForCurrentUserAction';
 import { getMaintenanceModeAction } from '../actions/getMaintenanceModeAction';
@@ -95,6 +96,11 @@ const goToDashboard = [
                 petitioner: [
                   setDefaultCaseTypeToDisplayAction,
                   getOpenAndClosedCasesForUserAction,
+                  getFeatureFlagValueFactoryAction(
+                    getConstants().ALLOWLIST_FEATURE_FLAGS
+                      .CONSOLIDATED_CASES_PARTY_ASSOCIATION,
+                    true,
+                  ),
                   setCasesAction,
                   setCurrentPageAction('DashboardPetitioner'),
                 ],

--- a/web-client/src/views/CaseListPetitioner.jsx
+++ b/web-client/src/views/CaseListPetitioner.jsx
@@ -14,6 +14,7 @@ export const CaseListPetitioner = connect(
       sequences.clearOpenClosedCasesCurrentPageSequence,
     closedTab: state.constants.EXTERNAL_USER_DASHBOARD_TABS.CLOSED,
     externalUserCasesHelper: state.externalUserCasesHelper,
+    featureFlagHelper: state.featureFlagHelper,
     openTab: state.constants.EXTERNAL_USER_DASHBOARD_TABS.OPEN,
     setCaseTypeToDisplaySequence: sequences.setCaseTypeToDisplaySequence,
     showMoreClosedCasesSequence: sequences.showMoreClosedCasesSequence,
@@ -24,6 +25,7 @@ export const CaseListPetitioner = connect(
     clearOpenClosedCasesCurrentPageSequence,
     closedTab,
     externalUserCasesHelper,
+    featureFlagHelper,
     openTab,
     setCaseTypeToDisplaySequence,
     showMoreClosedCasesSequence,
@@ -75,9 +77,11 @@ export const CaseListPetitioner = connect(
                 <tbody>
                   {cases.map(item => (
                     <CaseListRowExternal
-                      onlyLinkIfRequestedUserAssociated
                       formattedCase={item}
                       key={item.docketNumber}
+                      onlyLinkIfRequestedUserAssociated={
+                        !featureFlagHelper.consolidatedCasesPartyAssociation
+                      }
                     />
                   ))}
                 </tbody>
@@ -119,6 +123,7 @@ export const CaseListPetitioner = connect(
                   >
                     {renderCaseListTable({
                       cases: externalUserCasesHelper.openCaseResults,
+                      featureFlagHelper,
                       showLoadMore:
                         externalUserCasesHelper.showLoadMoreOpenCases,
                       showMoreResultsSequence: showMoreOpenCasesSequence,
@@ -132,6 +137,7 @@ export const CaseListPetitioner = connect(
                   >
                     {renderCaseListTable({
                       cases: externalUserCasesHelper.closedCaseResults,
+                      featureFlagHelper,
                       showLoadMore:
                         externalUserCasesHelper.showLoadMoreClosedCases,
                       showMoreResultsSequence: showMoreClosedCasesSequence,
@@ -171,6 +177,7 @@ export const CaseListPetitioner = connect(
               {caseType === closedTab &&
                 renderCaseListTable({
                   cases: externalUserCasesHelper.closedCaseResults,
+                  featureFlagHelper,
                   showLoadMore: externalUserCasesHelper.showLoadMoreClosedCases,
                   showMoreResultsSequence: showMoreClosedCasesSequence,
                   tabName: closedTab,
@@ -178,6 +185,7 @@ export const CaseListPetitioner = connect(
               {caseType === openTab &&
                 renderCaseListTable({
                   cases: externalUserCasesHelper.openCaseResults,
+                  featureFlagHelper,
                   showLoadMore: externalUserCasesHelper.showLoadMoreOpenCases,
                   showMoreResultsSequence: showMoreOpenCasesSequence,
                   tabName: openTab,


### PR DESCRIPTION
# [9594](https://github.com/flexion/ef-cms/issues/9594)

Adds a feature flag called consolidated-cases-party-association which is then used to determine whether we should show a link on CaseListPetitioner.jsx.