### PR TITLE
9998 refactor search type

### DIFF
--- a/shared/src/business/useCases/judgeActivityReport/getCountOfOpinionsFiledByJudgesInteractor.test.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getCountOfOpinionsFiledByJudgesInteractor.test.ts
@@ -90,7 +90,6 @@ describe('getCountOfOpinionsFiledByJudgesInteractor', () => {
         documentEventCodes: OPINION_EVENT_CODES_WITH_BENCH_OPINION,
         endDate: '2020-03-22T03:59:59.999Z',
         judges: mockJudges,
-        searchType: 'opinion',
         startDate: '2020-02-12T05:00:00.000Z',
       },
     });

--- a/shared/src/business/useCases/judgeActivityReport/getCountOfOpinionsFiledByJudgesInteractor.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getCountOfOpinionsFiledByJudgesInteractor.ts
@@ -40,7 +40,6 @@ export const getCountOfOpinionsFiledByJudgesInteractor = async (
         documentEventCodes: OPINION_EVENT_CODES_WITH_BENCH_OPINION,
         endDate: searchEntity.endDate,
         judges: searchEntity.judges,
-        searchType: 'opinion',
         startDate: searchEntity.startDate,
       },
     });

--- a/shared/src/business/useCases/judgeActivityReport/getCountOfOrdersFiledByJudgesInteractor.test.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getCountOfOrdersFiledByJudgesInteractor.test.ts
@@ -117,7 +117,6 @@ describe('getCountOfOrdersFiledByJudgesInteractor', () => {
         documentEventCodes: orderEventCodesToSearch,
         endDate: '2020-03-22T03:59:59.999Z',
         judges: mockJudges,
-        searchType: 'order',
         startDate: '2020-02-12T05:00:00.000Z',
       },
     });

--- a/shared/src/business/useCases/judgeActivityReport/getCountOfOrdersFiledByJudgesInteractor.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getCountOfOrdersFiledByJudgesInteractor.ts
@@ -56,7 +56,6 @@ export const getCountOfOrdersFiledByJudgesInteractor = async (
         documentEventCodes: orderEventCodesToSearch,
         endDate: searchEntity.endDate,
         judges: searchEntity.judges,
-        searchType: 'order',
         startDate: searchEntity.startDate,
       },
     });

--- a/web-api/src/persistence/elasticsearch/fetchEventCodesCountForJudges.test.ts
+++ b/web-api/src/persistence/elasticsearch/fetchEventCodesCountForJudges.test.ts
@@ -68,7 +68,6 @@ describe('fetchEventCodesCountForJudges', () => {
     documentEventCodes: orderEventCodesToSearch,
     endDate: '2020-03-22T03:59:59.999Z',
     judges: [judgeUser.name],
-    searchType: 'order',
     startDate: '2020-02-12T05:00:00.000Z',
   };
 

--- a/web-api/src/persistence/elasticsearch/fetchEventCodesCountForJudges.ts
+++ b/web-api/src/persistence/elasticsearch/fetchEventCodesCountForJudges.ts
@@ -13,7 +13,6 @@ export type FetchEventCodesParamsType = {
   endDate: string;
   documentEventCodes: any;
   judges: string[];
-  searchType: string;
   startDate: string;
 };
 

--- a/web-api/src/persistence/elasticsearch/getCasesClosedCountByJudge.ts
+++ b/web-api/src/persistence/elasticsearch/getCasesClosedCountByJudge.ts
@@ -75,12 +75,5 @@ export const getCasesClosedCountByJudge = async ({
         [CASE_STATUS_TYPES.closedDismissed]: 0,
       };
 
-  const judgeNameToLog =
-    judges.length > 1 ? 'all judges' : `judge ${judges[0]}`;
-
-  applicationContext.logger.info(
-    `Found ${total} closed cases associated with ${judgeNameToLog}`,
-  );
-
   return { aggregations: results, total };
 };

--- a/web-api/src/persistence/elasticsearch/helpers/searchQueryForAggregation.ts
+++ b/web-api/src/persistence/elasticsearch/helpers/searchQueryForAggregation.ts
@@ -57,7 +57,7 @@ export const computeDocumentFilters = ({ params }) => {
     });
   }
 
-  if (params.searchType) {
+  if (params.documentEventCodes && params.documentEventCodes.length) {
     documentFilters.push({
       terms: { 'eventCode.S': params.documentEventCodes },
     });


### PR DESCRIPTION
1. Removed need for creating new separate `searchType` flag to indicate event codes search.
2. Removed unnecessary logs.