### PR TITLE
10217 reupload bug

### DIFF
--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -598,6 +598,7 @@ export const INITIAL_DOCUMENT_TYPES = {
     eventCode: 'APW',
     tabTitle: 'APW',
     sort: 5,
+    fileName: 'applicationForWaiverOfFilingFeeFile',
   },
   corporateDisclosure: {
     documentTitle: 'Corporate Disclosure Statement',
@@ -605,6 +606,7 @@ export const INITIAL_DOCUMENT_TYPES = {
     eventCode: 'DISC',
     tabTitle: 'CDS',
     sort: 4,
+    fileName: 'corporateDisclosureFile',
   },
   petition: {
     documentTitle: 'Petition',
@@ -612,6 +614,7 @@ export const INITIAL_DOCUMENT_TYPES = {
     eventCode: 'P',
     tabTitle: 'Petition',
     sort: 0,
+    fileName: 'petitionFile',
   },
   requestForPlaceOfTrial: {
     documentTitle: 'Request for Place of Trial at [Place]',
@@ -619,14 +622,22 @@ export const INITIAL_DOCUMENT_TYPES = {
     eventCode: 'RQT',
     tabTitle: 'RQT',
     sort: 3,
+    fileName: 'requestForPlaceOfTrialFile',
   },
-  stin: STIN_DOCKET_ENTRY_TYPE,
+  stin: {
+    documentType: 'Statement of Taxpayer Identification',
+    eventCode: 'STIN',
+    sort: 1,
+    tabTitle: 'STIN',
+    fileName: 'stinFile',
+  },
   attachmentToPetition: {
     documentTitle: 'Attachment to Petition',
     documentType: 'Attachment to Petition',
     eventCode: 'ATP',
     tabTitle: 'ATP',
     sort: 2,
+    fileName: 'attachmentToPetitionFile',
   },
 } as const;
 

--- a/web-client/src/presenter/actions/CaseCreation/setupFilesForCaseCreationAction.test.ts
+++ b/web-client/src/presenter/actions/CaseCreation/setupFilesForCaseCreationAction.test.ts
@@ -20,7 +20,7 @@ describe('setupFilesForCaseCreationAction test', () => {
 
     expect(result.output.files).toMatchObject({
       applicationForWaiverOfFilingFee: file,
-      atp: file,
+      attachmentToPetition: file,
       corporateDisclosure: undefined,
       petition: file,
       requestForPlaceOfTrial: file,

--- a/web-client/src/presenter/actions/CaseCreation/setupFilesForCaseCreationAction.ts
+++ b/web-client/src/presenter/actions/CaseCreation/setupFilesForCaseCreationAction.ts
@@ -14,7 +14,7 @@ export const setupFilesForCaseCreationAction = ({ get }: ActionProps) => {
   return {
     files: {
       applicationForWaiverOfFilingFee: applicationForWaiverOfFilingFeeFile,
-      atp: attachmentToPetitionFile,
+      attachmentToPetition: attachmentToPetitionFile,
       corporateDisclosure: corporateDisclosureFile,
       petition: petitionFile,
       requestForPlaceOfTrial: requestForPlaceOfTrialFile,

--- a/web-client/src/presenter/actions/createCaseAction.test.ts
+++ b/web-client/src/presenter/actions/createCaseAction.test.ts
@@ -14,7 +14,7 @@ describe('createCaseAction', () => {
       file: {},
       uploadProgress: jest.fn(),
     },
-    atp: {
+    attachmentToPetition: {
       file: {},
       uploadProgress: jest.fn(),
     },
@@ -125,7 +125,7 @@ describe('createCaseAction', () => {
 
     expect(filePetitionInteractor).toHaveBeenCalled();
     expect(filePetitionInteractor.mock.calls[0][1]).toMatchObject({
-      atpUploadProgress: fileUploadProgressMap.atp,
+      atpUploadProgress: fileUploadProgressMap.attachmentToPetition,
       corporateDisclosureUploadProgress:
         fileUploadProgressMap.corporateDisclosure,
       petitionMetadata: MOCK_CASE,
@@ -229,7 +229,7 @@ describe('createCaseAction', () => {
 
     expect(filePetitionInteractor).toHaveBeenCalled();
     expect(filePetitionInteractor.mock.calls[0][1]).toMatchObject({
-      atpUploadProgress: fileUploadProgressMap.atp,
+      atpUploadProgress: fileUploadProgressMap.attachmentToPetition,
       corporateDisclosureUploadProgress:
         fileUploadProgressMap.corporateDisclosure,
       petitionMetadata: MOCK_CASE,
@@ -268,7 +268,7 @@ describe('createCaseAction', () => {
 
     expect(filePetitionInteractor).toHaveBeenCalled();
     expect(filePetitionInteractor.mock.calls[0][1]).toMatchObject({
-      atpUploadProgress: fileUploadProgressMap.atp,
+      atpUploadProgress: fileUploadProgressMap.attachmentToPetition,
       corporateDisclosureUploadProgress:
         fileUploadProgressMap.corporateDisclosure,
       petitionMetadata: MOCK_CASE,

--- a/web-client/src/presenter/actions/createCaseAction.ts
+++ b/web-client/src/presenter/actions/createCaseAction.ts
@@ -20,7 +20,7 @@ export const createCaseAction = async ({
     filePetitionResult = await applicationContext
       .getUseCases()
       .filePetitionInteractor(applicationContext, {
-        atpUploadProgress: fileUploadProgressMap.atp,
+        atpUploadProgress: fileUploadProgressMap.attachmentToPetition,
         corporateDisclosureUploadProgress:
           fileUploadProgressMap.corporateDisclosure,
         petitionMetadata: form,

--- a/web-client/src/presenter/actions/createCaseFromPaperAction.test.ts
+++ b/web-client/src/presenter/actions/createCaseFromPaperAction.test.ts
@@ -37,7 +37,7 @@ describe('createCaseFromPaperAction', () => {
       },
       props: {
         fileUploadProgressMap: {
-          atp: fileMetaData,
+          attachmentToPetition: fileMetaData,
           corporate: fileMetaData,
           petition: fileMetaData,
           requestForPlaceOfTrial: fileMetaData,
@@ -91,7 +91,7 @@ describe('createCaseFromPaperAction', () => {
 
       props: {
         fileUploadProgressMap: {
-          atp: fileMetaData,
+          attachmentToPetition: fileMetaData,
           corporate: fileMetaData,
           petition: fileMetaData,
           requestForPlaceOfTrial: fileMetaData,

--- a/web-client/src/presenter/actions/createCaseFromPaperAction.ts
+++ b/web-client/src/presenter/actions/createCaseFromPaperAction.ts
@@ -17,7 +17,7 @@ export const createCaseFromPaperAction = async ({
       .filePetitionFromPaperInteractor(applicationContext, {
         applicationForWaiverOfFilingFeeUploadProgress:
           fileUploadProgressMap.waiverOfFilingFee,
-        atpUploadProgress: fileUploadProgressMap.atp,
+        atpUploadProgress: fileUploadProgressMap.attachmentToPetition,
         corporateDisclosureUploadProgress: fileUploadProgressMap.corporate,
         petitionMetadata,
         petitionUploadProgress: fileUploadProgressMap.petition,

--- a/web-client/src/presenter/actions/getDocumentSelectedForPreviewAction.test.ts
+++ b/web-client/src/presenter/actions/getDocumentSelectedForPreviewAction.test.ts
@@ -14,21 +14,6 @@ describe('getDocumentSelectedForPreviewAction', () => {
     presenter.providers.applicationContext = applicationContext;
   });
 
-  it('should return documentInS3 if there is a selected document', async () => {
-    const documentId = 'docId1';
-    const { output } = await runAction(getDocumentSelectedForPreviewAction, {
-      modules: {
-        presenter,
-      },
-      props: {
-        documentId,
-      },
-      state: {},
-    });
-
-    expect(output).toEqual({ documentInS3: { docketEntryId: documentId } });
-  });
-
   it('should return props.fileFromBrowserMemory when state.form has an entry equal to documentSelectedForPreview', async () => {
     const { output } = await runAction(getDocumentSelectedForPreviewAction, {
       modules: {

--- a/web-client/src/presenter/actions/getDocumentSelectedForPreviewAction.ts
+++ b/web-client/src/presenter/actions/getDocumentSelectedForPreviewAction.ts
@@ -3,20 +3,7 @@ import { state } from '@web-client/presenter/app.cerebral';
 export const getDocumentSelectedForPreviewAction = ({
   applicationContext,
   get,
-  props,
-}: ActionProps<{
-  documentId?: string;
-}>) => {
-  const { documentId } = props;
-
-  if (documentId) {
-    return {
-      documentInS3: {
-        docketEntryId: documentId,
-      },
-    };
-  }
-
+}: ActionProps) => {
   const { INITIAL_DOCUMENT_TYPES_MAP } = applicationContext.getConstants();
   const documentSelectedForPreview = get(
     state.currentViewMetadata.documentSelectedForPreview,

--- a/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.test.ts
+++ b/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.test.ts
@@ -39,6 +39,14 @@ describe('saveCaseDetailInternalEditAction', () => {
       modules: {
         presenter,
       },
+      props: {
+        fileUploadProgressMap: {
+          petition: {
+            file: {},
+            uploadProgress: jest.fn(),
+          },
+        },
+      },
       state: {
         caseDetail: {
           ...caseDetail,
@@ -49,10 +57,7 @@ describe('saveCaseDetailInternalEditAction', () => {
             },
           ],
         },
-        form: {
-          ...caseDetail,
-          petitionFile: {},
-        },
+        form: caseDetail,
       },
     });
 
@@ -76,12 +81,17 @@ describe('saveCaseDetailInternalEditAction', () => {
       modules: {
         presenter,
       },
+      props: {
+        fileUploadProgressMap: {
+          corporateDisclosure: {
+            file: {},
+            uploadProgress: jest.fn(),
+          },
+        },
+      },
       state: {
         caseDetail,
-        form: {
-          ...caseDetail,
-          corporateDisclosureFile: {},
-        },
+        form: caseDetail,
       },
     });
 
@@ -115,6 +125,14 @@ describe('saveCaseDetailInternalEditAction', () => {
       modules: {
         presenter,
       },
+      props: {
+        fileUploadProgressMap: {
+          corporateDisclosure: {
+            file: {},
+            uploadProgress: jest.fn(),
+          },
+        },
+      },
       state: {
         caseDetail,
         form: caseDetail,
@@ -138,6 +156,14 @@ describe('saveCaseDetailInternalEditAction', () => {
     await runAction(saveCaseDetailInternalEditAction, {
       modules: {
         presenter,
+      },
+      props: {
+        fileUploadProgressMap: {
+          corporateDisclosure: {
+            file: {},
+            uploadProgress: jest.fn(),
+          },
+        },
       },
       state: {
         caseDetail,
@@ -164,9 +190,21 @@ describe('saveCaseDetailInternalEditAction', () => {
       requestForPlaceOfTrialFileSize: 2,
     };
 
+    applicationContext
+      .getUseCases()
+      .saveCaseDetailInternalEditInteractor.mockReturnValue(caseDetail);
+
     await runAction(saveCaseDetailInternalEditAction, {
       modules: {
         presenter,
+      },
+      props: {
+        fileUploadProgressMap: {
+          requestForPlaceOfTrial: {
+            file: mockRqtFile,
+            uploadProgress: jest.fn(),
+          },
+        },
       },
       state: {
         form: caseDetail,
@@ -213,6 +251,14 @@ describe('saveCaseDetailInternalEditAction', () => {
     await runAction(saveCaseDetailInternalEditAction, {
       modules: {
         presenter,
+      },
+      props: {
+        fileUploadProgressMap: {
+          requestForPlaceOfTrial: {
+            file: mockRqtFile,
+            uploadProgress: jest.fn(),
+          },
+        },
       },
       state: {
         form: caseDetail,

--- a/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.ts
+++ b/web-client/src/presenter/actions/saveCaseDetailInternalEditAction.ts
@@ -1,10 +1,13 @@
+import { FileUploadProgressMapType } from '@shared/business/entities/EntityConstants';
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const saveCaseDetailInternalEditAction = async ({
   applicationContext,
   get,
   props,
-}: ActionProps) => {
+}: ActionProps<{
+  fileUploadProgressMap: FileUploadProgressMapType;
+}>) => {
   const {
     INITIAL_DOCUMENT_TYPES,
     INITIAL_DOCUMENT_TYPES_FILE_MAP,
@@ -18,8 +21,9 @@ export const saveCaseDetailInternalEditAction = async ({
 
   for (const key of keys) {
     const fileKey = INITIAL_DOCUMENT_TYPES_FILE_MAP[key];
-    if (fileUploadProgressMap[fileKey]) {
-      if (fileKey === 'petitionFile') {
+
+    if (fileUploadProgressMap[key]) {
+      if (key === 'petition') {
         const oldPetitionDocument = originalCase.docketEntries.find(
           document =>
             document.eventCode === INITIAL_DOCUMENT_TYPES.petition.eventCode,
@@ -28,16 +32,16 @@ export const saveCaseDetailInternalEditAction = async ({
         await applicationContext
           .getUseCases()
           .uploadDocumentAndMakeSafeInteractor(applicationContext, {
-            document: fileUploadProgressMap[fileKey].file,
+            document: fileUploadProgressMap[key].file,
             key: oldPetitionDocument.docketEntryId,
-            onUploadProgress: fileUploadProgressMap[fileKey].uploadProgress,
+            onUploadProgress: fileUploadProgressMap[key].uploadProgress,
           });
       } else {
         const newDocketEntryId = await applicationContext
           .getUseCases()
           .uploadDocumentAndMakeSafeInteractor(applicationContext, {
-            document: fileUploadProgressMap[fileKey].file,
-            onUploadProgress: fileUploadProgressMap[fileKey].uploadProgress,
+            document: fileUploadProgressMap[key].file,
+            onUploadProgress: fileUploadProgressMap[key].uploadProgress,
           });
 
         let { documentTitle, documentType } = INITIAL_DOCUMENT_TYPES[key];

--- a/web-client/src/presenter/actions/setDocumentUploadModeAction.ts
+++ b/web-client/src/presenter/actions/setDocumentUploadModeAction.ts
@@ -5,7 +5,7 @@ import { state } from '@web-client/presenter/app.cerebral';
  * @returns {Function} returns a callback function that sets currentViewMetadata.documentUploadMode on state
  */
 export const setDocumentUploadModeAction =
-  documentUploadMode =>
+  (documentUploadMode?: string) =>
   /**
    * sets the value of state.currentViewMetadata.documentUploadMode entry to the value passed in
    * @param {object} providers the providers object

--- a/web-client/src/presenter/actions/setProgressForFileUploadAction.test.ts
+++ b/web-client/src/presenter/actions/setProgressForFileUploadAction.test.ts
@@ -6,7 +6,7 @@ describe('setProgressForFileUploadAction', () => {
     const results = await runAction(setProgressForFileUploadAction, {
       props: {
         files: {
-          atp: [{ size: 1 }],
+          attachmentToPetition: [{ size: 1 }],
           petition: { size: 2 },
           stin: { size: 3 },
           trial: { size: 4 },
@@ -25,7 +25,7 @@ describe('setProgressForFileUploadAction', () => {
     });
 
     expect(results.output.fileUploadProgressMap).toMatchObject({
-      atp: {
+      attachmentToPetition: {
         file: {},
         uploadProgress: expect.any(Function),
       },
@@ -57,7 +57,7 @@ describe('setProgressForFileUploadAction', () => {
     const results = await runAction(setProgressForFileUploadAction, {
       props: {
         files: {
-          atp: [{ size: 1 }],
+          attachmentToPetition: [{ size: 1 }],
           petition: { size: 2 },
           stin: { size: 3 },
           trial: { size: 4 },
@@ -74,7 +74,7 @@ describe('setProgressForFileUploadAction', () => {
         },
       },
     });
-    results.output.fileUploadProgressMap.atp.uploadProgress({
+    results.output.fileUploadProgressMap.attachmentToPetition.uploadProgress({
       isDone: true,
     });
     results.output.fileUploadProgressMap.petition.uploadProgress({
@@ -118,7 +118,7 @@ describe('setProgressForFileUploadAction', () => {
     const results = await runAction(setProgressForFileUploadAction, {
       props: {
         files: {
-          atp: [{ size: 1 }],
+          attachmentToPetition: [{ size: 1 }],
           noFile: undefined,
           petition: { size: 2 },
           stin: { size: 3 },
@@ -128,7 +128,7 @@ describe('setProgressForFileUploadAction', () => {
     });
 
     expect(results.output.fileUploadProgressMap).toMatchObject({
-      atp: {
+      attachmentToPetition: {
         file: {},
         uploadProgress: expect.any(Function),
       },

--- a/web-client/src/presenter/computeds/petitionQcHelper.test.ts
+++ b/web-client/src/presenter/computeds/petitionQcHelper.test.ts
@@ -49,12 +49,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { isPetitionFile } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(isPetitionFile).toBe(true);
     });
@@ -75,12 +70,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { documentTabsToDisplay } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(documentTabsToDisplay.map(tab => tab.tabTitle)).toEqual(
         initialTabs,
@@ -108,12 +98,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { documentTabsToDisplay } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(documentTabsToDisplay.map(tab => tab.tabTitle)).toEqual([
         initialTabs[0], // Petition
@@ -123,7 +108,7 @@ describe('petitionQcHelper', () => {
       ]);
     });
 
-    it('displays ATP tabs for electronic filings when an ATP is uploaded', () => {
+    it('displays ATP tab for electronic filings when an ATP is uploaded', () => {
       mockState = {
         caseDetail: {
           docketEntries: [
@@ -141,12 +126,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { documentTabsToDisplay } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(documentTabsToDisplay.map(tab => tab.tabTitle)).toEqual([
         initialTabs[0], // Petition
@@ -155,7 +135,35 @@ describe('petitionQcHelper', () => {
       ]);
     });
 
-    it('hides CDS and ATP tabs for electronic filings if one was NOT initially filed', () => {
+    it('displays CDS tab for electronic filings when a CDS is uploaded', () => {
+      mockState = {
+        caseDetail: {
+          docketEntries: [
+            {
+              eventCode: INITIAL_DOCUMENT_TYPES.corporateDisclosure.eventCode,
+            },
+          ],
+        },
+        currentViewMetadata: {
+          documentSelectedForPreview: 'petitionFile',
+        },
+        form: {
+          isPaper: false,
+        },
+      };
+
+      const { documentTabsToDisplay } = runCompute(petitionQcHelper, {
+        state: mockState,
+      });
+
+      expect(documentTabsToDisplay.map(tab => tab.tabTitle)).toEqual([
+        initialTabs[0], // Petition
+        initialTabs[1], // STIN
+        initialTabs[4], // CDS
+      ]);
+    });
+
+    it('hides CDS and ATP tabs for electronic filings if none of the docs were initially filed', () => {
       mockState = {
         caseDetail: {
           docketEntries: [],
@@ -169,12 +177,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { documentTabsToDisplay } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(documentTabsToDisplay.map(tab => tab.tabTitle)).toEqual([
         initialTabs[0], // Petition
@@ -198,12 +201,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { showRemovePdfButton } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(showRemovePdfButton).toEqual(true);
     });
@@ -222,12 +220,7 @@ describe('petitionQcHelper', () => {
       };
 
       const { showRemovePdfButton } = runCompute(petitionQcHelper, {
-        state: {
-          ...mockState,
-          pdfForSigning: {
-            signatureData: null,
-          },
-        },
+        state: mockState,
       });
       expect(showRemovePdfButton).toEqual(false);
     });

--- a/web-client/src/presenter/computeds/petitionQcHelper.ts
+++ b/web-client/src/presenter/computeds/petitionQcHelper.ts
@@ -10,11 +10,15 @@ export const petitionQcHelper = (
     applicationContext.getConstants();
   const { isPaper } = get(state.form);
   const documents = get(state.caseDetail.docketEntries);
-  const ATP_EVENT_CODE = INITIAL_DOCUMENT_TYPES.attachmentToPetition.eventCode;
 
   const hasCDS = !!documents.find(
     doc =>
       doc.eventCode === INITIAL_DOCUMENT_TYPES.corporateDisclosure.eventCode,
+  );
+
+  const hasATP = !!documents.find(
+    doc =>
+      doc.eventCode === INITIAL_DOCUMENT_TYPES.attachmentToPetition.eventCode,
   );
 
   const documentSelectedForPreview = get(
@@ -35,34 +39,16 @@ export const petitionQcHelper = (
     },
   );
 
-  const atpDocketTabsForDisplay = documents
-    .filter(doc => doc.eventCode === ATP_EVENT_CODE)
-    .map(doc => {
-      return {
-        ...INITIAL_DOCUMENT_TYPES.attachmentToPetition,
-        documentId: doc.docketEntryId,
-      };
-    });
-
   documentTabsToDisplay.sort((a, b) => a.sort - b.sort);
-
-  if (atpDocketTabsForDisplay.length) {
-    const firstTwoTabs = documentTabsToDisplay.slice(0, 2);
-    const remainingTabs = documentTabsToDisplay.slice(3);
-    documentTabsToDisplay = [
-      ...firstTwoTabs,
-      ...atpDocketTabsForDisplay,
-      ...remainingTabs,
-    ];
-  }
 
   if (!isPaper) {
     documentTabsToDisplay = documentTabsToDisplay.filter(tab => {
-      if (tab.tabTitle === 'ATP' && !atpDocketTabsForDisplay.length) {
-        return false;
+      if (tab.tabTitle === 'ATP') {
+        // Do not display ATP tab if it wasn't filed electronically
+        return hasATP;
       }
       if (tab.tabTitle === 'CDS') {
-        // Do not display CDS tab if one wasn't filed electronically
+        // Do not display ATP tab if it wasn't filed electronically
         return hasCDS;
       } else {
         // Do not display APW and RQT tabs for electronic filing

--- a/web-client/src/presenter/computeds/petitionQcHelper.ts
+++ b/web-client/src/presenter/computeds/petitionQcHelper.ts
@@ -48,7 +48,7 @@ export const petitionQcHelper = (
         return hasATP;
       }
       if (tab.tabTitle === 'CDS') {
-        // Do not display ATP tab if it wasn't filed electronically
+        // Do not display CDS tab if it wasn't filed electronically
         return hasCDS;
       } else {
         // Do not display APW and RQT tabs for electronic filing

--- a/web-client/src/presenter/presenter.ts
+++ b/web-client/src/presenter/presenter.ts
@@ -1158,7 +1158,8 @@ export const presenterSequences = {
   setCurrentPageIndexSequence:
     setCurrentPageIndexSequence as unknown as Function,
   setCustomCaseReportFiltersSequence,
-  setDocumentForPreviewSequence,
+  setDocumentForPreviewSequence:
+    setDocumentForPreviewSequence as unknown as Function,
   setDocumentForUploadSequence:
     setDocumentForUploadSequence as unknown as Function,
   setDocumentUploadModeSequence:

--- a/web-client/src/presenter/sequences/setDocumentForPreviewSequence.ts
+++ b/web-client/src/presenter/sequences/setDocumentForPreviewSequence.ts
@@ -25,4 +25,4 @@ export const setDocumentForPreviewSequence = [
       setDocumentUploadModeAction('preview'),
     ],
   },
-] as unknown as (props: { documentId?: string }) => void;
+];

--- a/web-client/src/views/PetitionQcScanBatchPreviewer.tsx
+++ b/web-client/src/views/PetitionQcScanBatchPreviewer.tsx
@@ -431,20 +431,14 @@ export const PetitionQcScanBatchPreviewer = connect(
       );
     };
 
-    const getDocumentId = (tabSelected: string): string | undefined => {
-      const documentId = tabSelected.split('_')[1];
-      return documentId === 'undefined' ? undefined : documentId;
-    };
-
     const renderTabs = documentTabsList => {
       if (documentTabsList && documentTabsList.length > 1) {
         return (
           <Tabs
             bind="currentViewMetadata.documentSelectedForPreview"
             className="document-select container-tabs margin-top-neg-205 margin-x-neg-205"
-            onSelect={tabSelected => {
-              const documentId = getDocumentId(tabSelected);
-              setDocumentForPreviewSequence({ documentId });
+            onSelect={() => {
+              setDocumentForPreviewSequence();
             }}
           >
             {documentTabsList.map(documentTab => {
@@ -453,7 +447,7 @@ export const PetitionQcScanBatchPreviewer = connect(
 
               return (
                 <Tab
-                  data-testid={`${documentTab.eventCode}_${documentTab.documentId}`}
+                  data-testid={documentTab.documentType}
                   icon={
                     isFileUploaded && (
                       <FontAwesomeIcon
@@ -462,8 +456,8 @@ export const PetitionQcScanBatchPreviewer = connect(
                       />
                     )
                   }
-                  key={`${documentTab.eventCode}_${documentTab.documentId}`}
-                  tabName={`${documentTab.tabTitle}_${documentTab.documentId}`}
+                  key={documentTab.documentType}
+                  tabName={documentTab.fileName} // may need some refactor (established in constants)
                   title={documentTab.tabTitle}
                 />
               );


### PR DESCRIPTION
1. Make sure documents re-uploaded during qc are properly set in state (attached to the case).
2. Using `attachmentToPetition` instead of `atp` to reduce how many keys we use to represent documents.