### PR TITLE
9827: add migrations for more documents

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.test.ts
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.test.ts
@@ -36,7 +36,7 @@ describe('migrateItems', () => {
     expect(results[0]).toEqual(mockItem);
   });
 
-  it('should modify docket entry items with documentType "Ownership Disclosure Statement", updating documentTitle and documentType', async () => {
+  it('should modify docket entry items with documentType "Ownership Disclosure Statement", updating documentType', async () => {
     const mockItem = {
       documentTitle: 'Ownership Disclosure Statement',
       documentType: 'Ownership Disclosure Statement',
@@ -52,7 +52,7 @@ describe('migrateItems', () => {
     });
   });
 
-  it('should modify docket entry items with documentType "Order for Ownership Disclosure Statement", updating documentTitle and documentType', async () => {
+  it('should modify docket entry items with documentType "Order for Ownership Disclosure Statement", updating documentType', async () => {
     const mockItem = {
       documentTitle: 'ORDER FOR CORPORATE DISCLOSURE STATEMENT BY 12/03/58',
       documentType: 'Order for Ownership Disclosure Statement',
@@ -68,7 +68,7 @@ describe('migrateItems', () => {
     });
   });
 
-  it('should modify docket entry items with previousDocument that has documentType "Ownership Disclosure Statement", updating documentTitle and documentType', async () => {
+  it('should modify docket entry items with previousDocument that has documentType "Ownership Disclosure Statement", updating documentType', async () => {
     const mockItem = {
       pk: `case|${MOCK_CASE.docketNumber}`,
       previousDocument: {

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.test.ts
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.test.ts
@@ -48,8 +48,44 @@ describe('migrateItems', () => {
 
     expect(results[0]).toEqual({
       ...mockItem,
-      documentTitle: INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentTitle,
       documentType: INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentType,
+    });
+  });
+
+  it('should modify docket entry items with documentType "Order for Ownership Disclosure Statement", updating documentTitle and documentType', async () => {
+    const mockItem = {
+      documentTitle: 'ORDER FOR CORPORATE DISCLOSURE STATEMENT BY 12/03/58',
+      documentType: 'Order for Ownership Disclosure Statement',
+      pk: `case|${MOCK_CASE.docketNumber}`,
+      sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+    };
+
+    const results = await migrateItems([mockItem], documentClient);
+
+    expect(results[0]).toEqual({
+      ...mockItem,
+      documentType: 'Order for Corporate Disclosure Statement',
+    });
+  });
+
+  it('should modify docket entry items with previousDocument that has documentType "Ownership Disclosure Statement", updating documentTitle and documentType', async () => {
+    const mockItem = {
+      pk: `case|${MOCK_CASE.docketNumber}`,
+      previousDocument: {
+        documentTitle: 'Ownership Disclosure Statement',
+        documentType: 'Ownership Disclosure Statement',
+      },
+      sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+    };
+
+    const results = await migrateItems([mockItem], documentClient);
+
+    expect(results[0]).toEqual({
+      ...mockItem,
+      previousDocument: {
+        ...mockItem.previousDocument,
+        documentType: INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentType,
+      },
     });
   });
 

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.ts
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.ts
@@ -18,8 +18,15 @@ export const migrateItems = items => {
       if (item.documentType === 'Ownership Disclosure Statement') {
         item.documentType =
           INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentType;
-        item.documentTitle =
-          INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentTitle;
+      } else if (
+        item.documentType === 'Order for Ownership Disclosure Statement'
+      ) {
+        item.documentType = 'Order for Corporate Disclosure Statement';
+      } else if (
+        item.previousDocument?.documentType === 'Ownership Disclosure Statement'
+      ) {
+        item.previousDocument.documentType =
+          INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentType;
       }
     } else if (isCase(item) && item.orderForOds !== undefined) {
       item.orderForCds = item.orderForOds;


### PR DESCRIPTION
adds migrations for two more types of docket entries:

- `documentType` of  `"Order for Corporate Disclosure Statement"`
- `previousDocument.documentType` of `"Corporate Disclosure Statement"`