### PR TITLE
9809: Increase search result size

### DIFF
--- a/shared/src/business/useCases/judgeActivityReport/getOpinionsFiledByJudgeInteractor.test.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getOpinionsFiledByJudgeInteractor.test.ts
@@ -1,3 +1,4 @@
+import { MAX_ELASTICSEARCH_PAGINATION } from '../../entities/EntityConstants';
 import { applicationContext } from '../../test/createTestApplicationContext';
 import { getOpinionsFiledByJudgeInteractor } from './getOpinionsFiledByJudgeInteractor';
 import { judgeUser, petitionsClerkUser } from '../../../test/mockUsers';
@@ -68,6 +69,7 @@ describe('getOpinionsFiledByJudgeInteractor', () => {
     ).toMatchObject({
       endDate: '2020-03-22T03:59:59.999Z',
       judge: mockValidRequest.judgeName,
+      overrideResultSize: MAX_ELASTICSEARCH_PAGINATION,
       startDate: '2020-02-12T05:00:00.000Z',
     });
     expect(result).toEqual([

--- a/shared/src/business/useCases/judgeActivityReport/getOpinionsFiledByJudgeInteractor.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getOpinionsFiledByJudgeInteractor.ts
@@ -1,5 +1,6 @@
 import {
   COURT_ISSUED_EVENT_CODES,
+  MAX_ELASTICSEARCH_PAGINATION,
   OPINION_EVENT_CODES_WITH_BENCH_OPINION,
 } from '../../entities/EntityConstants';
 import { InvalidRequest, UnauthorizedError } from '../../../errors/errors';
@@ -52,6 +53,7 @@ export const getOpinionsFiledByJudgeInteractor = async (
       endDate: searchEntity.endDate,
       isOpinionSearch: true,
       judge: searchEntity.judgeName,
+      overrideResultSize: MAX_ELASTICSEARCH_PAGINATION,
       startDate: searchEntity.startDate,
     });
 

--- a/shared/src/business/useCases/judgeActivityReport/getOrdersFiledByJudgeInteractor.test.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getOrdersFiledByJudgeInteractor.test.ts
@@ -1,3 +1,4 @@
+import { MAX_ELASTICSEARCH_PAGINATION } from '../../entities/EntityConstants';
 import { applicationContext } from '../../test/createTestApplicationContext';
 import { getOrdersFiledByJudgeInteractor } from './getOrdersFiledByJudgeInteractor';
 import { judgeUser, petitionsClerkUser } from '../../../test/mockUsers';
@@ -67,6 +68,7 @@ describe('getOrdersFiledByJudgeInteractor', () => {
     ).toMatchObject({
       endDate: '2020-03-22T03:59:59.999Z',
       judge: mockValidRequest.judgeName,
+      overrideResultSize: MAX_ELASTICSEARCH_PAGINATION,
       startDate: '2020-02-12T05:00:00.000Z',
     });
     expect(result).toEqual([

--- a/shared/src/business/useCases/judgeActivityReport/getOrdersFiledByJudgeInteractor.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getOrdersFiledByJudgeInteractor.ts
@@ -1,6 +1,9 @@
 import { InvalidRequest, UnauthorizedError } from '../../../errors/errors';
 import { JudgeActivityReportSearch } from '../../entities/judgeActivityReport/JudgeActivityReportSearch';
-import { ORDER_EVENT_CODES } from '../../entities/EntityConstants';
+import {
+  MAX_ELASTICSEARCH_PAGINATION,
+  ORDER_EVENT_CODES,
+} from '../../entities/EntityConstants';
 import {
   ROLE_PERMISSIONS,
   isAuthorized,
@@ -53,6 +56,7 @@ export const getOrdersFiledByJudgeInteractor = async (
       documentEventCodes: orderEventCodesToSearch,
       endDate: searchEntity.endDate,
       judge: searchEntity.judgeName,
+      overrideResultSize: MAX_ELASTICSEARCH_PAGINATION,
       startDate: searchEntity.startDate,
     });
 

--- a/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.test.ts
+++ b/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.test.ts
@@ -119,24 +119,24 @@ describe('judgeActivityReportHelper', () => {
     });
   });
 
-  describe('showResults', () => {
+  describe('showResultsTables', () => {
     it('should false when there are no orders, opinions, trial sessions and cases for the specified judge', () => {
-      const { showResults } = runCompute(judgeActivityReportHelper, {
+      const { showResultsTables } = runCompute(judgeActivityReportHelper, {
         state: {
           form: mockForm,
           judgeActivityReportData: {},
         },
       });
 
-      expect(showResults).toBe(false);
+      expect(showResultsTables).toBe(false);
     });
 
     it('should true when there are orders, opinions, trial sessions or cases for the specified judge', () => {
-      const { showResults } = runCompute(judgeActivityReportHelper, {
+      const { showResultsTables } = runCompute(judgeActivityReportHelper, {
         state: baseState,
       });
 
-      expect(showResults).toBe(true);
+      expect(showResultsTables).toBe(true);
     });
   });
 

--- a/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.test.ts
+++ b/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.test.ts
@@ -4,11 +4,15 @@ import {
 } from '../../../../../shared/src/business/entities/EntityConstants';
 import { applicationContextForClient as applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
 import { judgeActivityReportHelper as judgeActivityReportHelperComputed } from './judgeActivityReportHelper';
+import { judgeUser } from '../../../../../shared/src/test/mockUsers';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../../withAppContext';
 
 describe('judgeActivityReportHelper', () => {
   let mockJudgeActivityReport;
+  let mockForm;
+  let baseState;
+
   const judgeActivityReportHelper = withAppContextDecorator(
     judgeActivityReportHelperComputed,
     { ...applicationContext },
@@ -60,53 +64,31 @@ describe('judgeActivityReportHelper', () => {
         [SESSION_TYPES.motionHearing]: 1.5,
       },
     };
+
+    mockForm = {
+      judgeName: judgeUser.name,
+    };
+
+    baseState = {
+      form: mockForm,
+      judgeActivityReportData: mockJudgeActivityReport,
+    };
   });
 
   describe('closedCasesTotal', () => {
     it('should be the sum of the values of cases closed off state.judgeActivityReportData', () => {
       const { closedCasesTotal } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: mockJudgeActivityReport,
-        },
+        state: baseState,
       });
 
       expect(closedCasesTotal).toBe(6);
     });
   });
 
-  it('should return reportHeader that includes judge name and the currentDate in MMDDYY format', () => {
-    applicationContext
-      .getUtilities()
-      .prepareDateFromString.mockReturnValue('2020-01-01');
-
-    const { reportHeader } = runCompute(judgeActivityReportHelper, {
-      state: {
-        form: { judgeName: '' },
-        judgeActivityReportData: mockJudgeActivityReport,
-      },
-    });
-
-    expect(currentDate).toBe('01/01/20');
-  });
-
-  describe('trialSessionsHeldCount', () => {
-    it('should be the sum of the values of trialSessions off state.judgeActivityReportData', () => {
-      const { trialSessionsHeldTotal } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: mockJudgeActivityReport,
-        },
-      });
-
-      expect(trialSessionsHeldTotal).toBe(3);
-    });
-  });
-
   describe('opinionsFiledTotal', () => {
     it('should be the sum of the values of opinions filed off state.judgeActivityReportData', () => {
       const { opinionsFiledTotal } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: mockJudgeActivityReport,
-        },
+        state: baseState,
       });
 
       expect(opinionsFiledTotal).toBe(5);
@@ -116,12 +98,24 @@ describe('judgeActivityReportHelper', () => {
   describe('ordersFiledTotal', () => {
     it('should be the sum of the values of orders filed off state.judgeActivityReportData', () => {
       const { ordersFiledTotal } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: mockJudgeActivityReport,
-        },
+        state: baseState,
       });
 
       expect(ordersFiledTotal).toBe(6);
+    });
+  });
+
+  describe('reportHeader', () => {
+    it('should return reportHeader that includes judge name and the currentDate in MMDDYY format', () => {
+      applicationContext
+        .getUtilities()
+        .prepareDateFromString.mockReturnValue('2020-01-01');
+
+      const { reportHeader } = runCompute(judgeActivityReportHelper, {
+        state: baseState,
+      });
+
+      expect(reportHeader).toBe(`${judgeUser.name} 01/01/20`);
     });
   });
 
@@ -129,6 +123,7 @@ describe('judgeActivityReportHelper', () => {
     it('should false when there are no orders, opinions, trial sessions and cases for the specified judge', () => {
       const { showResults } = runCompute(judgeActivityReportHelper, {
         state: {
+          form: mockForm,
           judgeActivityReportData: {},
         },
       });
@@ -138,40 +133,47 @@ describe('judgeActivityReportHelper', () => {
 
     it('should true when there are orders, opinions, trial sessions or cases for the specified judge', () => {
       const { showResults } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: mockJudgeActivityReport,
-        },
+        state: baseState,
       });
 
       expect(showResults).toBe(true);
     });
   });
 
-  describe('showSelectDateRangeTextRangeMessage', () => {
+  describe('showSelectDateRangeText', () => {
     it('should be false when the form has been submitted (there are orders, opinions, trial sessions and cases for the specified judge)', () => {
-      const { showSelectDateRangeTextRangeMessage } = runCompute(
+      const { showSelectDateRangeText } = runCompute(
         judgeActivityReportHelper,
         {
-          state: {
-            judgeActivityReportData: mockJudgeActivityReport,
-          },
+          state: baseState,
         },
       );
 
-      expect(showSelectDateRangeTextRangeMessage).toBe(false);
+      expect(showSelectDateRangeText).toBe(false);
     });
 
     it('should true when form has NOT been submitted (there are orders, opinions, trial sessions or cases for the specified judge)', () => {
-      const { showSelectDateRangeTextRangeMessage } = runCompute(
+      const { showSelectDateRangeText } = runCompute(
         judgeActivityReportHelper,
         {
           state: {
+            form: mockForm,
             judgeActivityReportData: {},
           },
         },
       );
 
-      expect(showSelectDateRangeTextRangeMessage).toBe(true);
+      expect(showSelectDateRangeText).toBe(true);
+    });
+  });
+
+  describe('trialSessionsHeldTotal', () => {
+    it('should be the sum of the values of trialSessions off state.judgeActivityReportData', () => {
+      const { trialSessionsHeldTotal } = runCompute(judgeActivityReportHelper, {
+        state: baseState,
+      });
+
+      expect(trialSessionsHeldTotal).toBe(3);
     });
   });
 });

--- a/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.test.ts
+++ b/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.test.ts
@@ -74,13 +74,14 @@ describe('judgeActivityReportHelper', () => {
     });
   });
 
-  it('should return currentDate in MMDDYY format', () => {
+  it('should return reportHeader that includes judge name and the currentDate in MMDDYY format', () => {
     applicationContext
       .getUtilities()
       .prepareDateFromString.mockReturnValue('2020-01-01');
 
-    const { currentDate } = runCompute(judgeActivityReportHelper, {
+    const { reportHeader } = runCompute(judgeActivityReportHelper, {
       state: {
+        form: { judgeName: '' },
         judgeActivityReportData: mockJudgeActivityReport,
       },
     });
@@ -146,25 +147,31 @@ describe('judgeActivityReportHelper', () => {
     });
   });
 
-  describe('showDateRangeMessage', () => {
+  describe('showSelectDateRangeTextRangeMessage', () => {
     it('should be false when the form has been submitted (there are orders, opinions, trial sessions and cases for the specified judge)', () => {
-      const { showDateRangeMessage } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: mockJudgeActivityReport,
+      const { showSelectDateRangeTextRangeMessage } = runCompute(
+        judgeActivityReportHelper,
+        {
+          state: {
+            judgeActivityReportData: mockJudgeActivityReport,
+          },
         },
-      });
+      );
 
-      expect(showDateRangeMessage).toBe(false);
+      expect(showSelectDateRangeTextRangeMessage).toBe(false);
     });
 
     it('should true when form has NOT been submitted (there are orders, opinions, trial sessions or cases for the specified judge)', () => {
-      const { showDateRangeMessage } = runCompute(judgeActivityReportHelper, {
-        state: {
-          judgeActivityReportData: {},
+      const { showSelectDateRangeTextRangeMessage } = runCompute(
+        judgeActivityReportHelper,
+        {
+          state: {
+            judgeActivityReportData: {},
+          },
         },
-      });
+      );
 
-      expect(showDateRangeMessage).toBe(true);
+      expect(showSelectDateRangeTextRangeMessage).toBe(true);
     });
   });
 });

--- a/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.ts
+++ b/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.ts
@@ -3,8 +3,9 @@ export const judgeActivityReportHelper = (get, applicationContext) => {
   const { casesClosedByJudge, opinions, orders, trialSessions } = get(
     state.judgeActivityReportData,
   );
+  const { judgeName } = get(state.form);
 
-  let showDateRangeMessage = false;
+  let showSelectDateRangeText = false;
 
   let closedCasesTotal,
     trialSessionsHeldTotal,
@@ -28,7 +29,7 @@ export const judgeActivityReportHelper = (get, applicationContext) => {
 
     ordersFiledTotal = orders.reduce((a: any, b: any) => a + b.count, 0);
   } else {
-    showDateRangeMessage = true;
+    showSelectDateRangeText = true;
   }
 
   const resultsCount =
@@ -46,13 +47,15 @@ export const judgeActivityReportHelper = (get, applicationContext) => {
       applicationContext.getConstants().DATE_FORMATS.MMDDYY,
     );
 
+  const reportHeader = `${judgeName} ${currentDate}`;
+
   return {
     closedCasesTotal,
-    currentDate,
     opinionsFiledTotal,
     ordersFiledTotal,
-    showDateRangeMessage,
+    reportHeader,
     showResults,
+    showSelectDateRangeText,
     trialSessionsHeldTotal,
   };
 };

--- a/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.ts
+++ b/web-client/src/presenter/computeds/JudgeActivityReport/judgeActivityReportHelper.ts
@@ -1,46 +1,45 @@
 import { state } from 'cerebral';
+import { sum, sumBy } from 'lodash';
+
 export const judgeActivityReportHelper = (get, applicationContext) => {
+  const { judgeName } = get(state.form);
+
   const { casesClosedByJudge, opinions, orders, trialSessions } = get(
     state.judgeActivityReportData,
   );
-  const { judgeName } = get(state.form);
 
-  let showSelectDateRangeText = false;
+  let closedCasesTotal: number = 0,
+    trialSessionsHeldTotal: number = 0,
+    opinionsFiledTotal: number = 0,
+    ordersFiledTotal: number = 0,
+    resultsCount: number = 0,
+    showSelectDateRangeText: boolean = false;
 
-  let closedCasesTotal,
-    trialSessionsHeldTotal,
-    opinionsFiledTotal,
-    ordersFiledTotal;
-  const hasFormBeenSubmitted =
+  const hasFormBeenSubmitted: boolean =
     casesClosedByJudge && opinions && orders && trialSessions;
 
   if (hasFormBeenSubmitted) {
-    closedCasesTotal = Object.values(casesClosedByJudge).reduce(
-      (a: number, b: number) => a + b,
-      0,
+    closedCasesTotal = sum(Object.values(casesClosedByJudge));
+
+    trialSessionsHeldTotal = sum(Object.values(trialSessions));
+
+    opinionsFiledTotal = sumBy(
+      opinions,
+      ({ count }: { count: number }) => count,
     );
 
-    trialSessionsHeldTotal = Object.values(trialSessions).reduce(
-      (a: number, b: number) => a + b,
-      0,
-    );
+    ordersFiledTotal = sumBy(orders, ({ count }: { count: number }) => count);
 
-    opinionsFiledTotal = opinions.reduce((a: any, b: any) => a + b.count, 0);
-
-    ordersFiledTotal = orders.reduce((a: any, b: any) => a + b.count, 0);
+    resultsCount =
+      ordersFiledTotal +
+      opinionsFiledTotal +
+      trialSessionsHeldTotal +
+      closedCasesTotal;
   } else {
     showSelectDateRangeText = true;
   }
 
-  const resultsCount =
-    ordersFiledTotal +
-    opinionsFiledTotal +
-    trialSessionsHeldTotal +
-    closedCasesTotal;
-
-  const showResults = resultsCount > 0;
-
-  const currentDate = applicationContext
+  const currentDate: string = applicationContext
     .getUtilities()
     .formatDateString(
       applicationContext.getUtilities().prepareDateFromString(),
@@ -54,7 +53,7 @@ export const judgeActivityReportHelper = (get, applicationContext) => {
     opinionsFiledTotal,
     ordersFiledTotal,
     reportHeader,
-    showResults,
+    showResultsTables: resultsCount > 0,
     showSelectDateRangeText,
     trialSessionsHeldTotal,
   };

--- a/web-client/src/views/JudgeActivityReport/JudgeActivityReport.tsx
+++ b/web-client/src/views/JudgeActivityReport/JudgeActivityReport.tsx
@@ -8,8 +8,6 @@ import React from 'react';
 
 export const JudgeActivityReport = connect(
   {
-    CLOSED_CASE_STATUSES: state.constants.CLOSED_CASE_STATUSES,
-    SESSION_TYPES: state.constants.SESSION_TYPES,
     form: state.form,
     judgeActivityReportData: state.judgeActivityReportData,
     judgeActivityReportHelper: state.judgeActivityReportHelper,
@@ -19,11 +17,9 @@ export const JudgeActivityReport = connect(
     validationErrors: state.validationErrors,
   },
   function JudgeActivityReport({
-    CLOSED_CASE_STATUSES,
     form,
     judgeActivityReportData,
     judgeActivityReportHelper,
-    SESSION_TYPES,
     submitJudgeActivityReportSequence,
     updateFormValueSequence,
     validationErrors,
@@ -43,21 +39,21 @@ export const JudgeActivityReport = connect(
           </caption>
           <thead>
             <tr>
-              <th aria-label="Case type">Case Type</th>
-              <th aria-label="Case type total" className="text-right">
+              <th aria-label="case type">Case Type</th>
+              <th aria-label="case type total" className="text-right">
                 Case Type Total
               </th>
             </tr>
           </thead>
           <tbody>
-            {CLOSED_CASE_STATUSES.map(status => (
-              <tr key={status}>
-                <td>{status}</td>
-                <td className="text-right">
-                  {judgeActivityReportData.casesClosedByJudge[status]}
-                </td>
-              </tr>
-            ))}
+            {Object.entries(judgeActivityReportData.casesClosedByJudge).map(
+              ([status, count]) => (
+                <tr key={status}>
+                  <td>{status}</td>
+                  <td className="text-right">{count}</td>
+                </tr>
+              ),
+            )}
           </tbody>
         </table>
       </>
@@ -79,21 +75,21 @@ export const JudgeActivityReport = connect(
 
           <thead>
             <tr>
-              <th aria-label="Session type">Session Type</th>
-              <th aria-label="Session type total" className="text-right">
+              <th aria-label="session type">Session Type</th>
+              <th aria-label="session type total" className="text-right">
                 Session Type Total
               </th>
             </tr>
           </thead>
           <tbody>
-            {Object.values(SESSION_TYPES).map(status => (
-              <tr key={status}>
-                <td>{status}</td>
-                <td className="text-right">
-                  {judgeActivityReportData.trialSessions[status]}
-                </td>
-              </tr>
-            ))}
+            {Object.entries(judgeActivityReportData.trialSessions).map(
+              ([sessionStatus, count]) => (
+                <tr key={sessionStatus}>
+                  <td>{sessionStatus}</td>
+                  <td className="text-right">{count}</td>
+                </tr>
+              ),
+            )}
           </tbody>
         </table>
       </>
@@ -124,13 +120,15 @@ export const JudgeActivityReport = connect(
             </tr>
           </thead>
           <tbody>
-            {judgeActivityReportData.orders.map(order => (
-              <tr key={order.eventCode}>
-                <td className="width-15">{order.eventCode}</td>
-                <td>{order.documentType}</td>
-                <td className="text-right">{order.count}</td>
-              </tr>
-            ))}
+            {judgeActivityReportData.orders.map(
+              ({ count, documentType, eventCode }) => (
+                <tr key={eventCode}>
+                  <td className="width-15">{eventCode}</td>
+                  <td>{documentType}</td>
+                  <td className="text-right">{count}</td>
+                </tr>
+              ),
+            )}
           </tbody>
         </table>
       </>
@@ -164,13 +162,15 @@ export const JudgeActivityReport = connect(
             </tr>
           </thead>
           <tbody>
-            {judgeActivityReportData.opinions.map(opinion => (
-              <tr key={opinion.eventCode}>
-                <td className="width-15">{opinion.eventCode}</td>
-                <td>{opinion.documentType}</td>
-                <td className="text-right">{opinion.count}</td>
-              </tr>
-            ))}
+            {judgeActivityReportData.opinions.map(
+              ({ count, documentType, eventCode }) => (
+                <tr key={eventCode}>
+                  <td className="width-15">{eventCode}</td>
+                  <td>{documentType}</td>
+                  <td className="text-right">{count}</td>
+                </tr>
+              ),
+            )}
           </tbody>
         </table>
       </>
@@ -236,7 +236,7 @@ export const JudgeActivityReport = connect(
             <div className="text-semibold margin-0">
               Enter a date range to view activity
             </div>
-          ) : judgeActivityReportHelper.showResults ? (
+          ) : judgeActivityReportHelper.showResultsTables ? (
             <>
               <div className="grid-row grid-gap">
                 <div className="grid-col-6">{closedCases()}</div>

--- a/web-client/src/views/JudgeActivityReport/JudgeActivityReport.tsx
+++ b/web-client/src/views/JudgeActivityReport/JudgeActivityReport.tsx
@@ -44,7 +44,7 @@ export const JudgeActivityReport = connect(
           <thead>
             <tr>
               <th aria-label="Case type">Case Type</th>
-              <th aria-label="Case type total" className="text-center">
+              <th aria-label="Case type total" className="text-right">
                 Case Type Total
               </th>
             </tr>
@@ -53,7 +53,7 @@ export const JudgeActivityReport = connect(
             {CLOSED_CASE_STATUSES.map(status => (
               <tr key={status}>
                 <td>{status}</td>
-                <td className="text-center">
+                <td className="text-right">
                   {judgeActivityReportData.casesClosedByJudge[status]}
                 </td>
               </tr>
@@ -80,14 +80,16 @@ export const JudgeActivityReport = connect(
           <thead>
             <tr>
               <th aria-label="Session type">Session Type</th>
-              <th aria-label="Session type total">Session Type Total</th>
+              <th aria-label="Session type total" className="text-right">
+                Session Type Total
+              </th>
             </tr>
           </thead>
           <tbody>
             {Object.values(SESSION_TYPES).map(status => (
               <tr key={status}>
                 <td>{status}</td>
-                <td className="text-center">
+                <td className="text-right">
                   {judgeActivityReportData.trialSessions[status]}
                 </td>
               </tr>
@@ -112,17 +114,21 @@ export const JudgeActivityReport = connect(
           </caption>
           <thead>
             <tr>
-              <th aria-label="event code">Event</th>
+              <th aria-label="event code" className="width-15">
+                Event
+              </th>
               <th aria-label="order type">Order Type</th>
-              <th aria-label="event total">Event Total</th>
+              <th aria-label="event total" className="text-right">
+                Event Total
+              </th>
             </tr>
           </thead>
           <tbody>
             {judgeActivityReportData.orders.map(order => (
               <tr key={order.eventCode}>
-                <td>{order.eventCode}</td>
+                <td className="width-15">{order.eventCode}</td>
                 <td>{order.documentType}</td>
-                <td>{order.count}</td>
+                <td className="text-right">{order.count}</td>
               </tr>
             ))}
           </tbody>
@@ -148,17 +154,21 @@ export const JudgeActivityReport = connect(
           </caption>
           <thead>
             <tr>
-              <th aria-label="event code">Event</th>
+              <th aria-label="event code" className="width-15">
+                Event
+              </th>
               <th aria-label="opinion type">Opinion Type</th>
-              <th aria-label="event total">Event Total</th>
+              <th aria-label="event total" className="text-right">
+                Event Total
+              </th>
             </tr>
           </thead>
           <tbody>
             {judgeActivityReportData.opinions.map(opinion => (
               <tr key={opinion.eventCode}>
-                <td>{opinion.eventCode}</td>
+                <td className="width-15">{opinion.eventCode}</td>
                 <td>{opinion.documentType}</td>
-                <td>{opinion.count}</td>
+                <td className="text-right">{opinion.count}</td>
               </tr>
             ))}
           </tbody>

--- a/web-client/src/views/JudgeActivityReport/JudgeActivityReport.tsx
+++ b/web-client/src/views/JudgeActivityReport/JudgeActivityReport.tsx
@@ -174,10 +174,7 @@ export const JudgeActivityReport = connect(
           <ErrorNotification />
 
           <div className="title">
-            <h1>
-              Activity - {form.judgeName}{' '}
-              {judgeActivityReportHelper.currentDate}
-            </h1>
+            <h1>Activity - {judgeActivityReportHelper.reportHeader}</h1>
           </div>
 
           <div className="blue-container">
@@ -225,7 +222,7 @@ export const JudgeActivityReport = connect(
         </section>
 
         <section className="usa-section grid-container">
-          {judgeActivityReportHelper.showDateRangeMessage ? (
+          {judgeActivityReportHelper.showSelectDateRangeText ? (
             <div className="text-semibold margin-0">
               Enter a date range to view activity
             </div>


### PR DESCRIPTION
Allow the maximum number of search results to be returned allowed by Opensearch for Judge Activity Report queries for Orders and Opinions.