### PR TITLE
9827: also needed to fix previousDocument.documentType

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.test.ts
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.test.ts
@@ -89,6 +89,27 @@ describe('migrateItems', () => {
     });
   });
 
+  it('should modify docket entry items with previousDocument that has documentType "Order for Ownership Disclosure Statement", updating documentType', async () => {
+    const mockItem = {
+      pk: `case|${MOCK_CASE.docketNumber}`,
+      previousDocument: {
+        documentTitle: 'Order for Ownership Disclosure Statement',
+        documentType: 'Order for Ownership Disclosure Statement',
+      },
+      sk: 'docket-entry|6d74eadc-0181-4ff5-826c-305200e8733d',
+    };
+
+    const results = await migrateItems([mockItem], documentClient);
+
+    expect(results[0]).toEqual({
+      ...mockItem,
+      previousDocument: {
+        ...mockItem.previousDocument,
+        documentType: 'Order for Corporate Disclosure Statement',
+      },
+    });
+  });
+
   it('should modify case items that have property "orderForOds"', async () => {
     const mockItem = {
       orderForOds: true,

--- a/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.ts
+++ b/web-api/migration-terraform/main/lambdas/migrations/0007-update-corporate-disclosure-document.ts
@@ -27,6 +27,12 @@ export const migrateItems = items => {
       ) {
         item.previousDocument.documentType =
           INITIAL_DOCUMENT_TYPES.corporateDisclosure.documentType;
+      } else if (
+        item.previousDocument?.documentType ===
+        'Order for Ownership Disclosure Statement'
+      ) {
+        item.previousDocument.documentType =
+          'Order for Corporate Disclosure Statement';
       }
     } else if (isCase(item) && item.orderForOds !== undefined) {
       item.orderForCds = item.orderForOds;


### PR DESCRIPTION
Apparently `previousDocument.documentType` can also be `"Order for Ownership Disclosure Statement"` and they need to be migrated in order to pass validation.