### PR TITLE
9818: Display petition email address and e-consent checkbox for each petitioner

### DIFF
--- a/web-client/src/presenter/actions/setFormValueAction.ts
+++ b/web-client/src/presenter/actions/setFormValueAction.ts
@@ -8,7 +8,6 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  */
 export const setFormValueAction = ({ props, store }) => {
-  console.log('props', props);
   if (props.value !== '' && props.value !== null) {
     store.set(state.form[props.key], props.value);
   } else {

--- a/web-client/src/presenter/actions/setFormValueAction.ts
+++ b/web-client/src/presenter/actions/setFormValueAction.ts
@@ -8,6 +8,7 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  */
 export const setFormValueAction = ({ props, store }) => {
+  console.log('props', props);
   if (props.value !== '' && props.value !== null) {
     store.set(state.form[props.key], props.value);
   } else {

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -203,13 +203,12 @@ export const ContactPrimary = connect(
               onChange={onChange}
             />
           )}
-          <FormGroup className="paper-petition-email-input">
+          <FormGroup>
             <label className="usa-label" htmlFor="paper-petition-email-primary">
               Petition email address{' '}
               <span className="usa-hint">(optional)</span>
             </label>
             <input
-              autoCapitalize="none"
               className="usa-input"
               id="paper-petition-email-primary"
               name="contactPrimary.paperPetitionEmail"
@@ -226,7 +225,7 @@ export const ContactPrimary = connect(
               }}
             />
           </FormGroup>
-          <FormGroup className="electronic-service-consent-input">
+          <FormGroup>
             <div className="usa-checkbox">
               <input
                 checked={data.contactPrimary.hasConsentedToEService || false}

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -204,14 +204,14 @@ export const ContactPrimary = connect(
             />
           )}
           <FormGroup className="paper-petition-email-input">
-            <label className="usa-label" htmlFor="paper-petition-email">
+            <label className="usa-label" htmlFor="paper-petition-email-primary">
               Petition email address{' '}
               <span className="usa-hint">(optional)</span>
             </label>
             <input
               autoCapitalize="none"
               className="usa-input max-width-200"
-              id="paper-petition-email"
+              id="paper-petition-email-primary"
               name="contactPrimary.paperPetitionEmail"
               type="email"
               value={data.contactPrimary.paperPetitionEmail || ''}
@@ -231,7 +231,7 @@ export const ContactPrimary = connect(
               <input
                 checked={data.contactPrimary.hasConsentedToEService || false}
                 className="usa-checkbox__input"
-                id="electronic-service-consent"
+                id="electronic-service-consent-primary"
                 name="contactPrimary.hasConsentedToEService"
                 type="checkbox"
                 onChange={e => {
@@ -243,7 +243,7 @@ export const ContactPrimary = connect(
               />
               <label
                 className="usa-checkbox__label"
-                htmlFor="electronic-service-consent"
+                htmlFor="electronic-service-consent-primary"
               >
                 E-service consent
               </label>

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -228,12 +228,6 @@ export const ContactPrimary = connect(
           </FormGroup>
           <FormGroup className="electronic-service-consent-input">
             <div className="usa-checkbox">
-              <label
-                className="usa-checkbox__label"
-                htmlFor="electronic-service-consent"
-              >
-                E-service consent
-              </label>
               <input
                 checked={data.contactPrimary.hasConsentedToEService || false}
                 className="usa-checkbox__input"
@@ -243,10 +237,16 @@ export const ContactPrimary = connect(
                 onChange={e => {
                   updateFormValueAndSecondaryContactInfoSequence({
                     key: e.target.name,
-                    value: e.target.value,
+                    value: e.target.checked,
                   });
                 }}
               />
+              <label
+                className="usa-checkbox__label"
+                htmlFor="electronic-service-consent"
+              >
+                E-service consent
+              </label>
             </div>
           </FormGroup>
           <FormGroup

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -203,7 +203,7 @@ export const ContactPrimary = connect(
               onChange={onChange}
             />
           )}
-          <FormGroup className="paper-petition-email-input" errorText={}>
+          <FormGroup className="paper-petition-email-input">
             <label className="usa-label" htmlFor="paper-petition-email">
               Petition email address{' '}
               <span className="usa-hint">(optional)</span>
@@ -213,11 +213,29 @@ export const ContactPrimary = connect(
               className="usa-input max-width-200"
               id="paper-petition-email"
               name="contactPrimary.paperPetitionEmail"
-              type="tel"
-              value={data.contactPrimary.phone || ''}
+              type="email"
+              value={data.contactPrimary.paperPetitionEmail || ''}
               onBlur={() => {
                 onBlurSequence();
               }}
+              onChange={e => {
+                updateFormValueAndSecondaryContactInfoSequence({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+              }}
+            />
+          </FormGroup>
+          <FormGroup className="electronic-service-consent-input">
+            <label className="usa-label" htmlFor="electronic-service-consent">
+              E-service consent
+            </label>
+            <input
+              checked={data.contactPrimary.hasConsentedToEService || false}
+              className="usa-checkbox__input"
+              id="electronic-service-consent"
+              name="contactPrimary.hasConsentedToEService"
+              type="checkbox"
               onChange={e => {
                 updateFormValueAndSecondaryContactInfoSequence({
                   key: e.target.name,

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -227,22 +227,27 @@ export const ContactPrimary = connect(
             />
           </FormGroup>
           <FormGroup className="electronic-service-consent-input">
-            <label className="usa-label" htmlFor="electronic-service-consent">
-              E-service consent
-            </label>
-            <input
-              checked={data.contactPrimary.hasConsentedToEService || false}
-              className="usa-checkbox__input"
-              id="electronic-service-consent"
-              name="contactPrimary.hasConsentedToEService"
-              type="checkbox"
-              onChange={e => {
-                updateFormValueAndSecondaryContactInfoSequence({
-                  key: e.target.name,
-                  value: e.target.value,
-                });
-              }}
-            />
+            <div className="usa-checkbox">
+              <label
+                className="usa-checkbox__label"
+                htmlFor="electronic-service-consent"
+              >
+                E-service consent
+              </label>
+              <input
+                checked={data.contactPrimary.hasConsentedToEService || false}
+                className="usa-checkbox__input"
+                id="electronic-service-consent"
+                name="contactPrimary.hasConsentedToEService"
+                type="checkbox"
+                onChange={e => {
+                  updateFormValueAndSecondaryContactInfoSequence({
+                    key: e.target.name,
+                    value: e.target.value,
+                  });
+                }}
+              />
+            </div>
           </FormGroup>
           <FormGroup
             className="phone-input"

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -226,27 +226,25 @@ export const ContactPrimary = connect(
             />
           </FormGroup>
           <FormGroup>
-            <div className="usa-checkbox">
-              <input
-                checked={data.contactPrimary.hasConsentedToEService || false}
-                className="usa-checkbox__input"
-                id="electronic-service-consent-primary"
-                name="contactPrimary.hasConsentedToEService"
-                type="checkbox"
-                onChange={e => {
-                  updateFormValueAndSecondaryContactInfoSequence({
-                    key: e.target.name,
-                    value: e.target.checked,
-                  });
-                }}
-              />
-              <label
-                className="usa-checkbox__label"
-                htmlFor="electronic-service-consent-primary"
-              >
-                E-service consent
-              </label>
-            </div>
+            <input
+              checked={data.contactPrimary.hasConsentedToEService || false}
+              className="usa-checkbox__input"
+              id="electronic-service-consent-primary"
+              name="contactPrimary.hasConsentedToEService"
+              type="checkbox"
+              onChange={e => {
+                updateFormValueAndSecondaryContactInfoSequence({
+                  key: e.target.name,
+                  value: e.target.checked,
+                });
+              }}
+            />
+            <label
+              className="usa-checkbox__label"
+              htmlFor="electronic-service-consent-primary"
+            >
+              E-service consent
+            </label>
           </FormGroup>
           <FormGroup
             className="phone-input"

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -210,7 +210,7 @@ export const ContactPrimary = connect(
             </label>
             <input
               autoCapitalize="none"
-              className="usa-input max-width-200"
+              className="usa-input"
               id="paper-petition-email-primary"
               name="contactPrimary.paperPetitionEmail"
               type="email"

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -203,6 +203,29 @@ export const ContactPrimary = connect(
               onChange={onChange}
             />
           )}
+          <FormGroup className="paper-petition-email-input" errorText={}>
+            <label className="usa-label" htmlFor="paper-petition-email">
+              Petition email address{' '}
+              <span className="usa-hint">(optional)</span>
+            </label>
+            <input
+              autoCapitalize="none"
+              className="usa-input max-width-200"
+              id="paper-petition-email"
+              name="contactPrimary.paperPetitionEmail"
+              type="tel"
+              value={data.contactPrimary.phone || ''}
+              onBlur={() => {
+                onBlurSequence();
+              }}
+              onChange={e => {
+                updateFormValueAndSecondaryContactInfoSequence({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+              }}
+            />
+          </FormGroup>
           <FormGroup
             className="phone-input"
             errorText={

--- a/web-client/src/views/StartCase/ContactSecondary.tsx
+++ b/web-client/src/views/StartCase/ContactSecondary.tsx
@@ -164,7 +164,7 @@ export const ContactSecondary = connect(
             />
           )}
 
-          <FormGroup className="paper-petition-email-input">
+          <FormGroup>
             <label
               className="usa-label"
               htmlFor="paper-petition-email-secondary"
@@ -189,28 +189,26 @@ export const ContactSecondary = connect(
               }}
             />
           </FormGroup>
-          <FormGroup className="electronic-service-consent-input">
-            <div className="usa-checkbox">
-              <input
-                checked={data.contactSecondary.hasConsentedToEService || false}
-                className="usa-checkbox__input"
-                id="electronic-service-consent-secondary"
-                name="contactSecondary.hasConsentedToEService"
-                type="checkbox"
-                onChange={e => {
-                  updateFormValueAndSecondaryContactInfoSequence({
-                    key: e.target.name,
-                    value: e.target.checked,
-                  });
-                }}
-              />
-              <label
-                className="usa-checkbox__label"
-                htmlFor="electronic-service-consent-secondary"
-              >
-                E-service consent
-              </label>
-            </div>
+          <FormGroup>
+            <input
+              checked={data.contactSecondary.hasConsentedToEService || false}
+              className="usa-checkbox__input"
+              id="electronic-service-consent-secondary"
+              name="contactSecondary.hasConsentedToEService"
+              type="checkbox"
+              onChange={e => {
+                updateFormValueAndSecondaryContactInfoSequence({
+                  key: e.target.name,
+                  value: e.target.checked,
+                });
+              }}
+            />
+            <label
+              className="usa-checkbox__label"
+              htmlFor="electronic-service-consent-secondary"
+            >
+              E-service consent
+            </label>
           </FormGroup>
 
           {contactsHelper.contactSecondary.displayPhone && (

--- a/web-client/src/views/StartCase/ContactSecondary.tsx
+++ b/web-client/src/views/StartCase/ContactSecondary.tsx
@@ -173,7 +173,6 @@ export const ContactSecondary = connect(
               <span className="usa-hint">(optional)</span>
             </label>
             <input
-              autoCapitalize="none"
               className="usa-input"
               id="paper-petition-email-secondary"
               name="contactSecondary.paperPetitionEmail"

--- a/web-client/src/views/StartCase/ContactSecondary.tsx
+++ b/web-client/src/views/StartCase/ContactSecondary.tsx
@@ -163,6 +163,57 @@ export const ContactSecondary = connect(
               onChange={onChange}
             />
           )}
+
+          <FormGroup className="paper-petition-email-input">
+            <label
+              className="usa-label"
+              htmlFor="paper-petition-email-secondary"
+            >
+              Petition email address{' '}
+              <span className="usa-hint">(optional)</span>
+            </label>
+            <input
+              autoCapitalize="none"
+              className="usa-input max-width-200"
+              id="paper-petition-email-secondary"
+              name="contactSecondary.paperPetitionEmail"
+              type="email"
+              value={data.contactSecondary.paperPetitionEmail || ''}
+              onBlur={() => {
+                onBlurSequence();
+              }}
+              onChange={e => {
+                updateFormValueAndSecondaryContactInfoSequence({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+              }}
+            />
+          </FormGroup>
+          <FormGroup className="electronic-service-consent-input">
+            <div className="usa-checkbox">
+              <input
+                checked={data.contactSecondary.hasConsentedToEService || false}
+                className="usa-checkbox__input"
+                id="electronic-service-consent-secondary"
+                name="contactSecondary.hasConsentedToEService"
+                type="checkbox"
+                onChange={e => {
+                  updateFormValueAndSecondaryContactInfoSequence({
+                    key: e.target.name,
+                    value: e.target.checked,
+                  });
+                }}
+              />
+              <label
+                className="usa-checkbox__label"
+                htmlFor="electronic-service-consent-secondary"
+              >
+                E-service consent
+              </label>
+            </div>
+          </FormGroup>
+
           {contactsHelper.contactSecondary.displayPhone && (
             <FormGroup
               errorText={

--- a/web-client/src/views/StartCase/ContactSecondary.tsx
+++ b/web-client/src/views/StartCase/ContactSecondary.tsx
@@ -174,7 +174,7 @@ export const ContactSecondary = connect(
             </label>
             <input
               autoCapitalize="none"
-              className="usa-input max-width-200"
+              className="usa-input"
               id="paper-petition-email-secondary"
               name="contactSecondary.paperPetitionEmail"
               type="email"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20249233/218859961-63f2135b-ee7f-4625-b1b0-07d9c49533d5.png)

Hard to tell, but we added for both contact primary and secondary:
![image](https://user-images.githubusercontent.com/20249233/218860148-a5a4a410-1af1-4df7-9d26-270dfec12df3.png)
