### PR TITLE
9681 - Extract stampDocument into useCaseHelper

### DIFF
--- a/shared/src/business/useCaseHelper/stampDocumentForService.js
+++ b/shared/src/business/useCaseHelper/stampDocumentForService.js
@@ -1,0 +1,34 @@
+const {
+  createISODateString,
+  formatDateString,
+} = require('../utilities/DateHandler');
+const {
+  ENTERED_AND_SERVED_EVENT_CODES,
+  GENERIC_ORDER_DOCUMENT_TYPE,
+} = require('../entities/courtIssuedDocument/CourtIssuedDocumentConstants');
+
+exports.stampDocumentForService = async ({
+  applicationContext,
+  documentToStamp,
+  pdfData,
+}) => {
+  const servedAt = createISODateString();
+
+  let serviceStampType = 'Served';
+
+  if (documentToStamp.documentType === GENERIC_ORDER_DOCUMENT_TYPE) {
+    serviceStampType = documentToStamp.serviceStamp;
+  } else if (
+    ENTERED_AND_SERVED_EVENT_CODES.includes(documentToStamp.eventCode)
+  ) {
+    serviceStampType = 'Entered and Served';
+  }
+
+  const serviceStampDate = formatDateString(servedAt, 'MMDDYY');
+
+  return await applicationContext.getUseCaseHelpers().addServedStampToDocument({
+    applicationContext,
+    pdfData,
+    serviceStampText: `${serviceStampType} ${serviceStampDate}`,
+  });
+};

--- a/shared/src/business/useCaseHelper/stampDocumentForService.js
+++ b/shared/src/business/useCaseHelper/stampDocumentForService.js
@@ -1,8 +1,4 @@
 const {
-  createISODateString,
-  formatDateString,
-} = require('../utilities/DateHandler');
-const {
   ENTERED_AND_SERVED_EVENT_CODES,
   GENERIC_ORDER_DOCUMENT_TYPE,
 } = require('../entities/courtIssuedDocument/CourtIssuedDocumentConstants');
@@ -12,8 +8,6 @@ exports.stampDocumentForService = async ({
   documentToStamp,
   pdfData,
 }) => {
-  const servedAt = createISODateString();
-
   let serviceStampType = 'Served';
 
   if (documentToStamp.documentType === GENERIC_ORDER_DOCUMENT_TYPE) {
@@ -24,7 +18,10 @@ exports.stampDocumentForService = async ({
     serviceStampType = 'Entered and Served';
   }
 
-  const serviceStampDate = formatDateString(servedAt, 'MMDDYY');
+  const servedAt = applicationContext.getUtilities().createISODateString();
+  const serviceStampDate = applicationContext
+    .getUtilities()
+    .formatDateString(servedAt, 'MMDDYY');
 
   return await applicationContext.getUseCaseHelpers().addServedStampToDocument({
     applicationContext,

--- a/shared/src/business/useCaseHelper/stampDocumentForService.test.js
+++ b/shared/src/business/useCaseHelper/stampDocumentForService.test.js
@@ -5,8 +5,6 @@ const { applicationContext } = require('../test/createTestApplicationContext');
 const { stampDocumentForService } = require('./stampDocumentForService');
 
 describe('stampDocumentForService', () => {
-  beforeEach(() => {});
-
   it('should set `Served` as the stamp text when the documentType is NOT order and the document eventCode is not one of ENTERED_AND_SERVED_EVENT_CODES', async () => {
     await stampDocumentForService({
       applicationContext,

--- a/shared/src/business/useCaseHelper/stampDocumentForService.test.js
+++ b/shared/src/business/useCaseHelper/stampDocumentForService.test.js
@@ -7,7 +7,7 @@ const { stampDocumentForService } = require('./stampDocumentForService');
 describe('stampDocumentForService', () => {
   beforeEach(() => {});
 
-  it('should set `Served` as the serviceStampType when the documentType is NOT order and the document eventCode is not one of ENTERED_AND_SERVED_EVENT_CODES', async () => {
+  it('should set `Served` as the stamp text when the documentType is NOT order and the document eventCode is not one of ENTERED_AND_SERVED_EVENT_CODES', async () => {
     await stampDocumentForService({
       applicationContext,
       documentToStamp: {
@@ -23,7 +23,7 @@ describe('stampDocumentForService', () => {
     ).toContain('Served');
   });
 
-  it('should set serviceStampType from the document when the documentType is Order', async () => {
+  it('should set stamp text from the document when the documentType is Order', async () => {
     const mockServiceStamp = 'This document is urgent!';
 
     await stampDocumentForService({
@@ -41,7 +41,7 @@ describe('stampDocumentForService', () => {
     ).toContain(mockServiceStamp);
   });
 
-  it('should include `Entered and Served` in the serviceStampType when the eventCode is in ENTERED_AND_SERVED_EVENT_CODES', async () => {
+  it('should set `Entered and Served` as the stamp text when the eventCode is in ENTERED_AND_SERVED_EVENT_CODES', async () => {
     await stampDocumentForService({
       applicationContext,
       documentToStamp: {
@@ -54,5 +54,27 @@ describe('stampDocumentForService', () => {
       applicationContext.getUseCaseHelpers().addServedStampToDocument.mock
         .calls[0][0].serviceStampText,
     ).toContain('Entered and Served');
+  });
+
+  it('should include the date served as today, formatted as "MMDDYY" in the service stamp', async () => {
+    const mockToday = '2009-03-01T21:40:46.415Z';
+    const mockTodayFormatted = applicationContext
+      .getUtilities()
+      .formatDateString(mockToday, 'MMDDYY');
+
+    applicationContext
+      .getUtilities()
+      .createISODateString.mockReturnValue(mockToday);
+
+    await stampDocumentForService({
+      applicationContext,
+      documentToStamp: {},
+      pdfData: {},
+    });
+
+    expect(
+      applicationContext.getUseCaseHelpers().addServedStampToDocument.mock
+        .calls[0][0].serviceStampText,
+    ).toContain(mockTodayFormatted);
   });
 });

--- a/shared/src/business/useCaseHelper/stampDocumentForService.test.js
+++ b/shared/src/business/useCaseHelper/stampDocumentForService.test.js
@@ -1,0 +1,51 @@
+const {
+  applicationContext,
+  testPdfDoc,
+} = require('../test/createTestApplicationContext');
+const {
+  MOCK_CASE,
+  MOCK_LEAD_CASE_WITH_PAPER_SERVICE,
+} = require('../../test/mockCase');
+const { Case, getContactPrimary } = require('../entities/cases/Case');
+const { SERVICE_INDICATOR_TYPES } = require('../entities/EntityConstants');
+const { stampDocumentForService } = require('./stampDocumentForService');
+
+describe('stampDocumentForService', () => {
+  let caseEntity;
+
+  const mockPdfUrl = 'www.example.com';
+  const mockDocketEntryId = 'cf105788-5d34-4451-aa8d-dfd9a851b675';
+
+  beforeEach(() => {
+    caseEntity = new Case(MOCK_CASE, { applicationContext });
+
+    applicationContext.getStorageClient().getObject.mockReturnValue({
+      promise: () => ({
+        Body: testPdfDoc,
+      }),
+    });
+
+    applicationContext
+      .getPersistenceGateway()
+      .getDownloadPolicyUrl.mockReturnValue({ url: mockPdfUrl });
+  });
+
+  it('should include `Entered and Served` in the serviceStampType when the eventCode is in ENTERED_AND_SERVED_EVENT_CODES', async () => {
+    await fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
+      clientConnectionId: mockClientConnectionId,
+      docketEntryId: caseRecord.docketEntries[0].docketEntryId,
+      docketNumbers: [caseRecord.docketNumber],
+      form: {
+        ...caseRecord.docketEntries[0],
+        documentType: 'Notice',
+        eventCode: 'ODJ',
+      },
+      subjectCaseDocketNumber: caseRecord.docketNumber,
+    });
+
+    expect(
+      applicationContext.getUseCaseHelpers().addServedStampToDocument.mock
+        .calls[0][0].serviceStampText,
+    ).toContain('Entered and Served');
+  });
+});

--- a/shared/src/business/useCaseHelper/stampDocumentForService.test.js
+++ b/shared/src/business/useCaseHelper/stampDocumentForService.test.js
@@ -1,46 +1,53 @@
 const {
-  applicationContext,
-  testPdfDoc,
-} = require('../test/createTestApplicationContext');
-const {
-  MOCK_CASE,
-  MOCK_LEAD_CASE_WITH_PAPER_SERVICE,
-} = require('../../test/mockCase');
-const { Case, getContactPrimary } = require('../entities/cases/Case');
-const { SERVICE_INDICATOR_TYPES } = require('../entities/EntityConstants');
+  ENTERED_AND_SERVED_EVENT_CODES,
+} = require('../entities/courtIssuedDocument/CourtIssuedDocumentConstants');
+const { applicationContext } = require('../test/createTestApplicationContext');
 const { stampDocumentForService } = require('./stampDocumentForService');
 
 describe('stampDocumentForService', () => {
-  let caseEntity;
+  beforeEach(() => {});
 
-  const mockPdfUrl = 'www.example.com';
-  const mockDocketEntryId = 'cf105788-5d34-4451-aa8d-dfd9a851b675';
-
-  beforeEach(() => {
-    caseEntity = new Case(MOCK_CASE, { applicationContext });
-
-    applicationContext.getStorageClient().getObject.mockReturnValue({
-      promise: () => ({
-        Body: testPdfDoc,
-      }),
+  it('should set `Served` as the serviceStampType when the documentType is NOT order and the document eventCode is not one of ENTERED_AND_SERVED_EVENT_CODES', async () => {
+    await stampDocumentForService({
+      applicationContext,
+      documentToStamp: {
+        documentType: 'Motion to Withdraw as Counsel',
+        eventCode: 'M112',
+      },
+      pdfData: {},
     });
 
-    applicationContext
-      .getPersistenceGateway()
-      .getDownloadPolicyUrl.mockReturnValue({ url: mockPdfUrl });
+    expect(
+      applicationContext.getUseCaseHelpers().addServedStampToDocument.mock
+        .calls[0][0].serviceStampText,
+    ).toContain('Served');
+  });
+
+  it('should set serviceStampType from the document when the documentType is Order', async () => {
+    const mockServiceStamp = 'This document is urgent!';
+
+    await stampDocumentForService({
+      applicationContext,
+      documentToStamp: {
+        documentType: 'Order',
+        serviceStamp: mockServiceStamp,
+      },
+      pdfData: {},
+    });
+
+    expect(
+      applicationContext.getUseCaseHelpers().addServedStampToDocument.mock
+        .calls[0][0].serviceStampText,
+    ).toContain(mockServiceStamp);
   });
 
   it('should include `Entered and Served` in the serviceStampType when the eventCode is in ENTERED_AND_SERVED_EVENT_CODES', async () => {
-    await fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
-      clientConnectionId: mockClientConnectionId,
-      docketEntryId: caseRecord.docketEntries[0].docketEntryId,
-      docketNumbers: [caseRecord.docketNumber],
-      form: {
-        ...caseRecord.docketEntries[0],
-        documentType: 'Notice',
-        eventCode: 'ODJ',
+    await stampDocumentForService({
+      applicationContext,
+      documentToStamp: {
+        eventCode: ENTERED_AND_SERVED_EVENT_CODES[0],
       },
-      subjectCaseDocketNumber: caseRecord.docketNumber,
+      pdfData: {},
     });
 
     expect(

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.test.ts
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.test.ts
@@ -94,6 +94,10 @@ describe('fileAndServeCourtIssuedDocumentInteractor', () => {
       .serveDocumentAndGetPaperServicePdf.mockReturnValue({
         pdfUrl: mockPdfUrl,
       });
+
+    applicationContext
+      .getUseCaseHelpers()
+      .stampDocumentForService.mockReturnValue(testPdfDoc);
   });
 
   it('should throw an error when the user is not authorized to file and serve a court issued document', async () => {
@@ -245,25 +249,6 @@ describe('fileAndServeCourtIssuedDocumentInteractor', () => {
       docketNumber: caseRecord.docketNumber,
       status: false,
     });
-  });
-
-  it('should include `Entered and Served` in the serviceStampType when the eventCode is in ENTERED_AND_SERVED_EVENT_CODES', async () => {
-    await fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
-      clientConnectionId: mockClientConnectionId,
-      docketEntryId: caseRecord.docketEntries[0].docketEntryId,
-      docketNumbers: [caseRecord.docketNumber],
-      form: {
-        ...caseRecord.docketEntries[0],
-        documentType: 'Notice',
-        eventCode: 'ODJ',
-      },
-      subjectCaseDocketNumber: caseRecord.docketNumber,
-    });
-
-    expect(
-      applicationContext.getUseCaseHelpers().addServedStampToDocument.mock
-        .calls[0][0].serviceStampText,
-    ).toContain('Entered and Served');
   });
 
   it('should save the generated notice to s3', async () => {

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.test.ts
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.test.ts
@@ -163,6 +163,20 @@ describe('fileAndServeCourtIssuedDocumentInteractor', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('should make a call to stamp the document as served', async () => {
+    await fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
+      clientConnectionId: mockClientConnectionId,
+      docketEntryId: caseRecord.docketEntries[0].docketEntryId,
+      docketNumbers: [caseRecord.docketNumber],
+      form: caseRecord.docketEntries[0],
+      subjectCaseDocketNumber: caseRecord.docketNumber,
+    });
+
+    expect(
+      applicationContext.getUseCaseHelpers().stampDocumentForService,
+    ).toHaveBeenCalled();
+  });
+
   it('should count the number of pages in the document to be served', async () => {
     const mockNumberOfPages = 90;
     applicationContext

--- a/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.ts
+++ b/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.ts
@@ -1,10 +1,7 @@
 import { Case } from '../../entities/cases/Case';
 import { DOCKET_SECTION } from '../../entities/EntityConstants';
 import { DocketEntry } from '../../entities/DocketEntry';
-import {
-  ENTERED_AND_SERVED_EVENT_CODES,
-  GENERIC_ORDER_DOCUMENT_TYPE,
-} from '../../entities/courtIssuedDocument/CourtIssuedDocumentConstants';
+import { ENTERED_AND_SERVED_EVENT_CODES } from '../../entities/courtIssuedDocument/CourtIssuedDocumentConstants';
 import { NotFoundError, UnauthorizedError } from '../../../errors/errors';
 import {
   ROLE_PERMISSIONS,
@@ -12,12 +9,8 @@ import {
 } from '../../../authorization/authorizationClientService';
 import { TrialSession } from '../../entities/trialSessions/TrialSession';
 import { WorkItem } from '../../entities/WorkItem';
-import { addServedStampToDocument } from './addServedStampToDocument';
 import { aggregatePartiesForService } from '../../utilities/aggregatePartiesForService';
-import {
-  createISODateString,
-  formatDateString,
-} from '../../utilities/DateHandler';
+import { createISODateString } from '../../utilities/DateHandler';
 
 const completeWorkItem = async ({
   applicationContext,
@@ -137,11 +130,21 @@ export const serveCourtIssuedDocumentInteractor = async (
       docketEntryId,
     });
 
-  const stampedPdf = await retrieveAndStampDocument({
-    applicationContext,
-    courtIssuedDocument,
-    docketEntryId,
-  });
+  const { Body: pdfData } = await applicationContext
+    .getStorageClient()
+    .getObject({
+      Bucket: applicationContext.environment.documentsBucketName,
+      Key: docketEntryId,
+    })
+    .promise();
+
+  const stampedPdf = await applicationContext
+    .getUseCaseHelpers()
+    .stampDocumentForService({
+      applicationContext,
+      documentToStamp: courtIssuedDocument,
+      pdfData,
+    });
 
   let serviceResults;
 
@@ -312,39 +315,6 @@ const serveDocumentOnOneCase = async ({
     });
 
   return new Case(validRawCaseEntity, { applicationContext });
-};
-
-const retrieveAndStampDocument = async ({
-  applicationContext,
-  courtIssuedDocument,
-  docketEntryId,
-}) => {
-  const { Body: pdfData } = await applicationContext
-    .getStorageClient()
-    .getObject({
-      Bucket: applicationContext.environment.documentsBucketName,
-      Key: docketEntryId,
-    })
-    .promise();
-
-  let serviceStampType = 'Served';
-
-  if (courtIssuedDocument.documentType === GENERIC_ORDER_DOCUMENT_TYPE) {
-    serviceStampType = courtIssuedDocument.serviceStamp;
-  } else if (
-    ENTERED_AND_SERVED_EVENT_CODES.includes(courtIssuedDocument.eventCode)
-  ) {
-    serviceStampType = 'Entered and Served';
-  }
-
-  const servedAt = createISODateString();
-  const serviceStampDate = formatDateString(servedAt, 'MMDDYY');
-
-  return await addServedStampToDocument({
-    applicationContext,
-    pdfData,
-    serviceStampText: `${serviceStampType} ${serviceStampDate}`,
-  });
 };
 
 const closeCaseAndUpdateTrialSessionForEnteredAndServedDocuments = async ({

--- a/web-api/src/getUseCaseHelpers.js
+++ b/web-api/src/getUseCaseHelpers.js
@@ -113,6 +113,9 @@ const {
   setPdfFormFields,
 } = require('../../shared/src/business/useCaseHelper/pdf/setPdfFormFields');
 const {
+  stampDocumentForService,
+} = require('../../shared/src/business/useCaseHelper/stampDocumentForService');
+const {
   updateAssociatedJudgeOnWorkItems,
 } = require('../../shared/src/business/useCaseHelper/workItems/updateAssociatedJudgeOnWorkItems');
 const {
@@ -176,6 +179,7 @@ const useCaseHelpers = {
   setNoticeOfChangeToInPersonProceeding,
   setNoticeOfChangeToRemoteProceeding,
   setPdfFormFields,
+  stampDocumentForService,
   updateAssociatedJudgeOnWorkItems,
   updateCaseAndAssociations,
   updateCaseAutomaticBlock,


### PR DESCRIPTION
Next step: Use `stampDocumentForService` in `serveCourtIssuedDocumentInteractor`