### PR TITLE
9493: fix service in save then serve flow 

### DIFF
--- a/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
+++ b/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
@@ -547,6 +547,23 @@ describe('serveExternallyFiledDocumentInteractor', () => {
     });
   });
 
+  it('should send a serve_document_complete notification WITHOUT a paper service url when none of the served cases have paper service parties', async () => {
+    caseRecord.petitioners[0].serviceIndicator =
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC;
+
+    await serveExternallyFiledDocumentInteractor(applicationContext, {
+      clientConnectionId,
+      docketEntryId: caseRecord.docketEntries[0].docketEntryId,
+      docketNumbers: [caseRecord.docketNumber],
+      subjectCaseDocketNumber: DOCKET_NUMBER,
+    });
+
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser.mock
+        .calls[0][0].message.pdfUrl,
+    ).toBeUndefined();
+  });
+
   it('throws an error when the docket entry does not exist on the subject case', async () => {
     const mockNonExistentDocketEntryId = 'd9f645b1-c0b6-4782-a798-091760343573';
 

--- a/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
+++ b/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
@@ -142,7 +142,9 @@ describe('serveExternallyFiledDocumentInteractor', () => {
       subjectCaseDocketNumber: DOCKET_NUMBER,
     });
 
-    expect(addCoverToPdf).toHaveBeenCalledTimes(1);
+    expect(
+      (addCoverToPdf as jest.Mock).mock.calls[0][0].docketEntryEntity.index,
+    ).toBeDefined();
   });
 
   it('should call serveDocumentAndGetPaperServicePdf to generate a paper service pdf', async () => {

--- a/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
+++ b/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
@@ -5,6 +5,7 @@ import {
   DOCKET_SECTION,
   PARTY_TYPES,
   ROLES,
+  SERVICE_INDICATOR_TYPES,
 } from '../../entities/EntityConstants';
 import {
   ENTERED_AND_SERVED_EVENT_CODES,
@@ -71,6 +72,7 @@ describe('serveExternallyFiledDocumentInteractor', () => {
           name: 'Guy Fieri',
           phone: '1234567890',
           postalCode: '12345',
+          serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
           state: 'CA',
         },
       ],

--- a/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
+++ b/shared/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
@@ -26,8 +26,8 @@ const { omit } = require('lodash');
  * @param {Object} applicationContext the application context
  * @param {Object} providers the providers object
  * @param {object} providers.clientConnectionId the client connection Id
- * @param {String[]} providers.docketNumbers the docket numbers that this docket entry needs to be filed and served on, will be one or more docket numbers
  * @param {String} providers.docketEntryId the ID of the docket entry being filed and served
+ * @param {String[]} providers.docketNumbers the docket numbers that this docket entry needs to be filed and served on, will be one or more docket numbers
  * @param {String} providers.subjectCaseDocketNumber the docket number that initiated the filing and service
  */
 export const serveExternallyFiledDocumentInteractor = async (
@@ -158,10 +158,16 @@ export const serveExternallyFiledDocumentInteractor = async (
       caseEntities.push(caseEntityToUpdate);
     }
 
+    const updatedSubjectCaseEntity = caseEntities.find(
+      c => c.docketNumber === subjectCaseDocketNumber,
+    );
+    const updatedSubjectDocketEntry =
+      updatedSubjectCaseEntity.getDocketEntryById({ docketEntryId });
+
     const { pdfData: servedDocWithCover } = await addCoverToPdf({
       applicationContext,
-      caseEntity: subjectCaseEntity,
-      docketEntryEntity: originalSubjectDocketEntry,
+      caseEntity: updatedSubjectCaseEntity,
+      docketEntryEntity: updatedSubjectDocketEntry,
       pdfData,
     });
 


### PR DESCRIPTION
this resolves issue with test case 11, which checks save for later then serve flow.
the bug was that a consolidated group without parties with paper service, pdfUrl was undefined and we needed to check for parties with paper service.

this also resolves an issue with SINGLE_DOCKET_RECORD_ONLY_EVENT_CODES not having an index (document no.) on the coversheet due to the docket entry not being updated when it was passed to `addCoverToPdf`