### PR TITLE
9681: remove default DOCKET_SECTION 

### DIFF
--- a/shared/src/business/entities/WorkItem.js
+++ b/shared/src/business/entities/WorkItem.js
@@ -78,10 +78,10 @@ joiValidationDecorator(WorkItem, WORK_ITEM_VALIDATION_RULES);
  * @param {object} props the props object
  * @param {string} props.assigneeId the user id of the user to assign the work item to
  * @param {string} props.assigneeName the name of the user to assign the work item to
- * @param {string} props.role the role of the user to assign the work item to
+ * @param {string} props.section the section of the user to assign the work item to
  * @param {string} props.sentBy the name of the user who sent the work item
+ * @param {string} props.sentBySection the section of the user who sent the work item
  * @param {string} props.sentByUserId the user id of the user who sent the work item
- * @param {string} props.sentByUserRole the role of the user who sent the work item
  * @returns {WorkItem} the updated work item
  */
 WorkItem.prototype.assignToUser = function ({

--- a/shared/src/business/useCaseHelper/docketEntry/fileDocumentOnOneCase.js
+++ b/shared/src/business/useCaseHelper/docketEntry/fileDocumentOnOneCase.js
@@ -111,9 +111,9 @@ const completeWorkItem = async ({
   workItemToUpdate.assignToUser({
     assigneeId: user.userId,
     assigneeName: user.name,
-    section: user.section ? user.section : DOCKET_SECTION,
+    section: user.section,
     sentBy: user.name,
-    sentBySection: user.section ? user.section : DOCKET_SECTION,
+    sentBySection: user.section,
     sentByUserId: user.userId,
   });
 

--- a/shared/src/business/useCaseHelper/docketEntry/fileDocumentOnOneCase.test.js
+++ b/shared/src/business/useCaseHelper/docketEntry/fileDocumentOnOneCase.test.js
@@ -205,7 +205,7 @@ describe('fileDocumentOnOneCase', () => {
       caseEntity: mockCaseEntity,
       docketEntryEntity: mockDocketEntry,
       subjectCaseDocketNumber: MOCK_LEAD_CASE_WITH_PAPER_SERVICE.docketNumber,
-      user: { ...docketClerkUser, section: undefined },
+      user: docketClerkUser,
     });
 
     const expectedDocketEntry = applicationContext

--- a/web-client/integration-tests/docketClerkAddsPaperFilingOnLeadCase.test.js
+++ b/web-client/integration-tests/docketClerkAddsPaperFilingOnLeadCase.test.js
@@ -145,9 +145,12 @@ describe('Docket clerk adds paper filing on lead case', () => {
       overwritable: false,
     });
 
-    expect(
-      cerebralTest.getState('currentViewMetadata.caseDetail.docketRecordTab'),
-    ).toEqual('documentView');
+    await waitForCondition({
+      booleanExpressionCondition: () =>
+        cerebralTest.getState(
+          'currentViewMetadata.caseDetail.docketRecordTab',
+        ) === 'documentView',
+    });
   });
 
   it('verify multi-docketed document has been filed on every case in the consolidated group', async () => {


### PR DESCRIPTION
Only petitionsClerk and docketClerk can serve documents, and they should have a section assigned. Updated outdated jsdocs

flexion#9681