### PR TITLE
9681 misc refactoring

### DIFF
--- a/web-client/src/presenter/sequences/openConfirmInitiateCourtIssuedFilingServiceModalSequence.js
+++ b/web-client/src/presenter/sequences/openConfirmInitiateCourtIssuedFilingServiceModalSequence.js
@@ -1,8 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { getConsolidatedCasesByCaseAction } from '../actions/CaseConsolidation/getConsolidatedCasesByCaseAction';
-import { getConstants } from '../../getConstants';
-import { getFeatureFlagValueFactoryAction } from '../actions/getFeatureFlagValueFactoryAction';
 import { setConsolidatedCasesForCaseAction } from '../actions/CaseConsolidation/setConsolidatedCasesForCaseAction';
 import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
@@ -20,10 +18,6 @@ export const openConfirmInitiateCourtIssuedFilingServiceModalSequence = [
     error: [setValidationErrorsAction, setValidationAlertErrorsAction],
     success: [
       clearModalStateAction,
-      getFeatureFlagValueFactoryAction(
-        getConstants().ALLOWLIST_FEATURE_FLAGS.MULTI_DOCKETABLE_PAPER_FILINGS,
-        true,
-      ),
       getConsolidatedCasesByCaseAction,
       setConsolidatedCasesForCaseAction,
       shouldSetupConsolidatedCasesAction,

--- a/web-client/src/views/ConfirmInitiateCourtIssuedFilingServiceModal.jsx
+++ b/web-client/src/views/ConfirmInitiateCourtIssuedFilingServiceModal.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 
 export const ConfirmInitiateCourtIssuedFilingServiceModal = connect(
   {
-    areMultiDocketablePaperFilingsEnabledFlag: state.featureFlagHelper,
     cancelSequence: sequences.dismissModalSequence,
     confirmInitiateCourtIssuedFilingServiceModalHelper:
       state.confirmInitiateCourtIssuedFilingServiceModalHelper,

--- a/web-client/src/views/ConfirmInitiatePaperFilingServiceModal.jsx
+++ b/web-client/src/views/ConfirmInitiatePaperFilingServiceModal.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 
 export const ConfirmInitiatePaperFilingServiceModal = connect(
   {
-    areMultiDocketablePaperFilingsEnabledFlag: state.featureFlagHelper,
     cancelSequence: sequences.dismissModalSequence,
     confirmInitiatePaperFilingServiceModalHelper:
       state.confirmInitiatePaperFilingServiceModalHelper,


### PR DESCRIPTION
flexion#9681

- openConfirmInitiateCourtIssuedFilingServiceModalSequence doesn't need to getFeatureFlagValueFactoryAction for MULTI_DOCKETABLE_PAPER_FILINGS
- areMultiDocketablePaperFilingsEnabledFlag is unused in [ConfirmInitiateCourtIssuedFilingServiceModal.jsx](https://github.com/ustaxcourt/ef-cms/pull/2695/files#diff-18563db4bff7253ce7507256e46c24157b97f88934d41b9667e5c67325df562c)