### PR TITLE
9828: Remove validation requiring positive numbers in Statistics and Penalties

### DIFF
--- a/shared/src/business/entities/Penalty.test.ts
+++ b/shared/src/business/entities/Penalty.test.ts
@@ -64,23 +64,6 @@ describe('Penalty', () => {
       );
     });
 
-    it('should fail if penaltyAmount is a negative number', () => {
-      const penalty = new Penalty(
-        {
-          name: 'Penalty 1 (IRS)',
-          penaltyAmount: -422.68,
-          penaltyType: PENALTY_TYPES.IRS_PENALTY_AMOUNT,
-          statisticId,
-        },
-        { applicationContext },
-      );
-
-      expect(penalty.isValid()).toBe(false);
-      expect(Object.keys(penalty.getFormattedValidationErrors())).toContain(
-        'penaltyAmount',
-      );
-    });
-
     it('should fail if penaltyType is undefined', () => {
       const penalty = new Penalty(
         {
@@ -135,6 +118,20 @@ describe('Penalty', () => {
           name: 'Penalty 1 (Court)',
           penaltyAmount: 100.0,
           penaltyType: PENALTY_TYPES.DETERMINATION_PENALTY_AMOUNT,
+          statisticId,
+        },
+        { applicationContext },
+      );
+
+      expect(penalty.isValid()).toBe(true);
+    });
+
+    it('should pass if penaltyAmount is a negative number', () => {
+      const penalty = new Penalty(
+        {
+          name: 'Penalty 1 (IRS)',
+          penaltyAmount: -422.68,
+          penaltyType: PENALTY_TYPES.IRS_PENALTY_AMOUNT,
           statisticId,
         },
         { applicationContext },

--- a/shared/src/business/entities/Penalty.ts
+++ b/shared/src/business/entities/Penalty.ts
@@ -42,7 +42,6 @@ Penalty.VALIDATION_RULES = joi.object().keys({
     .description('Penalty name.'),
   penaltyAmount: joi
     .number()
-    .positive()
     .allow(0)
     .required()
     .description('The dollar amount of the penalty.'),

--- a/shared/src/business/entities/Penalty.ts
+++ b/shared/src/business/entities/Penalty.ts
@@ -42,7 +42,6 @@ Penalty.VALIDATION_RULES = joi.object().keys({
     .description('Penalty name.'),
   penaltyAmount: joi
     .number()
-    .allow(0)
     .required()
     .description('The dollar amount of the penalty.'),
   penaltyId: JoiValidationConstants.UUID.required().description(

--- a/shared/src/business/entities/Statistic.test.ts
+++ b/shared/src/business/entities/Statistic.test.ts
@@ -67,34 +67,6 @@ describe('Statistic', () => {
       ]);
     });
 
-    it('fails validation if a irsDeficiencyAmount, irsTotalPenalties, determinationTotalPenalties, and/or determinationDeficiencyAmount are not positive numbers', () => {
-      const statistic = new Statistic(
-        {
-          determinationDeficiencyAmount: -4352.32,
-          determinationTotalPenalties: -4,
-          irsDeficiencyAmount: -2.0,
-          irsTotalPenalties: -222.22,
-          penalties: [
-            {
-              name: 'Penalty 1(IRS)',
-              penaltyAmount: 100.0,
-              penaltyType: 'irsPenaltyAmount',
-            },
-          ],
-          year: 2015,
-          yearOrPeriod: 'Year',
-        },
-        { applicationContext },
-      );
-      expect(statistic.isValid()).toBeFalsy();
-      expect(Object.keys(statistic.getFormattedValidationErrors())).toEqual([
-        'determinationDeficiencyAmount',
-        'determinationTotalPenalties',
-        'irsDeficiencyAmount',
-        'irsTotalPenalties',
-      ]);
-    });
-
     it('fails validation if a lastDateOfPeriod is a date in the future', () => {
       const statistic = new Statistic(
         {
@@ -146,6 +118,28 @@ describe('Statistic', () => {
             {
               name: 'Penalty 1(IRS)',
               penaltyAmount: 100.0,
+              penaltyType: 'irsPenaltyAmount',
+            },
+          ],
+          year: 2015,
+          yearOrPeriod: 'Year',
+        },
+        { applicationContext },
+      );
+      expect(statistic.isValid()).toBeTruthy();
+    });
+
+    it('passes validation if an irsDeficiencyAmount, irsTotalPenalties, determinationTotalPenalties, and/or determinationDeficiencyAmount include negative numbers', () => {
+      const statistic = new Statistic(
+        {
+          determinationDeficiencyAmount: -4352.32,
+          determinationTotalPenalties: 0,
+          irsDeficiencyAmount: -2.0,
+          irsTotalPenalties: -222.22,
+          penalties: [
+            {
+              name: 'Penalty 1(IRS)',
+              penaltyAmount: -222.22,
               penaltyType: 'irsPenaltyAmount',
             },
           ],

--- a/shared/src/business/entities/Statistic.ts
+++ b/shared/src/business/entities/Statistic.ts
@@ -73,16 +73,16 @@ Statistic.VALIDATION_RULES = joi.object().keys({
     .alternatives()
     .conditional('determinationTotalPenalties', {
       is: joi.exist().not(null),
-      otherwise: joi.number().positive().allow(0).optional().allow(null),
-      then: joi.number().positive().allow(0).required(),
+      otherwise: joi.number().optional().allow(null),
+      then: joi.number().required(),
     })
     .description('The amount of the deficiency determined by the Court.'),
   determinationTotalPenalties: joi
     .alternatives()
     .conditional('determinationDeficiencyAmount', {
       is: joi.exist().not(null),
-      otherwise: joi.number().positive().allow(0).optional().allow(null),
-      then: joi.number().positive().allow(0).required(),
+      otherwise: joi.number().optional().allow(null),
+      then: joi.number().required(),
     })
     .description(
       'The total amount of penalties for the period or year determined by the Court.',
@@ -90,14 +90,10 @@ Statistic.VALIDATION_RULES = joi.object().keys({
   entityName: JoiValidationConstants.STRING.valid('Statistic').required(),
   irsDeficiencyAmount: joi
     .number()
-    .positive()
-    .allow(0)
     .required()
     .description('The amount of the deficiency on the IRS notice.'),
   irsTotalPenalties: joi
     .number()
-    .positive()
-    .allow(0)
     .required()
     .description(
       'The total amount of penalties for the period or year on the IRS notice.',

--- a/web-client/src/ustc-ui/DollarsInput/DollarsInput.tsx
+++ b/web-client/src/ustc-ui/DollarsInput/DollarsInput.tsx
@@ -5,7 +5,6 @@ export const DollarsInput = props => {
   return (
     <NumericFormat
       {...props}
-      allowNegative={false}
       decimalScale="2"
       fixedDecimalScale={true}
       prefix="$"


### PR DESCRIPTION
- Mini PR for story [9828](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/9828). 
- Validation rules requiring positive numbers removed from Statistic and Penalty entities as well as from DollarsInput component. 
- Negative numbers now allowed in any Deficiency or Penalty field.
- All other validation rules remain intact

---

#### Case creation review

![image](https://user-images.githubusercontent.com/93543562/226725358-b376db60-a3cf-4d76-bae3-7501e344a419.png)

---

#### Statistic/Penalty entry during case creation

![image](https://user-images.githubusercontent.com/93543562/226725550-5af5df81-3e8a-48e5-9af0-8eeb5a5ab625.png)

---

#### Case Information, Statistics Tab, Itemized Penalties Modal

![image](https://user-images.githubusercontent.com/93543562/226725733-2a0eefee-a9c6-4360-a7d8-593e6d809597.png)

---

#### Add New Statistic 

![image](https://user-images.githubusercontent.com/93543562/226725967-d670647b-617f-47e7-b66d-c1052a840163.png)


--- Edit Existing Statistic

####

![image](https://user-images.githubusercontent.com/93543562/226726107-96a90c85-4ad4-4d1a-9ad7-e9872edb8383.png)
